### PR TITLE
chore(deps): patch 6 Dependabot alerts (django 6.0.4, pygments 2.20.0)

### DIFF
--- a/Main/backend/uv.lock
+++ b/Main/backend/uv.lock
@@ -407,16 +407,16 @@ wheels = [
 
 [[package]]
 name = "django"
-version = "6.0.3"
+version = "6.0.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "asgiref" },
     { name = "sqlparse" },
     { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/80/e1/894115c6bd70e2c8b66b0c40a3c367d83a5a48c034a4d904d31b62f7c53a/django-6.0.3.tar.gz", hash = "sha256:90be765ee756af8a6cbd6693e56452404b5ad15294f4d5e40c0a55a0f4870fe1", size = 10872701, upload-time = "2026-03-03T13:55:15.026Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/60/b9/4155091ad1788b38563bd77a7258c0834e8c12a7f56f6975deaf54f8b61d/django-6.0.4.tar.gz", hash = "sha256:8cfa2572b3f2768b2e84983cf3c4811877a01edb64e817986ec5d60751c113ac", size = 10907407, upload-time = "2026-04-07T13:55:44.961Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/72/b1/23f2556967c45e34d3d3cf032eb1bd3ef925ee458667fb99052a0b3ea3a6/django-6.0.3-py3-none-any.whl", hash = "sha256:2e5974441491ddb34c3f13d5e7a9f97b07ba03bf70234c0a9c68b79bbb235bc3", size = 8358527, upload-time = "2026-03-03T13:55:10.552Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/47/3d61d611609764aa71a37f7037b870e7bfb22937366974c4fd46cada7bab/django-6.0.4-py3-none-any.whl", hash = "sha256:14359c809fc16e8f81fd2b59d7d348e4d2d799da6840b10522b6edf7b8afc1da", size = 8368342, upload-time = "2026-04-07T13:55:37.999Z" },
 ]
 
 [[package]]
@@ -1802,11 +1802,11 @@ wheels = [
 
 [[package]]
 name = "pygments"
-version = "2.19.2"
+version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Bumps `django` 6.0.3 → 6.0.4 and `pygments` 2.19.2 → 2.20.0 in `Main/backend/uv.lock`.
- Closes 6 open Dependabot alerts on `main` (2 high, 1 moderate, 3 low).
- Lockfile-only change; `pyproject.toml` constraints already permit both versions.

## Alerts closed

| # | Severity | Package | Advisory |
|---|----------|---------|----------|
| #117 | high | django | [GHSA-mvfq-ggxm-9mc5](https://github.com/advisories/GHSA-mvfq-ggxm-9mc5) — ASGI header spoofing via underscore/hyphen conflation |
| #115 | high | django | [GHSA-933h-hp56-hf7m](https://github.com/advisories/GHSA-933h-hp56-hf7m) — `DATA_UPLOAD_MAX_MEMORY_SIZE` bypass via missing/understated `Content-Length` |
| #116 | medium | django | [GHSA-5mf9-h53q-7mhq](https://github.com/advisories/GHSA-5mf9-h53q-7mhq) — MultiPartParser DoS |
| #119 | low | django | [GHSA-mmwr-2jhp-mc7j](https://github.com/advisories/GHSA-mmwr-2jhp-mc7j) — `ModelAdmin.list_editable` privilege abuse |
| #118 | low | django | [GHSA-pwjp-ccjc-ghwg](https://github.com/advisories/GHSA-pwjp-ccjc-ghwg) — `GenericInlineModelAdmin` privilege abuse |
| #111 | low  | pygments | [GHSA-5239-wwwm-4pmq](https://github.com/advisories/GHSA-5239-wwwm-4pmq) — ReDoS in GUID regex |

## How produced
```
uv lock --upgrade-package django --upgrade-package pygments
```
Resolved cleanly with no transitive cascade — only the two named packages moved.

## Test plan
- [ ] CI green on `Main/backend` test suite
- [ ] No runtime regression in Django admin / migrations on a smoke deploy
- [ ] Dependabot alerts #111, #115, #116, #117, #118, #119 auto-close after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)