### PR TITLE
fix(deploy): verifier accepts gunicorn settings in conf.py, not just Procfile

### DIFF
--- a/Main/backend/verify_deployment.py
+++ b/Main/backend/verify_deployment.py
@@ -27,21 +27,32 @@ def check_memory_baseline():
 
 
 def check_gunicorn_config():
-    """Verify Gunicorn has proper worker recycling configured"""
+    """
+    Verify Gunicorn has worker recycling configured.
+
+    Settings may live in either Procfile/Dockerfile CMD as CLI flags
+    (--max-requests, --max-requests-jitter) OR in gunicorn.conf.py as
+    Python assignments (max_requests = ..., max_requests_jitter = ...).
+    Both are equivalent — accept either.
+    """
     procfile_path = backend_dir / 'Procfile'
-    if not procfile_path.exists():
-        print("WARNING: Procfile not found")
-        return False
+    config_path = backend_dir / 'gunicorn.conf.py'
 
-    with open(procfile_path) as f:
-        content = f.read()
+    procfile_text = procfile_path.read_text() if procfile_path.exists() else ''
+    config_text = config_path.read_text() if config_path.exists() else ''
 
-    has_max_requests = '--max-requests' in content
-    has_jitter = '--max-requests-jitter' in content
+    has_max_requests = (
+        '--max-requests' in procfile_text
+        or 'max_requests' in config_text
+    )
+    has_jitter = (
+        '--max-requests-jitter' in procfile_text
+        or 'max_requests_jitter' in config_text
+    )
 
     print("\nGunicorn Configuration:")
-    print(f"  Worker recycling (--max-requests): {'OK' if has_max_requests else 'MISSING'}")
-    print(f"  Jitter (--max-requests-jitter): {'OK' if has_jitter else 'MISSING'}")
+    print(f"  Worker recycling (max_requests): {'OK' if has_max_requests else 'MISSING'}")
+    print(f"  Jitter (max_requests_jitter): {'OK' if has_jitter else 'MISSING'}")
 
     return has_max_requests and has_jitter
 


### PR DESCRIPTION
## Summary

The post-merge `backend-deploy.yml` workflow was failing at the `verify_deployment.py` step on `main` (most recently on the PR #286 merge commit `538ab78`). The verifier reported:

```
Worker recycling (--max-requests): MISSING
Jitter (--max-requests-jitter): MISSING
```

But those settings **are** configured — they just live in `gunicorn.conf.py` (lines 9–10), not as CLI flags in `Procfile`. The PR #286 prod refactor consolidated all gunicorn worker tuning into the config file (referenced by `Procfile` via `--config gunicorn.conf.py`), but `verify_deployment.py` was never updated to follow the indirection. It was still grepping `Procfile` only, missing the now-correct location.

## Fix

`check_gunicorn_config()` now accepts either:
- CLI-flag form (`--max-requests` / `--max-requests-jitter`) in `Procfile`, **or**
- Python-assignment form (`max_requests` / `max_requests_jitter`) in `gunicorn.conf.py`

Both are equivalent from gunicorn's perspective — accepting either eliminates the false-negative.

## Test plan

- [x] `uv run python verify_deployment.py` locally → **all 5 checks PASS**
- [ ] Merge → next push to `main` runs `backend-deploy.yml` → verify step passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)