### PR TITLE
chore: ignore Sphinx _build/ output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,8 @@ __pycache__/
 
 # Python distribution / packaging
 build/
+# Sphinx HTML build output
+_build/
 develop-eggs/
 dist/
 downloads/


### PR DESCRIPTION
Adds two lines to `.gitignore` so Sphinx's generated HTML output (`_build/`) is no longer tracked.

```gitignore
# Sphinx HTML build output
_build/
```