### PR TITLE
fix(api): stop leaking exception details in research-mode error responses

### DIFF
--- a/Main/backend/datascraper/datascraper.py
+++ b/Main/backend/datascraper/datascraper.py
@@ -803,16 +803,19 @@ def create_advanced_response(
             return response_text, source_entries
 
     except Exception as e:
-        logging.error(f"OpenAI Responses API failed: {e}")
+        logging.error(f"OpenAI Responses API failed: {e}", exc_info=True)
         qt.flag("error", message=str(e))
         qt.complete()
+        # Return a generic message to the client; the exception detail is logged
+        # server-side above. Never surface str(e) — it can leak stack traces,
+        # file paths, or other internal details (information disclosure).
+        client_message = "I encountered an error while searching for information. Please try again."
         if stream:
-            error_message = str(e)
             async def error_gen():
-                yield f"I encountered an error while searching for information: {error_message}. Please try again.", []
+                yield client_message, []
             return error_gen()
         else:
-            return f"I encountered an error while searching for information: {str(e)}. Please try again.", []
+            return client_message, []
 
 
 async def _create_advanced_response_stream_async(
@@ -846,8 +849,10 @@ async def _create_advanced_response_stream_async(
             yield text_chunk, source_entries
 
     except Exception as e:
-        logging.error(f"Error in advanced streaming: {e}")
-        yield f"Error: {str(e)}", []
+        logging.error(f"Error in advanced streaming: {e}", exc_info=True)
+        # Generic client-facing message; detail is logged above, never surfaced
+        # to the user (information-disclosure hardening).
+        yield "I encountered an error while searching for information. Please try again.", []
 
 
 def create_advanced_response_streaming(


### PR DESCRIPTION
## What & why

`create_advanced_response` (research mode) and its streaming helper
`_create_advanced_response_stream_async` caught their own internal exceptions
and returned the **raw `str(e)`** as the assistant's response content:

```python
# before — datascraper.py
return f"I encountered an error while searching for information: {str(e)}. Please try again.", []
...
yield f"Error: {str(e)}", []
```

Because the error is *swallowed into a normal return value* (not raised), it
sails right past the view-layer sanitizer in `openai_views._handle_sync`
(`_safe_error_message`) and reaches the client through `JsonResponse`
(sync path) and the SSE endpoints (streaming paths) — leaking stack traces,
file paths, and other internal detail.

This is the root cause behind the CodeQL **`py/stack-trace-exposure`** finding
(alert #63 at `openai_views.py:385`). Thinking mode (`create_agent_response`)
is unaffected — it lets exceptions propagate to the view boundary, where they
are already sanitized.

## The fix

Sanitize at the **source layer** (`datascraper.py`) so every caller is
protected at once — the OpenAI-compat API (`openai_views.py`) *and* the
frontend `views.py` SSE endpoints:

- Return a generic, non-revealing message to the client.
- Keep the full exception **server-side**, now logged with `exc_info=True`
  for better diagnostics.
- Mirrors the existing `_safe_error_message` pattern already used on the
  view's own error path.

Three call sites closed (the complete "exception-string-into-response" family
in this module): the research-mode sync return, its streaming `yield`, and the
streaming helper's `yield`. Other handlers in the module already `raise` and
propagate to the sanitized boundary.

## Scope notes

- Behavior on success paths is unchanged; only error branches differ.
- `datascraper/url_tools.py` returns scraping errors as structured
  `{"error": ...}` JSON that callers inspect via an `if "error" in` guard
  (e.g. `openai_views.py:253` drops the content on error). That is a different
  pattern and not part of this fix — worth a separate look later.
- Branched off `origin/main` (post line-ending normalization), so the diff is
  content-only: **1 file, +11 / −6**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)