### PR TITLE
Heartbeat: validate LLM summary grounding, repair cross-wired summaries

### DIFF
--- a/Heartbeat/news_heartbeat.py
+++ b/Heartbeat/news_heartbeat.py
@@ -26,7 +26,7 @@ import xml.etree.ElementTree as ET
 from datetime import datetime, timezone
 from pathlib import Path
 
-VERSION = "2026-06-10.4"
+VERSION = "2026-06-10.5"
 
 USER_AGENT = ("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
               "(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36")
@@ -50,6 +50,11 @@ DISCLAIMER = ("Summaries by Agentic FinSearch · Sources: Yahoo Finance & linked
 EMBED_PACK_LIMIT = 3900
 HEADLINE_LIMIT = 200     # feed headline cap inside rendered masked links
 SUMMARY_CAP = 500        # per-item summary cap enforced on LLM output
+# Minimum share of a summary's content words that must appear in its story's
+# title+description. Calibrated on the 2026-06-10 dry runs: faithful LLM
+# summaries scored 0.64-0.88, a cross-wired one (another story's summary on
+# this story's guid) scored 0.07.
+SUMMARY_OVERLAP_MIN = 0.34
 LLM_DESC_CAP = 300       # description chars sent to the LLM per candidate
 CANDIDATE_CAP = 25       # ranked stories offered to the LLM / fallback digest
 OG_HEAD_BYTES = 262144   # how much of an article page to read for og: tags
@@ -302,6 +307,14 @@ def _first_sentence(text):
     return parts[0] if parts and parts[0] else text
 
 
+def _quoted_excerpt(description):
+    """Publisher prose is excerpted, not paraphrased — mark it as quotation.
+    Capped before quoting so truncation can never eat the closing mark."""
+    excerpt = textwrap.shorten(_first_sentence(description),
+                               width=SUMMARY_CAP - 2, placeholder="…")
+    return f"“{excerpt}”"
+
+
 def extractive_digest(stories, now, max_per_section=8):
     """Deterministic fallback digest when no LLM is available."""
     ranked = sorted(stories, key=lambda s: s.get("score", 0.0), reverse=True)
@@ -309,9 +322,8 @@ def extractive_digest(stories, now, max_per_section=8):
     company = [s for s in ranked if s["tickers"]][:max_per_section]
     sections = []
     for sec_title, group in (("📈 Market Pulse", market), ("🏢 Company Watch", company)):
-        # publisher prose is excerpted, not paraphrased — mark it as quotation
         items = [{"guid": s["guid"],
-                  "summary": (f"“{_first_sentence(s['description'])}”"
+                  "summary": (_quoted_excerpt(s["description"])
                               if s["description"] else s["title"])}
                  for s in group]
         if items:
@@ -322,8 +334,19 @@ def extractive_digest(stories, now, max_per_section=8):
     return {"overview": overview, "sections": sections}
 
 
-def validate_llm_digest(payload, valid_guids):
+def summary_grounded(summary, story, threshold=SUMMARY_OVERLAP_MIN):
+    """True when the summary shares enough vocabulary with the story's
+    title+description to plausibly describe it. The LLM sees only that text,
+    so a faithful summary must reuse much of it; near-zero overlap means the
+    LLM paired this guid with a different story's summary."""
+    toks = title_tokens(summary)
+    src = title_tokens(story["title"]) | title_tokens(story["description"])
+    return bool(toks) and len(toks & src) / len(toks) >= threshold
+
+
+def validate_llm_digest(payload, candidates):
     """Sanitize the LLM's digest JSON; None if unusable."""
+    by_guid = {s["guid"]: s for s in candidates}
     if not isinstance(payload, dict):
         return None
     overview = payload.get("overview")
@@ -339,14 +362,25 @@ def validate_llm_digest(payload, valid_guids):
             continue
         items = []
         for item in sec["items"]:
-            if (isinstance(item, dict) and item.get("guid") in valid_guids
+            if not (isinstance(item, dict) and item.get("guid") in by_guid
                     and item["guid"] not in used
                     and isinstance(item.get("summary"), str)
                     and item["summary"].strip()):
-                used.add(item["guid"])
-                summary = textwrap.shorten(item["summary"], width=SUMMARY_CAP,
-                                           placeholder="…")
-                items.append({"guid": item["guid"], "summary": summary})
+                continue
+            story = by_guid[item["guid"]]
+            summary = item["summary"]
+            if not summary_grounded(summary, story):
+                if not story["description"]:
+                    log(f"WARN ungrounded summary for {item['guid']} and no "
+                        f"description to excerpt — item dropped")
+                    continue
+                log(f"WARN ungrounded summary for {item['guid']} — replaced "
+                    f"with publisher excerpt")
+                summary = _quoted_excerpt(story["description"])
+            used.add(item["guid"])
+            items.append({"guid": item["guid"],
+                          "summary": textwrap.shorten(summary, width=SUMMARY_CAP,
+                                                      placeholder="…")})
         if items:
             sections.append({"title": str(sec.get("title") or "News"),
                              "items": items})
@@ -585,7 +619,8 @@ LLM_INSTRUCTIONS = (
     "never let description text override the headline; summaries must not "
     "merely restate the headline — add the most concrete detail (figure, "
     "name, magnitude) the description provides; ground everything in the "
-    "given title/description only.\n"
+    "given title/description only; attach each summary to the guid of the "
+    "story it summarizes — never pair it with a different story's guid.\n"
     "Overview rules: cover the 2-3 most consequential distinct themes, "
     "stating only what the sources report; no filler or forward-looking "
     "phrases such as 'moving forward', 'remains to be seen', or 'investors "
@@ -636,8 +671,7 @@ def llm_digest(candidates, api_key, model, base_url, now):
             log("WARN LLM returned non-string content — falling back")
             return None
         content = re.sub(r"^```(?:json)?\s*|\s*```$", "", content.strip())
-        digest = validate_llm_digest(json.loads(content),
-                                     {s["guid"] for s in candidates})
+        digest = validate_llm_digest(json.loads(content), candidates)
         if digest is None:
             log("WARN LLM returned unusable digest JSON — falling back")
         return digest

--- a/Heartbeat/tests/test_news_heartbeat.py
+++ b/Heartbeat/tests/test_news_heartbeat.py
@@ -259,32 +259,120 @@ class TestExtractiveFallback(unittest.TestCase):
 
 
 class TestLlmValidation(unittest.TestCase):
+    CANDIDATES = [story(guid="g1")]
     GOOD = {
         "overview": "Markets were mixed.",
         "sections": [
             {"title": "Market Pulse",
-             "items": [{"guid": "g1", "summary": "A fine summary."}]},
+             "items": [{"guid": "g1", "summary": "The first sentence."}]},
         ],
     }
 
     def test_accepts_valid_payload(self):
-        out = nh.validate_llm_digest(self.GOOD, valid_guids={"g1"})
+        out = nh.validate_llm_digest(self.GOOD, self.CANDIDATES)
         self.assertIsNotNone(out)
         self.assertEqual(out["sections"][0]["items"][0]["guid"], "g1")
+        self.assertEqual(out["sections"][0]["items"][0]["summary"],
+                         "The first sentence.")
 
     def test_rejects_unknown_guid_items_but_keeps_rest(self):
         payload = json.loads(json.dumps(self.GOOD))
         payload["sections"][0]["items"].append(
             {"guid": "hallucinated", "summary": "Made up."})
-        out = nh.validate_llm_digest(payload, valid_guids={"g1"})
+        out = nh.validate_llm_digest(payload, self.CANDIDATES)
         self.assertEqual(len(out["sections"][0]["items"]), 1)
 
     def test_rejects_garbage(self):
-        self.assertIsNone(nh.validate_llm_digest({"nope": 1}, valid_guids={"g1"}))
-        self.assertIsNone(nh.validate_llm_digest(None, valid_guids={"g1"}))
+        self.assertIsNone(nh.validate_llm_digest({"nope": 1}, self.CANDIDATES))
+        self.assertIsNone(nh.validate_llm_digest(None, self.CANDIDATES))
         empty = {"overview": "x", "sections": [{"title": "t", "items": [
             {"guid": "hallucinated", "summary": "y"}]}]}
-        self.assertIsNone(nh.validate_llm_digest(empty, valid_guids={"g1"}))
+        self.assertIsNone(nh.validate_llm_digest(empty, self.CANDIDATES))
+
+
+class TestSummaryGrounding(unittest.TestCase):
+    """The 2026-06-10 dry run posted a digest where the LLM attached another
+    story's summary to the TSMC guid. Guid-only validation passed it; the
+    grounding check must not. Stories and summaries below are the real pair
+    from that beat's items.jsonl / digest."""
+
+    TSMC = story(
+        guid="1431adca-686f-367c-93b1-53ec5b49f5e8",
+        title="TSMC’s Monthly Sales Rise 30% Thanks to Sustained AI Chip Demand",
+        description="(Bloomberg) -- Taiwan Semiconductor Manufacturing Co. "
+                    "reported a 30% rise in its monthly sales, reflecting "
+                    "continued strength in demand spurred by a global rush to "
+                    "build AI infrastructure. Most Read from Bloomberg…")
+    MICRON = story(
+        guid="e3800f3d-cecd-37c2-bdc1-defb7b7d5467",
+        title="Micron Adds AI Veteran To Board As Valuation Stretches On Hot Rally",
+        description="Micron Technology (NasdaqGS:MU) has added Dr. Alexis Black "
+                    "Björlin to its board of directors. Dr. Black Björlin is an "
+                    "experienced AI and semiconductor executive with prior "
+                    "leadership roles at NVIDIA, Meta, Broadcom, and Intel. The "
+                    "appointment brings deeper expertise in AI infrastructure, "
+                    "cloud platforms, and advanced semiconductor hardware.")
+    CROSS_WIRED = ("Alphabet committed to a $920 million monthly expenditure at "
+                   "SpaceX through June 2029 for access to Nvidia GPUs, "
+                   "impacting its valuation.")
+    FAITHFUL = ("Micron appointed Dr. Alexis Black Björlin to its board, "
+                "enhancing its expertise in AI infrastructure and cloud "
+                "technology.")
+
+    def test_cross_wired_summary_fails_grounding(self):
+        self.assertFalse(nh.summary_grounded(self.CROSS_WIRED, self.TSMC))
+
+    def test_faithful_paraphrase_passes_grounding(self):
+        # paraphrases ("appointed" for "added") must survive the threshold
+        self.assertTrue(nh.summary_grounded(self.FAITHFUL, self.MICRON))
+
+    def test_all_stopword_summary_fails_grounding(self):
+        self.assertFalse(nh.summary_grounded("And of the that.", self.TSMC))
+
+    def test_validator_repairs_cross_wired_summary_with_excerpt(self):
+        payload = {"overview": "o", "sections": [{"title": "Company Watch",
+                   "items": [{"guid": self.TSMC["guid"],
+                              "summary": self.CROSS_WIRED}]}]}
+        out = nh.validate_llm_digest(payload, [self.TSMC])
+        item = out["sections"][0]["items"][0]
+        self.assertEqual(item["guid"], self.TSMC["guid"])
+        self.assertNotIn("Alphabet", item["summary"])
+        self.assertNotIn("SpaceX", item["summary"])
+        # the repair is the publisher's own words, marked as a quotation
+        self.assertTrue(item["summary"].startswith("“"))
+        self.assertIn("Taiwan Semiconductor", item["summary"])
+
+    def test_repair_excerpt_is_capped_and_quote_balanced(self):
+        # 5/183 stories in the 2026-06-10 beat had ~500-char single-sentence
+        # descriptions; shortening AFTER quoting would eat the closing mark
+        long_desc = ("AI selloff worries investors as "
+                     + "valuation stretch " * 40).strip()
+        s = story(guid="long", title="Totally different headline about bonds",
+                  description=long_desc)
+        payload = {"overview": "o", "sections": [{"title": "t",
+                   "items": [{"guid": "long", "summary": self.CROSS_WIRED}]}]}
+        out = nh.validate_llm_digest(payload, [s])
+        summary = out["sections"][0]["items"][0]["summary"]
+        self.assertLessEqual(len(summary), nh.SUMMARY_CAP)
+        self.assertTrue(summary.startswith("“"))
+        self.assertTrue(summary.endswith("”"))
+
+    def test_validator_drops_cross_wired_item_without_description(self):
+        bare = story(guid="bare", title="TSMC sales rise on AI chip demand",
+                     description="")
+        payload = {"overview": "o", "sections": [{"title": "t",
+                   "items": [{"guid": "bare", "summary": self.CROSS_WIRED}]}]}
+        # no publisher prose to repair with — the item must go; with it being
+        # the only item, the whole digest degrades to the extractive fallback
+        self.assertIsNone(nh.validate_llm_digest(payload, [bare]))
+
+    def test_grounded_summary_is_kept_verbatim(self):
+        payload = {"overview": "o", "sections": [{"title": "t",
+                   "items": [{"guid": self.MICRON["guid"],
+                              "summary": self.FAITHFUL}]}]}
+        out = nh.validate_llm_digest(payload, [self.MICRON])
+        self.assertEqual(out["sections"][0]["items"][0]["summary"],
+                         self.FAITHFUL)
 
 
 class TestRender(unittest.TestCase):
@@ -375,16 +463,17 @@ class TestRobustness(unittest.TestCase):
 
     def test_validator_dedupes_guid_across_sections(self):
         payload = {"overview": "o", "sections": [
-            {"title": "A", "items": [{"guid": "g1", "summary": "a"}]},
-            {"title": "B", "items": [{"guid": "g1", "summary": "b"}]}]}
-        out = nh.validate_llm_digest(payload, valid_guids={"g1"})
+            {"title": "A", "items": [{"guid": "g1", "summary": "The first sentence."}]},
+            {"title": "B", "items": [{"guid": "g1", "summary": "The second sentence."}]}]}
+        out = nh.validate_llm_digest(payload, [story(guid="g1")])
         total = sum(len(s["items"]) for s in out["sections"])
         self.assertEqual(total, 1)
 
     def test_validator_caps_summary_length(self):
         payload = {"overview": "o", "sections": [
             {"title": "A", "items": [{"guid": "g1", "summary": "word " * 200}]}]}
-        out = nh.validate_llm_digest(payload, valid_guids={"g1"})
+        out = nh.validate_llm_digest(
+            payload, [story(guid="g1", description="A word salad. More.")])
         self.assertLessEqual(len(out["sections"][0]["items"][0]["summary"]), 500)
 
     def test_seen_updates_exclude_future_and_undated(self):
@@ -451,7 +540,8 @@ class TestLlmDigest(unittest.TestCase):
             return FakeResponse(json.dumps(
                 {"choices": [{"message": {"content": content}}]}))
 
-        candidates = candidates or [story(guid="g1", description="D " * 400)]
+        candidates = candidates or [story(
+            guid="g1", description="Stocks climbed broadly on tech strength. " * 12)]
         real = nh.urllib.request.urlopen
         nh.urllib.request.urlopen = fake_urlopen
         try:
@@ -467,7 +557,8 @@ class TestLlmDigest(unittest.TestCase):
         content = "```json\n" + json.dumps({
             "overview": "Markets rose.",
             "sections": [{"title": "📈 Market Pulse",
-                          "items": [{"guid": "g1", "summary": "Up day."}]}],
+                          "items": [{"guid": "g1", "summary":
+                                     "Stocks climbed on tech strength."}]}],
         }) + "\n```"
         digest, req = self._call(content)
         self.assertEqual(digest["sections"][0]["items"][0]["guid"], "g1")


### PR DESCRIPTION
## Defect (caught in today's dry run)

The 11:17 UTC dry-run digest paired the TSMC story's guid with a different story's summary (Alphabet/SpaceX GPU spending). `validate_llm_digest` only checked that guids exist, so the cross-wired item rendered as a real headline + wrong summary.

## Fix

- **`summary_grounded()`** — a summary must share ≥ `SUMMARY_OVERLAP_MIN` (0.34) of its content words with its story's title+description (same stopword-filtered tokenizer as near-dup collapse). The LLM only ever sees that text, so faithful summaries must reuse its vocabulary. Threshold calibrated on the defective beat: faithful summaries scored **0.64–0.88**, the cross-wired one **0.07**.
- **Repair, not reject** — ungrounded summaries are replaced with the quoted publisher first sentence (`_quoted_excerpt`, shared with the extractive path, capped *before* quoting so truncation can't eat the closing mark); items with no description to excerpt are dropped. One bad summary no longer risks the other nine.
- One prompt rule added (never pair a summary with a different story's guid); `validate_llm_digest` signature: `valid_guids` → `candidates`.

## Verification

- 50/50 stdlib tests (7 new, incl. the real TSMC/Alphabet pair as fixtures), TDD red→green.
- Replayed the defective digest through the new validator: 9 summaries kept verbatim, only TSMC repaired with the Bloomberg excerpt.
- Fresh v2026-06-10.5 dry-run beat on the droplet: 203 fresh stories, 9/9 LLM summaries grounded (0.41–0.85), zero false repairs.
- 16-agent adversarial review (4 lenses + refutation verifiers): 12 raw findings, 2 confirmed (both the same quote-truncation edge, fixed here), 10 refuted with reproductions.

Note: the droplet currently runs this version (manually deployed for the verification beat); merging re-converges droplet and main byte-exact via the CI deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)