### PR TITLE
XBRL benchmark reconciliation: fact_id recipe + concept→tag selection (S2/S13)

### DIFF
--- a/Docs/superpowers/plans/2026-06-26-xbrl-truth-layer-p0p1-deferred.md
+++ b/Docs/superpowers/plans/2026-06-26-xbrl-truth-layer-p0p1-deferred.md
@@ -105,6 +105,18 @@ benchmark's own frozen snapshot (`xbrl.duckdb`), not a live re-fetch.** This is 
 gating fact-join risk, downstream of (not the) tag selection. Entry point: source the
 benchmark `xbrl.duckdb` (487,623 facts / 246 cos — not checked in) before the P4 grader.
 
+**⚠️ Forward risk for breadth ingest — `taxonomy` dropped from the key + multi-taxonomy
+docs.** The reconciled recipe drops `taxonomy` (the generator's key is us-gaap-only), but
+`ingest.companyfacts_rows` still iterates *every* taxonomy in a companyfacts doc
+(`us-gaap`, `dei`, `srt`, …). For the demo trio this is moot — `_prune` keeps only
+us-gaap. But an unpruned breadth ingest could mint the same `fact_id` for two facts that
+differ only by taxonomy (same tag name + period + unit + accession + value across, say,
+`us-gaap` and `srt`). This is **caught loud, not silent**: the intra-doc collision guard
+in `ingest_doc` raises rather than `ON CONFLICT DO NOTHING`. Mitigation is to ingest from
+the benchmark's frozen `xbrl.duckdb` (already us-gaap facts) rather than re-deriving from
+multi-taxonomy companyfacts; if a future path must ingest raw companyfacts, filter to
+`us-gaap` first (or fold `taxonomy`/`dim_hash` into the key for the non-benchmark store).
+
 ---
 
 ### S2/S13 (historical) — original defer rationale

--- a/Docs/superpowers/plans/2026-06-26-xbrl-truth-layer-p0p1-deferred.md
+++ b/Docs/superpowers/plans/2026-06-26-xbrl-truth-layer-p0p1-deferred.md
@@ -38,6 +38,77 @@ Est. effort: ~half a day, gated on the benchmark/P4 design.
 
 ### S2/S13 — `fact_id` canonical recipe reconciliation (encoding + field set)
 
+**Status: ✅ RESOLVED 2026-06-26.** The recipe was reconciled against the benchmark
+generator and `make_fact_id` was changed to match byte-for-byte.
+
+**How it was reconciled (the generator source is NOT checked in — only its output
+`Materials/XBRL Tree/Benchmark/cases_v1_final.json` + the contributor guide).** The
+guide documents the field set; the exact serialization was recovered empirically by
+reproducing two real `gold_fact_path` sha1s against their SEC `companyfacts` source
+fields (a known-plaintext/known-digest recovery). The generator's recipe is:
+
+```
+sha1("|".join(str(x) for x in (cik, concept, period_start, period_end, unit, accession, dim_hash)))
+```
+- `concept` = the raw us-gaap tag (e.g. `Revenues`); `period_start=None` (instant facts)
+  → `str()` → `'None'`; `dim_hash=''` for consolidated companyfacts facts (trailing `|`).
+- Verified anchors (pinned in `tests/test_truthlayer_store.py::test_make_fact_id_matches_benchmark_gold_path`):
+  NVDA FY2026 `Revenues` → `d7a34159f863a4bbbbe3b092a3f9611070cfe5ad`;
+  Meta FY2025 `Assets` → `293b650557be02293fc40c70526e46d6b9096ee2`.
+
+**Deltas applied to our recipe (was `cik|taxonomy|tag|unit|pstart|pend|accn`):** dropped
+`taxonomy`; moved `unit` to after the period dates; appended `dim_hash` (a real param,
+default `''`, so the deferred raw-XBRL dimensional path can populate it without
+re-hashing the consolidated facts). The intra-doc collision guard in `ingest_doc` stays
+(the field set still omits `fy/fp/frame/value`, matching the generator). Prose was wrong
+twice — the contributor guide omitted `period_start`, the cases guide added `value` — so
+the empirical hash match is of record.
+
+**concept→tag SELECTION divergence — ✅ RESOLVED 2026-06-27.** The other half of the
+S2/S13 join (tag selection, not the hash) is reconciled and exhaustively validated.
+
+*The NVDA alarm was a false positive.* NVDA does report `Revenues` AND (historically)
+`RevenueFromContractWithCustomerExcludingAssessedTax`, but **not** the latter for the
+FY2026 consolidated period — so first-tag-wins correctly falls through to `Revenues`,
+because `retrieve._select` only considers a tag that reports a fact *for the queried
+period*. The registry order was never wrong for revenue.
+
+*How it was reconciled (empirically, not from the guide's `CANONICAL_METRICS` prose —
+which proved unreliable twice already).* Reversed every `gold_fact_path` hash in
+`cases_v1_final.json` against full us-gaap companyfacts for all 197 referenced companies
+(harness: `Main/backend/truthlayer/_tagrecover/`, see its README). Recovered: the
+generator uses a single **conflict-free global tag-priority order** per concept;
+per-company "divergence" is just which tags each company reports. `validate_full.py`
+confirms the reconciled registry reproduces the gold tag on **742/742** resolvable
+single-entity facts, 0 mismatches.
+
+*Registry deltas (`truthlayer/registry.py`, REGISTRY_VERSION → 2026-06-27):* added 5
+benchmark concepts — `net_income` (`NetIncomeLoss`≻`ProfitLoss`), `operating_income`
+(`OperatingIncomeLoss`), `gross_profit` (`GrossProfit`), `research_and_development`
+(`ResearchAndDevelopmentExpense`), `cash_and_equivalents`
+(`CashAndCashEquivalentsAtCarryingValue`); inserted
+`RevenueFromContractWithCustomerIncludingAssessedTax` below `Revenues` (CrowdStrike is
+the lone gold fact using it); added `BENCHMARK_CONCEPT_ALIAS` +
+`resolve_benchmark_concept` mapping the benchmark's own concept names
+(`total_assets`→`assets`, `cogs`→`cost_of_revenue`, `stockholders_equity`→`equity`,
+`reported_gross_profit`→`gross_profit`, …). Existing orders (revenue, cogs, equity,
+assets) were already correct — verified, unchanged. Pinned offline by
+`tests/test_truthlayer_benchmark_selection.py` (5 real gold anchors + order/alias).
+
+**⚠️ NEW open item surfaced during reconciliation — accession DRIFT (gating for breadth
+ingest / P4).** For ~33 facts across a few companies (BLK, CEG, CRWV) the *entire*
+`gold_fact_path` points to accessions that **live** SEC companyfacts no longer returns:
+the benchmark's gold was generated against a **frozen** companyfacts snapshot since
+drifted. Because `fact_id` includes `accession`, a grader re-fetching from live SEC mints
+different ids than gold for any drifted fact. **Breadth ingest for P4 must load the
+benchmark's own frozen snapshot (`xbrl.duckdb`), not a live re-fetch.** This is the next
+gating fact-join risk, downstream of (not the) tag selection. Entry point: source the
+benchmark `xbrl.duckdb` (487,623 facts / 246 cos — not checked in) before the P4 grader.
+
+---
+
+### S2/S13 (historical) — original defer rationale
+
 **Status: deferred 2026-06-26 (Phase A + Phase B self-reviews; defer rule D6 — spec-scheduled checkpoint)**
 
 **What:** Two latent properties of `make_fact_id` (`store.py`), both unreachable on the current

--- a/Main/backend/.dockerignore
+++ b/Main/backend/.dockerignore
@@ -87,6 +87,16 @@ node_modules/
 npm-debug.log
 yarn-error.log
 
+# Truth-layer store: a build artifact, NOT source. entrypoint.sh rebuilds it from the
+# vendored companyfacts snapshots at container start, so never bake a developer's local
+# copy into the image — it may be stale relative to the fact_id recipe / registry
+# version (the committed truthlayer/data/companyfacts/*.json snapshots ARE kept).
+truthlayer/data/truthlayer.duckdb
+truthlayer/data/truthlayer.duckdb.wal
+truthlayer/data/.building-*
+# _tagrecover investigation cache (~760 MB of fetched companyfacts; tooling-only).
+truthlayer/_tagrecover/companyfacts/
+
 # Temporary files
 tmp/
 temp/

--- a/Main/backend/entrypoint.sh
+++ b/Main/backend/entrypoint.sh
@@ -25,8 +25,11 @@ mkdir -p "${CACHE_FILE_PATH:-/tmp/fingpt_cache}"
 # read-write lock is exclusive across processes, so the workers must all open the
 # store read-only — which requires it to already exist. Building here (single process,
 # connection closed immediately) avoids a cold-start lock fight between workers.
+# Gate on _store_is_current (NOT mere existence): an image-baked store built under an
+# older fact_id recipe / registry version must be rebuilt here, not lazily in a
+# concurrent post-fork window. This mirrors the request-path gate in retrieve._ensure_built.
 echo "Building XBRL truth-layer store..."
-python -c "from truthlayer import ingest, store; ingest.build_from_vendored().close() if not store.DB_PATH.exists() else print('truth-layer store already present')" || {
+python -c "from truthlayer import ingest, retrieve; ingest.build_from_vendored().close() if not retrieve._store_is_current() else print('truth-layer store already current')" || {
     echo "ERROR: failed to build truth-layer store" >&2
     exit 1
 }

--- a/Main/backend/tests/test_truthlayer_benchmark_selection.py
+++ b/Main/backend/tests/test_truthlayer_benchmark_selection.py
@@ -1,0 +1,146 @@
+"""Concept->tag SELECTION reconciled against the benchmark generator (S2/S13, the
+half that the fact_id hash reconciliation did NOT cover).
+
+The generator stores, per concept, ONE us-gaap tag inside each gold_fact_path hash.
+Track-R facts-reached only joins if our resolver SELECTS that same tag. The rule
+was recovered empirically by reversing 858 gold hashes in cases_v1_final.json
+against fetched SEC companyfacts (tooling: truthlayer/_tagrecover/): for every
+concept the generator uses a single, CONFLICT-FREE global tag-priority order, and
+`retrieve_evidence`'s first-present-tag-wins reproduces it because `_select` only
+considers a tag that actually reports a fact for the queried period.
+
+These tests pin (a) the recovered priority order and (b) end-to-end gold anchors:
+registry-selected tag -> make_fact_id -> a REAL gold_fact_path hash, for each
+benchmark concept our registry did not previously cover.
+"""
+from datetime import date
+
+import pytest
+
+from truthlayer import store
+from truthlayer.registry import (
+    CONCEPT_REGISTRY, BENCHMARK_CONCEPT_ALIAS, get_concept,
+    resolve_benchmark_concept,
+)
+
+
+def _first_present_tag(concept: str, available: set[str]) -> str | None:
+    """Offline mirror of retrieve_evidence: first registry tag for `concept` that is
+    present (i.e. that _select would find a period fact for). The real path filters
+    presence by period in SQL; here `available` is the set of tags reporting the
+    queried period, so this exercises the registry ORDER identically."""
+    for tag in get_concept(concept).tags:
+        if tag in available:
+            return tag
+    return None
+
+
+# --- recovered ground truth: (cik, registry-concept, tag, ps, pe, unit, accn, gold) ---
+# Each was reversed from a real case's gold_fact_path; see _tagrecover/anchors.py.
+GOLD_ANCHORS = [
+    ("net_income", 97476, "NetIncomeLoss",
+     date(2025, 1, 1), date(2025, 12, 31), "USD", "0000097476-26-000059",
+     "f494a68abe558cc9db28a70b4feb6f6c955158b4"),
+    ("operating_income", 18230, "OperatingIncomeLoss",
+     date(2025, 1, 1), date(2025, 12, 31), "USD", "0000018230-26-000008",
+     "3d9854ad48bfa32e78420b185d1070703dbead5e"),
+    ("gross_profit", 1045810, "GrossProfit",
+     date(2025, 1, 27), date(2026, 1, 25), "USD", "0001045810-26-000021",
+     "e4fd53279204a524d56372e0bb045557abcced18"),
+    ("research_and_development", 1045810, "ResearchAndDevelopmentExpense",
+     date(2024, 1, 29), date(2025, 1, 26), "USD", "0001045810-26-000021",
+     "62a99caa879716902576a53f0ffe313fb98f8448"),
+    ("cash_and_equivalents", 1707925, "CashAndCashEquivalentsAtCarryingValue",
+     None, date(2025, 12, 31), "USD", "0001628280-26-011430",
+     "e4e4e70e394e119cc27ee54493b059aba335ee79"),
+    # CrowdStrike reports revenue ONLY under the Including-assessed-tax variant — the
+    # lone gold fact (of 230) using it. Caught by the full 742-fact validation sweep.
+    ("revenue", 1535527, "RevenueFromContractWithCustomerIncludingAssessedTax",
+     date(2025, 2, 1), date(2026, 1, 31), "USD", "0001535527-26-000010",
+     "ee6fdb46fe1c98b76ddfcd12bdfe4cf6dc71cf5c"),
+]
+
+
+@pytest.mark.parametrize("concept,cik,tag,ps,pe,unit,accn,gold", GOLD_ANCHORS,
+                         ids=[a[0] for a in GOLD_ANCHORS])
+def test_registry_selected_tag_reproduces_real_gold_hash(concept, cik, tag, ps, pe, unit, accn, gold):
+    # The registry must (1) know this benchmark concept and (2) select `tag` for it;
+    # then the reconciled make_fact_id recipe must reproduce the real gold hash.
+    selected = _first_present_tag(concept, {tag})
+    assert selected == tag, f"{concept}: registry selected {selected!r}, gold used {tag!r}"
+    assert store.make_fact_id(cik, selected, ps, pe, unit, accn) == gold
+
+
+def test_new_concepts_have_correct_period_type():
+    assert get_concept("net_income").period_type == "duration"
+    assert get_concept("operating_income").period_type == "duration"
+    assert get_concept("gross_profit").period_type == "duration"
+    assert get_concept("research_and_development").period_type == "duration"
+    assert get_concept("cash_and_equivalents").period_type == "instant"
+
+
+def test_net_income_priority_netincomeloss_over_profitloss():
+    # Recovered: NetIncomeLoss > ProfitLoss (gold chose NetIncomeLoss 15x head-to-head).
+    assert _first_present_tag("net_income", {"NetIncomeLoss", "ProfitLoss"}) == "NetIncomeLoss"
+    # Falls through to ProfitLoss only when NetIncomeLoss is absent (gold did this 6x).
+    assert _first_present_tag("net_income", {"ProfitLoss"}) == "ProfitLoss"
+
+
+def test_revenue_order_matches_generator_priority():
+    # The crux of yesterday's false-alarm: order is RevenueFromContractExcluding >
+    # Revenues > SalesRevenueNet > SalesRevenueGoodsNet (conflict-free over 230 facts).
+    tags = get_concept("revenue").tags
+    order = {t: i for i, t in enumerate(tags)}
+    assert order["RevenueFromContractWithCustomerExcludingAssessedTax"] < order["Revenues"]
+    assert order["Revenues"] < order["SalesRevenueNet"]
+    assert order["SalesRevenueNet"] < order["SalesRevenueGoodsNet"]
+    # Including-assessed-tax variant ranks below both Excluding and Revenues (recovered
+    # constraints: Excluding > Including, Revenues > Including); only used when alone.
+    assert order["RevenueFromContractWithCustomerExcludingAssessedTax"] < order["RevenueFromContractWithCustomerIncludingAssessedTax"]
+    assert order["Revenues"] < order["RevenueFromContractWithCustomerIncludingAssessedTax"]
+    assert _first_present_tag(
+        "revenue", {"RevenueFromContractWithCustomerIncludingAssessedTax"}
+    ) == "RevenueFromContractWithCustomerIncludingAssessedTax"
+    # NVDA regime: only Revenues present for FY2026 -> first-tag-wins falls through.
+    assert _first_present_tag("revenue", {"Revenues"}) == "Revenues"
+    # Both present -> the generator (and we) pick RevenueFromContract.
+    assert _first_present_tag(
+        "revenue", {"RevenueFromContractWithCustomerExcludingAssessedTax", "Revenues"}
+    ) == "RevenueFromContractWithCustomerExcludingAssessedTax"
+
+
+def test_cogs_and_equity_orders_match_generator():
+    cogs = {t: i for i, t in enumerate(get_concept("cost_of_revenue").tags)}
+    assert cogs["CostOfGoodsAndServicesSold"] < cogs["CostOfRevenue"]  # 50 vs 21 in gold
+    eq = {t: i for i, t in enumerate(get_concept("equity").tags)}
+    assert (eq["StockholdersEquityIncludingPortionAttributableToNoncontrollingInterest"]
+            < eq["StockholdersEquity"])
+
+
+def test_benchmark_concept_alias_resolves_every_single_fact_concept():
+    # The benchmark keys required_facts by its OWN concept names (total_assets, cogs,
+    # stockholders_equity, reported_gross_profit, ...). The grader maps them to our
+    # registry via BENCHMARK_CONCEPT_ALIAS; every alias must land on a real concept.
+    expected_primary = {
+        "revenue": "RevenueFromContractWithCustomerExcludingAssessedTax",
+        "cogs": "CostOfGoodsAndServicesSold",
+        "reported_gross_profit": "GrossProfit",
+        "operating_income": "OperatingIncomeLoss",
+        "net_income": "NetIncomeLoss",
+        "research_and_development": "ResearchAndDevelopmentExpense",
+        "total_assets": "Assets",
+        "total_liabilities": "Liabilities",
+        "stockholders_equity":
+            "StockholdersEquityIncludingPortionAttributableToNoncontrollingInterest",
+        "current_assets": "AssetsCurrent",
+        "current_liabilities": "LiabilitiesCurrent",
+        "cash_and_equivalents": "CashAndCashEquivalentsAtCarryingValue",
+    }
+    for bench_key, primary_tag in expected_primary.items():
+        concept = resolve_benchmark_concept(bench_key)
+        assert concept in CONCEPT_REGISTRY, f"{bench_key} -> {concept!r} not in registry"
+        assert get_concept(concept).tags[0] == primary_tag, (
+            f"{bench_key}: primary tag is {get_concept(concept).tags[0]!r}, "
+            f"generator used {primary_tag!r}")
+    # The alias map must not silently drop a benchmark concept.
+    assert set(BENCHMARK_CONCEPT_ALIAS) == set(expected_primary)

--- a/Main/backend/tests/test_truthlayer_store.py
+++ b/Main/backend/tests/test_truthlayer_store.py
@@ -1,11 +1,24 @@
 from datetime import date
 from decimal import Decimal
 
+import pytest
+
 from truthlayer import store
 
 
+@pytest.fixture
+def built_store_db(tmp_path):
+    """A freshly built, checkpointed, closed store; yields its on-disk path."""
+    from truthlayer import ingest
+    db = tmp_path / "t.duckdb"
+    con = ingest.build_from_vendored(db)
+    con.execute("CHECKPOINT")
+    con.close()
+    return db
+
+
 def test_make_fact_id_is_stable_and_distinguishes_accession():
-    # Signature: (cik, tag, period_start, period_end, unit, accession, dim_hash='')
+    # Signature: (cik, concept, period_start, period_end, unit, accession, *, dim_hash='')
     a = store.make_fact_id(320193, "Assets", None, date(2023, 9, 30), "USD", "acc-1")
     a_again = store.make_fact_id(320193, "Assets", None, date(2023, 9, 30), "USD", "acc-1")
     b = store.make_fact_id(320193, "Assets", None, date(2023, 9, 30), "USD", "acc-2")
@@ -21,6 +34,20 @@ def test_connect_creates_schema():
     assert {"fact_id", "value_exact", "filed", "period_start", "frame"} <= set(cols)
     ent_cols = [r[1] for r in con.execute("PRAGMA table_info('entities')").fetchall()]
     assert {"cik", "ticker", "name"} <= set(ent_cols)
+    meta_cols = [r[1] for r in con.execute("PRAGMA table_info('meta')").fetchall()]
+    assert {"key", "value"} <= set(meta_cols)
+
+
+def test_dim_hash_is_keyword_only():
+    # Keyword-only so it can't be supplied by accident in the wrong positional slot of
+    # a 7-field, all-stringified JOIN KEY. A 7th positional arg must raise, not hash.
+    with pytest.raises(TypeError):
+        store.make_fact_id(320193, "Assets", None, date(2023, 9, 30), "USD", "acc-1", "x")
+    # Supplied by keyword it participates in the hash (a real param, not a constant).
+    base = store.make_fact_id(320193, "Assets", None, date(2023, 9, 30), "USD", "acc-1")
+    dimmed = store.make_fact_id(320193, "Assets", None, date(2023, 9, 30), "USD", "acc-1",
+                                dim_hash="seg=US")
+    assert base != dimmed
 
 
 def test_value_exact_preserves_more_than_six_decimals():
@@ -67,3 +94,55 @@ def test_make_fact_id_golden():
         1045810, "Revenues", date(2025, 1, 27), date(2026, 1, 25), "USD",
         "0001045810-26-000021")
     assert fid == "d7a34159f863a4bbbbe3b092a3f9611070cfe5ad"
+
+
+def test_built_store_fact_ids_match_recipe(tmp_path):
+    # End-to-end ingest->store pin: EVERY stored fact_id must equal make_fact_id
+    # recomputed from that same row's fields. Without this, a store built under an old
+    # recipe would pass every other test (none assert on a STORED fact_id) while
+    # serving ids that never join to the benchmark gold. Recompute over the WHOLE table
+    # (no LIMIT) — a few thousand rows hash in milliseconds — so a recipe desync scoped
+    # to a single entity or tag can't slip through an unordered sample.
+    from truthlayer import ingest
+    con = ingest.build_from_vendored(tmp_path / "t.duckdb")
+    try:
+        rows = con.execute(
+            "SELECT fact_id, cik, tag, period_start, period_end, unit, accession "
+            "FROM facts"
+        ).fetchall()
+        assert rows, "vendored snapshots produced no facts"
+        mismatched = [
+            fid for fid, cik, tag, ps, pe, unit, accn in rows
+            if fid != store.make_fact_id(cik, tag, ps, pe, unit, accn)
+        ]
+        assert not mismatched, f"{len(mismatched)}/{len(rows)} stored fact_ids != recipe"
+    finally:
+        con.close()
+
+
+def test_built_store_stamps_versions(built_store_db):
+    # The build records its recipe+registry versions into `meta` so staleness is
+    # detectable; read_meta must round-trip exactly what build_versions() declared.
+    assert store.read_meta(built_store_db) == store.build_versions()
+
+
+def test_read_meta_treats_missing_or_legacy_store_as_stale(tmp_path):
+    # Missing file -> {}. A store predating the meta table -> {} (so it reads as stale
+    # and is rebuilt, never trusted) instead of raising.
+    assert store.read_meta(tmp_path / "nope.duckdb") == {}
+    legacy = tmp_path / "legacy.duckdb"
+    con = store.connect(legacy)
+    con.execute("DROP TABLE meta")          # simulate a store built before the meta table
+    con.execute("CHECKPOINT")
+    con.close()
+    assert store.read_meta(legacy) == {}
+
+
+def test_store_is_current_detects_version_drift(built_store_db, monkeypatch):
+    # The payoff of the meta stamp: a recipe/registry bump must invalidate a store
+    # built under the old version so _ensure_built rebuilds it.
+    from truthlayer import retrieve
+    monkeypatch.setattr(store, "DB_PATH", built_store_db)
+    assert retrieve._store_is_current() is True
+    monkeypatch.setattr(store, "FACT_ID_RECIPE_VERSION", "0000-00-00")  # simulate a bump
+    assert retrieve._store_is_current() is False

--- a/Main/backend/tests/test_truthlayer_store.py
+++ b/Main/backend/tests/test_truthlayer_store.py
@@ -5,9 +5,10 @@ from truthlayer import store
 
 
 def test_make_fact_id_is_stable_and_distinguishes_accession():
-    a = store.make_fact_id(320193, "us-gaap", "Assets", "USD", None, date(2023, 9, 30), "acc-1")
-    a_again = store.make_fact_id(320193, "us-gaap", "Assets", "USD", None, date(2023, 9, 30), "acc-1")
-    b = store.make_fact_id(320193, "us-gaap", "Assets", "USD", None, date(2023, 9, 30), "acc-2")
+    # Signature: (cik, tag, period_start, period_end, unit, accession, dim_hash='')
+    a = store.make_fact_id(320193, "Assets", None, date(2023, 9, 30), "USD", "acc-1")
+    a_again = store.make_fact_id(320193, "Assets", None, date(2023, 9, 30), "USD", "acc-1")
+    b = store.make_fact_id(320193, "Assets", None, date(2023, 9, 30), "USD", "acc-2")
     assert a == a_again            # deterministic
     assert a != b                  # a restatement (different accession) is a different fact
     assert len(a) == 40            # sha1 hex
@@ -33,10 +34,36 @@ def test_value_exact_preserves_more_than_six_decimals():
     assert got == v
 
 
+def test_make_fact_id_matches_benchmark_gold_path():
+    # S2/S13 reconciliation: make_fact_id is a CROSS-SYSTEM JOIN KEY — it must
+    # reproduce the benchmark's gold_fact_path sha1s byte-for-byte, or Track-R
+    # facts-reached grading can never join our retrieved fact to the gold fact.
+    #
+    # These two anchors are REAL gold hashes lifted from cases_v1_final.json, with
+    # the source fact fields recovered from SEC companyfacts. The recipe is
+    #   sha1("|".join(str(x) for x in
+    #        (cik, concept, period_start, period_end, unit, accession, dim_hash)))
+    # concept = the raw us-gaap tag; period_start=None (instant facts) -> str() -> 'None';
+    # dim_hash = '' for consolidated companyfacts facts (no segment/member dimensions).
+    #
+    # NVIDIA FY2026 Revenues (duration) — cases_v1_final.json[0].gold_fact_path:
+    assert store.make_fact_id(
+        1045810, "Revenues", date(2025, 1, 27), date(2026, 1, 25), "USD",
+        "0001045810-26-000021",
+    ) == "d7a34159f863a4bbbbe3b092a3f9611070cfe5ad"
+    # Meta FY2025 Assets (instant; period_start is None) — same file:
+    assert store.make_fact_id(
+        1326801, "Assets", None, date(2025, 12, 31), "USD",
+        "0001628280-26-003942",
+    ) == "293b650557be02293fc40c70526e46d6b9096ee2"
+
+
 def test_make_fact_id_golden():
-    # Pins the canonical sha1 recipe (spec S2) so it cannot drift silently and the
-    # teammate's gold_fact_path generator can diff against a known value. If the S13
-    # reconciliation deliberately changes the recipe, update this hash on purpose.
+    # Pins the canonical sha1 recipe (spec S2/S13, reconciled against the benchmark
+    # generator) so it cannot drift silently. If the recipe deliberately changes,
+    # update this hash on purpose — but it must stay consistent with the real
+    # gold_fact_path anchors in test_make_fact_id_matches_benchmark_gold_path.
     fid = store.make_fact_id(
-        320193, "us-gaap", "Assets", "USD", None, date(2023, 9, 30), "0000320193-23-000106")
-    assert fid == "8f4f87c831b284fcb30381590a01bece0983ec4b"
+        1045810, "Revenues", date(2025, 1, 27), date(2026, 1, 25), "USD",
+        "0001045810-26-000021")
+    assert fid == "d7a34159f863a4bbbbe3b092a3f9611070cfe5ad"

--- a/Main/backend/truthlayer/_tagrecover/.gitignore
+++ b/Main/backend/truthlayer/_tagrecover/.gitignore
@@ -1,0 +1,2 @@
+companyfacts/
+__pycache__/

--- a/Main/backend/truthlayer/_tagrecover/README.md
+++ b/Main/backend/truthlayer/_tagrecover/README.md
@@ -1,0 +1,52 @@
+# `_tagrecover` — benchmark concept→tag selection conformance harness
+
+Investigation + conformance tooling (NOT imported by the package) used to reconcile
+`CONCEPT_REGISTRY` against the benchmark generator's tag-selection rule (spec S2/S13,
+the half the `fact_id` hash reconciliation did not cover). Kept because conformance to
+the generator's tag choice is what Track-R facts-reached grading depends on — a future
+P4-grader author will want to re-prove it.
+
+## Why this exists
+
+`cases_v1_final.json` stores, per concept, exactly one us-gaap tag *inside* each
+`gold_fact_path` sha1 — the tag is never in plaintext. If our resolver SELECTS a
+different tag than the generator stored, the hashes don't join and Track-R fails even
+with a byte-perfect recipe. So the rule had to be recovered by reversing the hashes.
+
+## The three scripts (run in order)
+
+1. `fetch.py` — fetch full **us-gaap** companyfacts for every company referenced by the
+   benchmark (197: 182 single-entity + 15 cross-entity comparison tickers) to
+   `companyfacts/` (gitignored, ~760 MB). Resumable, rate-limited ~8 req/s. Must be
+   **unpruned** us-gaap — the vendored package snapshots are pruned to registry tags and
+   therefore hide the competitor tags we are trying to discover.
+2. `recover.py` — for every `(case, required_fact value)`, find the us-gaap fact(s)
+   reporting that value, hash each candidate with the reconciled recipe, keep the one whose
+   hash ∈ `gold_fact_path`. Emits the concept→chosen-tag distribution, the pairwise
+   priority constraints (`chosen ≻ sibling`, only countable when one company reports both
+   value-equal), and per-company divergence.
+3. `validate_full.py` — exhaustive check: does the reconciled `CONCEPT_REGISTRY`
+   (first-present-tag-wins over the tags the company reports at the gold fact's period+unit)
+   select the SAME tag the generator stored, for every resolvable fact?
+
+## Result (2026-06-27)
+
+- **742 / 742** resolvable single-entity facts: registry reproduces the gold tag. **0
+  mismatches** across all 9 single-fact concepts.
+- The generator uses a single, **conflict-free global tag-priority order** per concept;
+  per-company "divergence" is just which tags a company happens to report. Our
+  first-present-tag-wins (`retrieve._select` filters tag by period presence) reproduces it.
+- Unmapped keys are only the **derived ratios** (`gross_margin`, `net_margin`,
+  `asset_turnover`, `equity_multiplier`) — Track-C computations, not stored facts.
+
+The result is pinned offline (no network) by
+`tests/test_truthlayer_benchmark_selection.py` (5 gold anchors + order/alias pins).
+
+## ⚠️ Accession drift — do NOT use this cache for breadth ingest
+
+For a few companies (BLK, CEG, CRWV …, ~33 facts) the **entire** `gold_fact_path` points
+to accessions that *live* SEC companyfacts no longer returns — the benchmark's gold was
+generated against a **frozen** companyfacts snapshot since drifted. `fact_id` includes
+`accession`, so a grader that re-fetches from live SEC will mint different ids than gold
+for any drifted fact. **Breadth ingest for the P4 grader must come from the benchmark's
+own frozen snapshot (`xbrl.duckdb`), not a live re-fetch.**

--- a/Main/backend/truthlayer/_tagrecover/fetch.py
+++ b/Main/backend/truthlayer/_tagrecover/fetch.py
@@ -1,0 +1,94 @@
+"""Investigation tooling (NOT package code) — fetch full us-gaap companyfacts for
+every company referenced by the benchmark, so the tag-selection recovery harness
+can see competitor tags the vendored *pruned* snapshots threw away.
+
+Resumable (skips cached), rate-limited (~8 req/s), us-gaap-only prune (keeps ALL
+us-gaap tags — correctness over disk; recovery's coverage report catches misses).
+"""
+from __future__ import annotations
+
+import json
+import sys
+import time
+from pathlib import Path
+
+import requests
+
+HERE = Path(__file__).resolve().parent
+CASES = Path("/mnt/d/fingpt/Materials/XBRL Tree/Benchmark/cases_v1_final.json")
+CACHE = HERE / "companyfacts"
+UA = "Agentic-FinSearch felixflyingt@gmail.com"
+HEADERS = {"User-Agent": UA}
+
+
+def unique_ciks() -> dict[int, str]:
+    """cik -> a label (ticker if known). Covers single-entity cases + resolves the
+    cross-entity comparison tickers that never appear as a primary entity."""
+    cases = json.loads(CASES.read_text())
+    cik_label: dict[int, str] = {}
+    t2c: dict[str, int] = {}
+    cross: set[str] = set()
+    for c in cases:
+        e = c["entity"]
+        if isinstance(e, dict) and "cik" in e:
+            cik_label[e["cik"]] = e.get("ticker", str(e["cik"]))
+            t2c[e.get("ticker", "")] = e["cik"]
+        elif isinstance(e, dict) and "companies" in e:
+            cross.update(e["companies"])
+    missing = sorted(cross - set(t2c))
+    if missing:
+        tmap = requests.get(
+            "https://www.sec.gov/files/company_tickers.json", headers=HEADERS, timeout=30
+        ).json()
+        by_ticker = {row["ticker"].upper(): row["cik_str"] for row in tmap.values()}
+        for tk in missing:
+            cik = by_ticker.get(tk.upper())
+            if cik is not None:
+                cik_label[int(cik)] = tk
+            else:
+                print(f"  ! could not resolve ticker {tk} -> cik", file=sys.stderr)
+    return cik_label
+
+
+def prune_usgaap(doc: dict) -> dict:
+    """Keep dei? no — only us-gaap, all tags. Drops other taxonomies to shrink disk."""
+    gaap = doc.get("facts", {}).get("us-gaap", {})
+    return {
+        "cik": doc.get("cik"),
+        "entityName": doc.get("entityName"),
+        "facts": {"us-gaap": gaap},
+    }
+
+
+def main() -> None:
+    CACHE.mkdir(parents=True, exist_ok=True)
+    targets = unique_ciks()
+    print(f"targets: {len(targets)} companies")
+    done = skipped = failed = 0
+    for i, (cik, label) in enumerate(sorted(targets.items()), 1):
+        out = CACHE / f"CIK{cik:010d}.json"
+        if out.exists():
+            skipped += 1
+            continue
+        url = f"https://data.sec.gov/api/xbrl/companyfacts/CIK{cik:010d}.json"
+        for attempt in range(3):
+            try:
+                r = requests.get(url, headers=HEADERS, timeout=60)
+                r.raise_for_status()
+                out.write_text(json.dumps(prune_usgaap(r.json())))
+                done += 1
+                break
+            except Exception as exc:  # noqa: BLE001
+                if attempt == 2:
+                    failed += 1
+                    print(f"  ! FAILED {label} CIK{cik:010d}: {exc}", file=sys.stderr)
+                else:
+                    time.sleep(1.5)
+        if i % 20 == 0:
+            print(f"  [{i}/{len(targets)}] done={done} skipped={skipped} failed={failed}")
+        time.sleep(0.13)  # ~8 req/s, under SEC's 10/s ceiling
+    print(f"DONE: fetched={done} skipped={skipped} failed={failed} total={len(targets)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/Main/backend/truthlayer/_tagrecover/recover.py
+++ b/Main/backend/truthlayer/_tagrecover/recover.py
@@ -1,0 +1,156 @@
+"""Investigation tooling (NOT package code) — recover the benchmark generator's
+concept->tag SELECTION rule empirically from cases_v1_final.json + fetched
+companyfacts, by reversing the gold_fact_path hashes.
+
+For every (case, required_fact value): find the us-gaap fact(s) in that company
+reporting that value, hash each candidate (cik, tag, ps, pe, unit, accn) with the
+RECONCILED recipe, and keep the one whose hash is in gold_fact_path. That match
+reveals the chosen tag AND re-validates the recipe on hundreds of fresh facts.
+
+Also captures, per matched fact, the SIBLING us-gaap tags the same company reported
+for the same (period, unit, value) but the generator passed over -> pairwise
+priority constraints (chosen > sibling).
+"""
+from __future__ import annotations
+
+import json
+import re
+import sys
+from collections import Counter, defaultdict
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE.parent.parent))  # Main/backend, so `import truthlayer`
+from truthlayer import store  # noqa: E402
+
+CASES = Path("/mnt/d/fingpt/Materials/XBRL Tree/Benchmark/cases_v1_final.json")
+CACHE = HERE / "companyfacts"
+
+
+def _d(s):
+    return s if s else None  # keep ISO string / None; make_fact_id str()s it
+
+
+def load_company_index(cik: int):
+    """Return list of (val, tag, ps, pe, unit, accn) for every us-gaap entry, or None."""
+    path = CACHE / f"CIK{cik:010d}.json"
+    if not path.exists():
+        return None
+    doc = json.loads(path.read_text())
+    rows = []
+    for tag, body in doc.get("facts", {}).get("us-gaap", {}).items():
+        for unit, entries in body.get("units", {}).items():
+            for e in entries:
+                rows.append((e["val"], tag, e.get("start"), e.get("end"), unit, e["accn"]))
+    return rows
+
+
+def concept_of(key: str) -> str:
+    """Normalize a required_facts key to a concept label (strip trailing period token)."""
+    return re.sub(r"_(\d{4}|y\d+|t\d*|prior|current|base|end|start)$", "", key)
+
+
+def main() -> None:
+    cases = json.loads(CASES.read_text())
+    # ticker -> cik from single-entity cases (for cross-entity required_facts keyed by ticker)
+    t2c = {}
+    for c in cases:
+        e = c["entity"]
+        if isinstance(e, dict) and "cik" in e:
+            t2c[e.get("ticker")] = e["cik"]
+    # resolve the cross-entity-only tickers from the fetch's cache filenames is hard;
+    # instead build ticker->cik from SEC map lazily only if needed (most resolve via t2c).
+
+    idx_cache: dict[int, list | None] = {}
+
+    def idx(cik):
+        if cik not in idx_cache:
+            idx_cache[cik] = load_company_index(cik)
+        return idx_cache[cik]
+
+    # concept -> Counter(chosen_tag)
+    concept_tags: dict[str, Counter] = defaultdict(Counter)
+    # (concept) -> Counter("chosen>sibling")
+    priority: dict[str, Counter] = defaultdict(Counter)
+    # per-(cik,concept) chosen tag, to detect per-company divergence
+    company_choice: dict[tuple, set] = defaultdict(set)
+    resolved = 0
+    unresolved = []
+    no_data = Counter()
+    total_facts = 0
+
+    for c in cases:
+        gold = set(c["gold_fact_path"])
+        cik_default = c["entity"].get("cik") if isinstance(c["entity"], dict) else None
+        for key, val in c["required_facts"].items():
+            total_facts += 1
+            # resolve cik: single-entity uses default; cross-entity key is a ticker
+            cik = cik_default
+            concept = concept_of(key)
+            if cik is None:  # cross-entity: key is a ticker
+                cik = t2c.get(key)
+                concept = "cross:" + c["template_id"]
+            if cik is None:
+                unresolved.append(("no-cik", key, c["template_id"]))
+                continue
+            rows = idx(cik)
+            if rows is None:
+                no_data[cik] += 1
+                continue
+            # candidate facts: same value (exact float match)
+            cands = [r for r in rows if r[0] == val]
+            hit = None
+            for (v, tag, ps, pe, unit, accn) in cands:
+                h = store.make_fact_id(cik, tag, _d(ps), _d(pe), unit, accn)
+                if h in gold:
+                    hit = (tag, ps, pe, unit, accn)
+                    break
+            if hit is None:
+                unresolved.append((cik, key, val, len(cands)))
+                continue
+            resolved += 1
+            ctag, cps, cpe, cunit, _accn = hit
+            concept_tags[concept][ctag] += 1
+            company_choice[(cik, concept)].add(ctag)
+            # siblings: other tags in same company reporting same (period, unit, value)
+            for (v, tag, ps, pe, unit, accn) in rows:
+                if tag != ctag and v == val and ps == cps and pe == cpe and unit == cunit:
+                    priority[concept][f"{ctag} > {tag}"] += 1
+
+    # ---- report ----
+    print("=" * 70)
+    print(f"COVERAGE: {resolved}/{total_facts} required_facts resolved to a gold tag")
+    print(f"  unresolved: {len(unresolved)}   companies-with-no-data hits: {sum(no_data.values())}")
+    if no_data:
+        print(f"  missing cik data for {len(no_data)} companies: {sorted(no_data)[:10]}...")
+    print("=" * 70)
+    print("\n### CONCEPT -> CHOSEN TAG DISTRIBUTION (the selection rule)")
+    for concept in sorted(concept_tags):
+        dist = concept_tags[concept]
+        print(f"\n  {concept}  (n={sum(dist.values())})")
+        for tag, n in dist.most_common():
+            print(f"      {n:4d}  {tag}")
+    print("\n### PRIORITY CONSTRAINTS (chosen > sibling, same period/value)")
+    any_pri = False
+    for concept in sorted(priority):
+        if priority[concept]:
+            any_pri = True
+            print(f"  {concept}:")
+            for rel, n in priority[concept].most_common():
+                print(f"      {n:4d}  {rel}")
+    if not any_pri:
+        print("  (none — no company reported two value-equal candidate tags for one period)")
+    print("\n### PER-COMPANY DIVERGENCE (same concept, different tag across companies)")
+    div = defaultdict(set)
+    for (cik, concept), tags in company_choice.items():
+        div[concept] |= tags
+    for concept in sorted(div):
+        if len(div[concept]) > 1:
+            print(f"  {concept}: {sorted(div[concept])}")
+    print("\n### UNRESOLVED SAMPLES (first 25)")
+    for u in unresolved[:25]:
+        print("   ", u)
+
+
+if __name__ == "__main__":
+    main()

--- a/Main/backend/truthlayer/_tagrecover/recover.py
+++ b/Main/backend/truthlayer/_tagrecover/recover.py
@@ -46,8 +46,10 @@ def load_company_index(cik: int):
 
 
 def concept_of(key: str) -> str:
-    """Normalize a required_facts key to a concept label (strip trailing period token)."""
-    return re.sub(r"_(\d{4}|y\d+|t\d*|prior|current|base|end|start)$", "", key)
+    """Normalize a required_facts key to a concept label (strip trailing period token).
+    Period tokens always carry a number (t1/t2, y1, 2025); `t\\d+` not `t\\d*` so a
+    concept legitimately ending in a bare '_t' is not over-stripped."""
+    return re.sub(r"_(\d{4}|y\d+|t\d+|prior|current|base|end|start)$", "", key)
 
 
 def main() -> None:

--- a/Main/backend/truthlayer/_tagrecover/validate_full.py
+++ b/Main/backend/truthlayer/_tagrecover/validate_full.py
@@ -1,0 +1,88 @@
+"""Exhaustive validation: for EVERY single-entity required_fact whose gold hash we
+can reverse, confirm the reconciled CONCEPT_REGISTRY (first-present-tag-wins over the
+tags the company actually reports for the gold fact's period) selects the SAME tag
+the generator stored. Goal: 0 mismatches across all concepts."""
+from __future__ import annotations
+import json, re, sys
+from collections import Counter
+from pathlib import Path
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE.parent.parent))
+from truthlayer import store, registry  # noqa
+CACHE = HERE / "companyfacts"
+cases = json.loads(Path("/mnt/d/fingpt/Materials/XBRL Tree/Benchmark/cases_v1_final.json").read_text())
+
+
+def load(cik):
+    p = CACHE / f"CIK{cik:010d}.json"
+    return json.loads(p.read_text()) if p.exists() else None
+
+
+def concept_of(key):
+    return re.sub(r"_(\d{4}|y\d+|t\d*|prior|current|base|end|start)$", "", key)
+
+
+def tags_present_at(doc, ps, pe, unit):
+    """All us-gaap tags reporting a fact at exactly (period_start, period_end) in the
+    gold fact's unit. NOTE: must use the gold unit, not hardcode USD — the benchmark
+    includes foreign private issuers (ASML/EUR, TM/JPY, ENB/CAD) whose headline facts
+    are in the home currency; _select prefers USD but does not exclude other units."""
+    present = set()
+    for tag, body in doc["facts"]["us-gaap"].items():
+        for u, ents in body.get("units", {}).items():
+            if u != unit:
+                continue
+            for e in ents:
+                if e.get("start") == ps and e.get("end") == pe:
+                    present.add(tag)
+    return present
+
+
+checked = matches = 0
+mismatches = []
+no_concept = Counter()
+for c in cases:
+    e = c["entity"]
+    if not (isinstance(e, dict) and "cik" in e):
+        continue  # cross-entity uses identical concepts/tags -> covered transitively
+    cik = e["cik"]
+    gold = set(c["gold_fact_path"])
+    doc = load(cik)
+    if not doc:
+        continue
+    for key, val in c["required_facts"].items():
+        bench_concept = concept_of(key)
+        reg_concept = registry.resolve_benchmark_concept(bench_concept)
+        if reg_concept not in registry.CONCEPT_REGISTRY:
+            no_concept[bench_concept] += 1
+            continue
+        # find the gold fact for this value: tag + period whose hash is in gold
+        goldfact = None
+        for tag, body in doc["facts"]["us-gaap"].items():
+            for unit, ents in body.get("units", {}).items():
+                for en in ents:
+                    if en["val"] == val and store.make_fact_id(
+                            cik, tag, en.get("start"), en.get("end"), unit, en["accn"]) in gold:
+                        goldfact = (tag, en.get("start"), en.get("end"), unit)
+        if goldfact is None:
+            continue  # ratio/derived/drifted — not a resolvable raw fact
+        gold_tag, ps, pe, gold_unit = goldfact
+        present = tags_present_at(doc, ps, pe, gold_unit)
+        spec = registry.CONCEPT_REGISTRY[reg_concept]
+        selected = next((t for t in spec.tags if t in present), None)
+        checked += 1
+        if selected == gold_tag:
+            matches += 1
+        else:
+            mismatches.append((e.get("ticker"), bench_concept, "gold=", gold_tag,
+                               "registry=", selected, "present∩regtags=",
+                               [t for t in spec.tags if t in present]))
+
+print(f"CHECKED {checked} resolvable single-entity facts")
+print(f"MATCHES {matches}  MISMATCHES {len(mismatches)}")
+if no_concept:
+    print(f"concepts with no registry mapping (expected: derived ratios): {dict(no_concept)}")
+for m in mismatches[:30]:
+    print("  MISMATCH", m)
+print("RESULT:", "PASS — registry reproduces gold tag selection everywhere"
+      if not mismatches else "FAIL — see mismatches above")

--- a/Main/backend/truthlayer/_tagrecover/validate_full.py
+++ b/Main/backend/truthlayer/_tagrecover/validate_full.py
@@ -19,7 +19,9 @@ def load(cik):
 
 
 def concept_of(key):
-    return re.sub(r"_(\d{4}|y\d+|t\d*|prior|current|base|end|start)$", "", key)
+    # Period tokens always carry a number (t1/t2, y1, 2025); t\d+ not t\d* so a
+    # concept legitimately ending in a bare '_t' is not over-stripped.
+    return re.sub(r"_(\d{4}|y\d+|t\d+|prior|current|base|end|start)$", "", key)
 
 
 def tags_present_at(doc, ps, pe, unit):

--- a/Main/backend/truthlayer/ingest.py
+++ b/Main/backend/truthlayer/ingest.py
@@ -16,6 +16,12 @@ USER_AGENT = "Agentic FinSearch admin@agenticfinsearch.org"
 DEMO_CIKS = {"AAPL": 320193, "MSFT": 789019, "TSLA": 1318605}
 
 # Keep vendored snapshots small: prune to the tags the registry actually uses.
+# NOTE: _prune() applies this set at save_snapshots() time, so the COMMITTED demo
+# snapshots only contain tags the registry referenced when they were last saved.
+# Adding a concept to the registry does NOT retroactively add its tag to those
+# snapshots — re-run save_snapshots() (needs network) if a newly added concept must
+# resolve on the demo trio. (The benchmark's 197-company breadth ingest is a separate
+# frozen source — see the deferred-items doc.)
 from truthlayer.registry import CONCEPT_REGISTRY  # noqa: E402
 _KEEP_TAGS = {t for spec in CONCEPT_REGISTRY.values() for t in spec.tags}
 
@@ -107,4 +113,7 @@ def build_from_vendored(db_path=store.DB_PATH):
         ingest_doc(con, doc)
         con.execute("UPDATE entities SET ticker = ? WHERE cik = ?",
                     [ticker_by_cik.get(doc["cik"]), doc["cik"]])
+    # Stamp the recipe + registry versions this store was built with, so a later
+    # recipe/registry bump invalidates it (retrieve._store_is_current rebuilds).
+    store.write_meta(con, store.build_versions())
     return con

--- a/Main/backend/truthlayer/ingest.py
+++ b/Main/backend/truthlayer/ingest.py
@@ -34,7 +34,8 @@ def companyfacts_rows(doc: dict):
                     ps, pe = _d(e.get("start")), _d(e.get("end"))
                     val = e["val"]
                     yield (
-                        store.make_fact_id(cik, taxonomy, tag, unit, ps, pe, e["accn"]),
+                        # dim_hash defaults to '' — companyfacts is consolidated only.
+                        store.make_fact_id(cik, tag, ps, pe, unit, e["accn"]),
                         cik, taxonomy, tag, unit, float(val), Decimal(str(val)),
                         ps, pe, e.get("fy"), e.get("fp"), e.get("form"),
                         e["accn"], _d(e.get("filed")), e.get("frame"),

--- a/Main/backend/truthlayer/registry.py
+++ b/Main/backend/truthlayer/registry.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-REGISTRY_VERSION = "2026-06-26"
+REGISTRY_VERSION = "2026-06-27"  # +benchmark concepts, tag order reconciled to gold
 
 
 class ConceptNotFound(KeyError):
@@ -26,12 +26,51 @@ CONCEPT_REGISTRY: dict[str, ConceptSpec] = {
         "RedeemableNoncontrollingInterestEquityCarryingAmount")),
     "revenue":             ConceptSpec("duration", (
         "RevenueFromContractWithCustomerExcludingAssessedTax",
-        "Revenues", "SalesRevenueNet", "SalesRevenueGoodsNet")),
+        "Revenues", "RevenueFromContractWithCustomerIncludingAssessedTax",
+        "SalesRevenueNet", "SalesRevenueGoodsNet")),
     "cost_of_revenue":     ConceptSpec("duration", (
         "CostOfGoodsAndServicesSold", "CostOfRevenue", "CostOfGoodsSold")),
     "current_assets":      ConceptSpec("instant",  ("AssetsCurrent",)),
     "current_liabilities": ConceptSpec("instant",  ("LiabilitiesCurrent",)),
+    # --- benchmark concepts (added 2026-06-27). Tag priority recovered empirically
+    # by reversing 858 gold_fact_path hashes in cases_v1_final.json against SEC
+    # companyfacts (tooling: truthlayer/_tagrecover/); only tags the generator
+    # actually stored in gold are listed, in the recovered conflict-free order. See
+    # tests/test_truthlayer_benchmark_selection.py for the pinned gold anchors.
+    "net_income":          ConceptSpec("duration", ("NetIncomeLoss", "ProfitLoss")),
+    "operating_income":    ConceptSpec("duration", ("OperatingIncomeLoss",)),
+    "gross_profit":        ConceptSpec("duration", ("GrossProfit",)),
+    "research_and_development": ConceptSpec("duration", ("ResearchAndDevelopmentExpense",)),
+    "cash_and_equivalents": ConceptSpec("instant",  ("CashAndCashEquivalentsAtCarryingValue",)),
 }
+
+# The benchmark keys required_facts by ITS OWN concept names; map them to our registry
+# concepts so the P4 grader joins by tag. Recovered alongside the tag order: the gold
+# fact for `total_assets` is the `Assets` tag (our `assets` concept), etc. Computed
+# metrics (gross_margin, net_margin, asset_turnover, equity_multiplier) are NOT here —
+# they are Track-C derivations, not a single stored fact.
+BENCHMARK_CONCEPT_ALIAS: dict[str, str] = {
+    "revenue":                  "revenue",
+    "cogs":                     "cost_of_revenue",
+    "reported_gross_profit":    "gross_profit",
+    "operating_income":         "operating_income",
+    "net_income":               "net_income",
+    "research_and_development":  "research_and_development",
+    "total_assets":             "assets",
+    "total_liabilities":        "liabilities",
+    "stockholders_equity":      "equity",
+    "current_assets":           "current_assets",
+    "current_liabilities":      "current_liabilities",
+    "cash_and_equivalents":     "cash_and_equivalents",
+}
+
+
+def resolve_benchmark_concept(benchmark_key: str) -> str:
+    """Map a benchmark required_facts concept name to our registry concept name.
+    Returns the key unchanged if it is already a registry concept (identity-safe)."""
+    if benchmark_key in BENCHMARK_CONCEPT_ALIAS:
+        return BENCHMARK_CONCEPT_ALIAS[benchmark_key]
+    return benchmark_key
 
 # Ratios reference CONCEPTS (rename map keeps the engine's input names stable):
 RATIO_CONCEPTS: dict[str, dict[str, str]] = {

--- a/Main/backend/truthlayer/retrieve.py
+++ b/Main/backend/truthlayer/retrieve.py
@@ -17,8 +17,24 @@ _local = threading.local()
 _build_lock = threading.Lock()
 
 
+def _store_is_current() -> bool:
+    """True only if a built store exists AND was stamped with the current recipe +
+    registry versions. A persisted store bakes fact_ids (recipe) and tag coverage
+    (registry) at build time; on a version drift the on-disk store is stale and is
+    rebuilt by _ensure_built — otherwise it would silently serve old-recipe fact_ids
+    that never join to the benchmark gold, or miss concepts added after it was built.
+    A store predating the `meta` table reads as {} (read_meta), so it counts as stale."""
+    if not store.DB_PATH.exists():
+        return False
+    actual = store.read_meta(store.DB_PATH)
+    return all(actual.get(k) == v for k, v in store.build_versions().items())
+
+
 def _ensure_built() -> None:
-    """Build the store from vendored snapshots once, if it isn't there yet.
+    """Build the store from vendored snapshots if it is missing OR stale.
+
+    "Stale" = built with a different fact_id recipe / registry version than the
+    running code (see _store_is_current); the rebuilt file atomically replaces it.
 
     Builds into a private temp file and atomically renames it into place, so two
     cold-start builders (threads here, OR separate worker processes) can never see
@@ -26,10 +42,10 @@ def _ensure_built() -> None:
     its own temp and the rename is atomic; last writer wins, data is identical.
     In production the build runs once in entrypoint.sh before workers fork, so this
     is normally a no-op fast path."""
-    if store.DB_PATH.exists():
+    if _store_is_current():
         return
     with _build_lock:                              # serialize threads within this process
-        if store.DB_PATH.exists():                 # double-checked after acquiring the lock
+        if _store_is_current():                    # double-checked after acquiring the lock
             return
         from truthlayer import ingest
         tmp = store.DB_PATH.with_name(f".building-{os.getpid()}-{store.DB_PATH.name}")

--- a/Main/backend/truthlayer/store.py
+++ b/Main/backend/truthlayer/store.py
@@ -8,6 +8,12 @@ import duckdb
 DATA_DIR = Path(__file__).resolve().parent / "data"
 DB_PATH = DATA_DIR / "truthlayer.duckdb"
 
+# Bump whenever make_fact_id's serialization changes. A built store bakes its
+# fact_ids at ingest time, so retrieve._store_is_current() rebuilds any store stamped
+# with a different recipe version rather than silently serving stale ids that no
+# longer join to the benchmark gold. See build_versions() / write_meta() / read_meta().
+FACT_ID_RECIPE_VERSION = "2026-06-26"
+
 # Column order is the contract for INSERT ... VALUES in ingest.py — do not reorder.
 FACT_COLUMNS = (
     "fact_id", "cik", "taxonomy", "tag", "unit", "value", "value_exact",
@@ -46,23 +52,37 @@ CREATE TABLE IF NOT EXISTS entities (
   ticker TEXT,
   name   TEXT
 );
+-- Build provenance: the code versions whose recipe/registry produced this store's
+-- rows. read_meta() compares these against the running code so a store built before
+-- a recipe or registry bump is detected as stale and rebuilt (not trusted).
+CREATE TABLE IF NOT EXISTS meta (
+  key   TEXT PRIMARY KEY,
+  value TEXT
+);
 """
 
 
-def make_fact_id(cik, tag, period_start, period_end, unit, accession, dim_hash="") -> str:
+def make_fact_id(cik, concept, period_start, period_end, unit, accession, *, dim_hash="") -> str:
     """sha1 of the canonical fact tuple — the cross-system JOIN KEY (spec S2/S13).
 
-    RECONCILED 2026-06-26 against the benchmark generator's gold_fact_path. The
-    recipe was recovered empirically (the generator source is not checked in) by
-    reproducing two real gold hashes from cases_v1_final.json against their SEC
-    companyfacts source fields, and is pinned by
+    RECONCILED 2026-06-26 against the benchmark generator's gold_fact_path (tracked by
+    FACT_ID_RECIPE_VERSION). The recipe was recovered empirically (the generator source
+    is not checked in) by reproducing real gold hashes from cases_v1_final.json against
+    their SEC companyfacts source fields, and is pinned by
     tests/test_truthlayer_store.py::test_make_fact_id_matches_benchmark_gold_path.
 
-    Canonical tuple order (== the generator's):
+    Canonical tuple order (== the generator's, and the positional arg order here):
         (cik, concept, period_start, period_end, unit, accession, dim_hash)
-    where `tag` here IS the generator's `concept` (the raw us-gaap tag, e.g.
-    'Revenues'). Earlier prose was wrong twice — the contributor guide omitted
-    period_start and the cases guide added value; the empirical match is of record.
+    `concept` IS the raw us-gaap tag the fact is reported under (e.g. 'Revenues') —
+    named to match the generator, not our `tag` column. The six canonical fields are
+    POSITIONAL on purpose: the call order is the documented recipe and the golden tests
+    pin it. `dim_hash` is KEYWORD-ONLY so it can never be supplied by accident in the
+    wrong slot — it defaults to '' (the only value consolidated companyfacts needs).
+
+    This is intentionally stringly-typed (each field goes through str()): callers may
+    pass period dates as date objects OR ISO strings — the _tagrecover tooling does the
+    latter — and None for an instant fact's period_start. So do NOT add isinstance
+    guards here; the golden hash tests are the guard for the recipe.
 
     Encoding couplings (verified byte-for-byte against the gold hashes):
       - Delimiter is a literal '|' with NO escaping; unreachable with SEC data
@@ -74,7 +94,7 @@ def make_fact_id(cik, tag, period_start, period_end, unit, accession, dim_hash="
         constant, so the deferred raw-XBRL dimensional ingest path can populate it
         without changing the recipe (and without re-hashing the consolidated facts).
     """
-    raw = "|".join(str(x) for x in (cik, tag, period_start, period_end, unit, accession, dim_hash))
+    raw = "|".join(str(x) for x in (cik, concept, period_start, period_end, unit, accession, dim_hash))
     return hashlib.sha1(raw.encode("utf-8")).hexdigest()
 
 
@@ -91,3 +111,39 @@ def connect(db_path=DB_PATH, read_only=False) -> "duckdb.DuckDBPyConnection":
     if not read_only:
         con.execute(_SCHEMA)
     return con
+
+
+def build_versions() -> dict[str, str]:
+    """The code versions a freshly built store is stamped with (into the `meta` table).
+    A persisted store is valid ONLY for these exact values: fact_id is recipe-baked and
+    tag coverage is registry-baked, both at ingest time. retrieve._store_is_current()
+    compares a store's stamp against this and rebuilds on any drift, so a recipe or
+    registry bump can never silently serve a stale store."""
+    from truthlayer.registry import REGISTRY_VERSION  # lazy: keep store import-cycle-free
+    return {
+        "fact_id_recipe_version": FACT_ID_RECIPE_VERSION,
+        "registry_version": REGISTRY_VERSION,
+    }
+
+
+def write_meta(con, items: dict) -> None:
+    """Upsert key/value strings into the store's `meta` table (idempotent)."""
+    con.executemany(
+        "INSERT INTO meta VALUES (?, ?) ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value",
+        [(k, v) for k, v in items.items()],
+    )
+
+
+def read_meta(db_path=DB_PATH) -> dict:
+    """Return {key: value} from a built store's `meta` table. Returns {} for ANY
+    failure — store missing, unreadable, or predating the meta table — so a legacy or
+    corrupt store reads as stale and gets rebuilt rather than trusted."""
+    con = None
+    try:
+        con = connect(db_path, read_only=True)
+        return dict(con.execute("SELECT key, value FROM meta").fetchall())
+    except duckdb.Error:
+        return {}
+    finally:
+        if con is not None:
+            con.close()

--- a/Main/backend/truthlayer/store.py
+++ b/Main/backend/truthlayer/store.py
@@ -49,23 +49,32 @@ CREATE TABLE IF NOT EXISTS entities (
 """
 
 
-def make_fact_id(cik, taxonomy, tag, unit, period_start, period_end, accession) -> str:
-    """sha1 of the documented canonical tuple (spec S2). This is a cross-system
-    JOIN KEY: the benchmark gold_fact_path is a list of these hashes, so the recipe
-    must be reconciled byte-for-byte against the teammate's case generator BEFORE
-    the P4 grader (spec S2/S13 checkpoint — intentionally NOT changed in this unit).
+def make_fact_id(cik, tag, period_start, period_end, unit, accession, dim_hash="") -> str:
+    """sha1 of the canonical fact tuple — the cross-system JOIN KEY (spec S2/S13).
 
-    Two encoding couplings the S13 reconciliation MUST pin (kept as-is here so the
-    teammate's most-likely-identical default join also matches):
-      - Delimiter is a literal '|' with NO escaping; a field containing '|' would
-        bleed into the next (unreachable with SEC data: PascalCase tags, USD/shares
-        units, digit-dash accessions never contain '|').
-      - None serializes via str() to the literal 'None' (only period_start is ever
-        None — instant facts; real dates stringify to ISO, so no instant/duration
-        collision). A reconciler using '' for NULL would produce different hashes.
-    See tests/test_truthlayer_store.py::test_make_fact_id_golden for the pinned recipe.
+    RECONCILED 2026-06-26 against the benchmark generator's gold_fact_path. The
+    recipe was recovered empirically (the generator source is not checked in) by
+    reproducing two real gold hashes from cases_v1_final.json against their SEC
+    companyfacts source fields, and is pinned by
+    tests/test_truthlayer_store.py::test_make_fact_id_matches_benchmark_gold_path.
+
+    Canonical tuple order (== the generator's):
+        (cik, concept, period_start, period_end, unit, accession, dim_hash)
+    where `tag` here IS the generator's `concept` (the raw us-gaap tag, e.g.
+    'Revenues'). Earlier prose was wrong twice — the contributor guide omitted
+    period_start and the cases guide added value; the empirical match is of record.
+
+    Encoding couplings (verified byte-for-byte against the gold hashes):
+      - Delimiter is a literal '|' with NO escaping; unreachable with SEC data
+        (PascalCase tags, USD/shares units, digit-dash accessions never contain '|').
+      - None serializes via str() to the literal 'None' (period_start is None for
+        instant/balance-sheet facts; real dates stringify to ISO).
+      - dim_hash is '' for consolidated companyfacts facts (no segment/member
+        dimensions), producing a trailing '|'. It is a real parameter, not a
+        constant, so the deferred raw-XBRL dimensional ingest path can populate it
+        without changing the recipe (and without re-hashing the consolidated facts).
     """
-    raw = "|".join(str(x) for x in (cik, taxonomy, tag, unit, period_start, period_end, accession))
+    raw = "|".join(str(x) for x in (cik, tag, period_start, period_end, unit, accession, dim_hash))
     return hashlib.sha1(raw.encode("utf-8")).hexdigest()
 
 


### PR DESCRIPTION
## What & why

Reconciles the XBRL truth layer's `fact_id` against the benchmark's `gold_fact_path` so **Track-R facts-reached grading can actually join** retrieved facts to gold. This closes spec checkpoint **S2/S13** end-to-end — both halves of the join key:

1. **The hash** — `make_fact_id`'s serialization reproduces the generator's sha1 byte-for-byte.
2. **The tag selected** — the resolver picks the *same* us-gaap tag the generator stored (a perfect hash of the wrong tag is still a miss).

The benchmark generator source isn't checked in, so both rules were **recovered empirically** by reversing the published `gold_fact_path` hashes against SEC `companyfacts` — the same known-plaintext method, scaled from 2 anchors to **858 facts across all 197 referenced companies**.

## Commit 1 — `fact_id` recipe (S2/S13)

Recovered recipe: `sha1("|".join((cik, concept, period_start, period_end, unit, accession, dim_hash)))`. Deltas vs the prior recipe: dropped `taxonomy`, moved `unit` after the period dates, appended `dim_hash` (real param, default `''` for consolidated companyfacts). Pinned by `test_make_fact_id_matches_benchmark_gold_path` (NVDA `d7a34159…`, Meta `293b6505…`).

## Commit 2 — concept→tag selection

The generator uses a single **conflict-free global tag-priority order** per concept; the apparent per-company divergence is just which tags each company reports.

- **Added 5 benchmark concepts:** `net_income` (`NetIncomeLoss`≻`ProfitLoss`), `operating_income`, `gross_profit`, `research_and_development`, `cash_and_equivalents`.
- **Inserted** `RevenueFromContractWithCustomerIncludingAssessedTax` below `Revenues` (CrowdStrike — the lone gold fact of 230 using it, caught by the full sweep, not the anchors).
- **Added** `BENCHMARK_CONCEPT_ALIAS` + `resolve_benchmark_concept` (the benchmark's own names: `total_assets`→`assets`, `cogs`→`cost_of_revenue`, …).
- **Existing orders unchanged** (revenue, cogs, equity, assets) — verified already correct. The earlier **NVDA "bug" was a false alarm**: NVDA doesn't report the Contract tag for the FY2026 consolidated period, so first-tag-wins correctly falls through to `Revenues` (`_select` filters tag by period presence).

## Verification

- **`_tagrecover/validate_full.py`: registry reproduces the gold tag on `742/742` resolvable single-entity facts — 0 mismatches**, across all 9 single-fact concepts. (Only unmapped keys are derived ratios — Track-C computations, not stored facts.)
- Pinned offline (no network) by `test_truthlayer_benchmark_selection.py` — **11 tests, 5 real gold anchors** (CAT/TXN/LIN/NVDA/CRWD).
- Full backend suite: **374 passed**; the **5 failures are pre-existing and unrelated** (tool-filtering / calculator / openai), confirmed by re-running on stashed-clean code.

## `_tagrecover/` (investigation + conformance harness)

`fetch` → `recover` → `validate_full` reproduces the 742/742 proof; kept for the future P4-grader author. The ~760 MB live-fetch cache is **gitignored** — only the scripts + README are committed.

## ⚠️ Next gate surfaced (not in this PR): accession drift

For ~33 facts (BLK, CEG, CRWV) the *entire* `gold_fact_path` points to accessions live SEC no longer returns — the benchmark's gold came from a **frozen** `companyfacts` snapshot since drifted. Because `fact_id` embeds `accession`, **breadth ingest for the P4 grader must load the benchmark's own frozen `xbrl.duckdb`, not a live SEC re-fetch.** Documented in the deferred-items doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
