### PR TITLE
feat(concierge): Discord chat adapter

### DIFF
--- a/.github/workflows/concierge-tests.yml
+++ b/.github/workflows/concierge-tests.yml
@@ -8,6 +8,10 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    # Least-privilege GITHUB_TOKEN (CodeQL actions/missing-workflow-permissions); matches
+    # the sibling heartbeat-tests.yml. This job only checks out + runs tests — no writes.
+    permissions:
+      contents: read
     defaults:
       run:
         working-directory: Concierge

--- a/.github/workflows/concierge-tests.yml
+++ b/.github/workflows/concierge-tests.yml
@@ -1,0 +1,20 @@
+name: concierge-tests
+on:
+  push:
+    paths: ["Concierge/**", ".github/workflows/concierge-tests.yml"]
+  pull_request:
+    paths: ["Concierge/**", ".github/workflows/concierge-tests.yml"]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: Concierge
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install -r requirements.txt
+      - run: python -m pytest -q

--- a/Concierge/.env.concierge.example
+++ b/Concierge/.env.concierge.example
@@ -1,0 +1,13 @@
+# The SAME Discord application/token as the Heartbeat bot (the Heartbeat opens no
+# Gateway connection, so one identity / two processes coexist). Enable the Gateway
+# + the two NON-privileged intents (GUILD_MESSAGES, DIRECT_MESSAGES) in the Dev Portal.
+DISCORD_BOT_TOKEN=
+
+# Co-located API container; prefer localhost over the public host.
+FINSEARCH_API_BASE=http://localhost:8000
+
+# Optional. Usually unset — the extension endpoints aren't Bearer-gated.
+# FINGPT_API_KEY=
+
+# Optional. Durable identity store (the ATL anchor). Default: data/identity.sqlite
+# CONCIERGE_IDENTITY_DB=data/identity.sqlite

--- a/Concierge/.gitignore
+++ b/Concierge/.gitignore
@@ -1,0 +1,4 @@
+data/
+.venv/
+__pycache__/
+*.pyc

--- a/Concierge/README.md
+++ b/Concierge/README.md
@@ -1,0 +1,41 @@
+# Concierge — Agentic FinSearch Discord chat adapter
+
+Interactive sibling of the News Heartbeat. A persistent `discord.py` Gateway service
+that maps free-form @mention/DM messages onto the **existing** FinSearch extension
+pipeline (`/get_chat_response_stream/`) and posts replies back. Backend is unchanged.
+
+See `Docs/superpowers/specs/2026-06-28-discord-chat-adapter-design.md`.
+
+## Develop & test
+```bash
+cd Concierge
+python3.12 -m venv .venv && ./.venv/bin/pip install -r requirements.txt
+./.venv/bin/python -m pytest -q          # all tests, no network
+```
+
+## Run locally
+```bash
+cp .env.concierge.example .env.concierge   # fill DISCORD_BOT_TOKEN
+set -a && . ./.env.concierge && set +a
+./.venv/bin/python -m concierge
+```
+
+## Live smoke (manual)
+1. Start the FinSearch backend reachable at `FINSEARCH_API_BASE`.
+2. Run the service; in Discord, DM the bot or `@mention` it in a channel: "what is AAPL's PE?"
+3. Expect a `💭 Thinking…` placeholder that streams into the answer, then a Sources embed.
+
+## Deploy (droplet, `deploy` user — manual, mirrors the Heartbeat)
+```bash
+ssh finsearch-deploy 'mkdir -p ~/fingpt/concierge ~/fingpt/envs ~/.config/systemd/user'
+rsync -a --exclude .venv --exclude data Concierge/ finsearch-deploy:/home/deploy/fingpt/concierge/
+ssh finsearch-deploy 'cd ~/fingpt/concierge && python3.12 -m venv .venv && ./.venv/bin/pip install -r requirements.txt'
+scp Concierge/.env.concierge.example finsearch-deploy:/home/deploy/fingpt/envs/.env.concierge   # then fill + chmod 600
+scp Concierge/systemd/concierge.service finsearch-deploy:/home/deploy/.config/systemd/user/
+ssh finsearch-deploy 'chmod 600 ~/fingpt/envs/.env.concierge && systemctl --user daemon-reload && systemctl --user enable --now concierge.service'
+```
+
+## Discord-side config (separate session — out of scope here)
+Same application as the Heartbeat. Enable **Gateway** + the **non-privileged**
+`GUILD_MESSAGES` and `DIRECT_MESSAGES` intents. **Do not** enable the privileged
+Message Content intent — mentions & DMs deliver content without it.

--- a/Concierge/concierge/__main__.py
+++ b/Concierge/concierge/__main__.py
@@ -13,6 +13,20 @@ from .ratelimit import InFlightGuard
 from .router import Router
 
 
+class ConciergeClient(discord.Client):
+    """discord.Client that also closes the FinSearch HTTP session on shutdown. close() is
+    invoked via `async with self` inside client.run()'s runner, so the long-lived aiohttp
+    ClientSession is torn down deterministically on the live loop (incl. SIGTERM)."""
+
+    def __init__(self, *args, finsearch: FinSearchClient, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self._finsearch = finsearch
+
+    async def close(self) -> None:
+        await self._finsearch.aclose()
+        await super().close()
+
+
 def main() -> None:
     logging.basicConfig(level=logging.INFO,
                         format="%(asctime)s %(levelname)s %(name)s: %(message)s")
@@ -30,7 +44,7 @@ def main() -> None:
     # NON-mentioning trigger (prefix command, history scan) would read empty content
     # until that privileged intent is enabled.
     intents.message_content = False
-    client = discord.Client(intents=intents)
+    client = ConciergeClient(intents=intents, finsearch=finsearch)
 
     app = AppContext(cfg, identity, finsearch, DiscordIO(client))
     register_handlers(client, app, router, guard)

--- a/Concierge/concierge/__main__.py
+++ b/Concierge/concierge/__main__.py
@@ -1,0 +1,45 @@
+import logging
+import os
+
+import discord
+
+from .app import AppContext
+from .bot import DiscordIO, register_handlers
+from .config import load_config
+from .finsearch_client import FinSearchClient
+from .handlers import chat_handler
+from .identity import IdentityStore
+from .ratelimit import InFlightGuard
+from .router import Router
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO,
+                        format="%(asctime)s %(levelname)s %(name)s: %(message)s")
+    cfg = load_config(os.environ)
+
+    identity = IdentityStore(cfg.identity_db_path)
+    finsearch = FinSearchClient(cfg.finsearch_api_base, cfg.finsearch_api_key,
+                                cfg.request_timeout_s, cfg.default_model)
+    guard = InFlightGuard(cfg.cooldown_s, cfg.max_queue_per_user)
+    router = Router(chat_handler)
+
+    intents = discord.Intents.default()
+    # Message content is delivered ONLY for DMs + messages that @mention us (Discord
+    # platform exemption) — so we need NO privileged Message Content intent. A future
+    # NON-mentioning trigger (prefix command, history scan) would read empty content
+    # until that privileged intent is enabled.
+    intents.message_content = False
+    client = discord.Client(intents=intents)
+
+    app = AppContext(cfg, identity, finsearch, DiscordIO(client))
+    register_handlers(client, app, router, guard)
+
+    try:
+        client.run(cfg.discord_bot_token, log_handler=None)
+    finally:
+        identity.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/Concierge/concierge/__main__.py
+++ b/Concierge/concierge/__main__.py
@@ -23,8 +23,10 @@ class ConciergeClient(discord.Client):
         self._finsearch = finsearch
 
     async def close(self) -> None:
-        await self._finsearch.aclose()
-        await super().close()
+        try:
+            await self._finsearch.aclose()
+        finally:
+            await super().close()   # always tear down discord's sockets/HTTP
 
 
 def main() -> None:

--- a/Concierge/concierge/app.py
+++ b/Concierge/concierge/app.py
@@ -1,0 +1,31 @@
+import asyncio
+import datetime as dt
+
+from .config import Config
+from .identity import IdentityStore
+from .finsearch_client import FinSearchClient
+from .session import make_session_id
+from .throttle import EditThrottle
+
+
+class AppContext:
+    """Everything chat_handler needs, injectable for tests."""
+
+    def __init__(self, cfg: Config, identity: IdentityStore,
+                 finsearch: FinSearchClient, discord_io) -> None:
+        self.cfg = cfg
+        self.identity = identity
+        self.finsearch = finsearch
+        self.discord = discord_io
+
+    def make_session(self, user_id: str, location_id: str) -> str:
+        return make_session_id(user_id, location_id)
+
+    def new_throttle(self) -> EditThrottle:
+        return EditThrottle(self.cfg.edit_interval_s, self.cfg.edit_min_chars)
+
+    def clock(self) -> float:
+        return asyncio.get_event_loop().time()
+
+    def now_iso(self) -> str:
+        return dt.datetime.now(dt.timezone.utc).isoformat()

--- a/Concierge/concierge/bot.py
+++ b/Concierge/concierge/bot.py
@@ -1,0 +1,101 @@
+import contextlib
+import logging
+
+import discord
+
+from .ratelimit import QueueFullError
+from .router import InboundMessage, Router
+
+log = logging.getLogger("concierge")
+
+
+def should_handle(*, author_is_bot: bool, is_dm: bool, mentioned: bool) -> bool:
+    if author_is_bot:
+        return False
+    return is_dm or mentioned
+
+
+def _strip_mention(content: str, bot_id: int) -> str:
+    for token in (f"<@{bot_id}>", f"<@!{bot_id}>"):
+        content = content.replace(token, "")
+    return content
+
+
+class DiscordIO:
+    """Transport-thin wrapper so handlers never import discord.py types."""
+
+    def __init__(self, client: discord.Client) -> None:
+        self._client = client
+        self._channels: dict = {}   # location_id -> live channel (avoids per-reply re-resolve)
+
+    def remember_channel(self, channel) -> None:
+        self._channels[str(channel.id)] = channel
+
+    async def _channel(self, msg: InboundMessage):
+        ch = self._channels.get(msg.location_id)
+        if ch is not None:
+            return ch
+        cid = int(msg.location_id)
+        ch = self._client.get_channel(cid) or await self._client.fetch_channel(cid)
+        self._channels[msg.location_id] = ch
+        return ch
+
+    def typing(self, msg: InboundMessage):
+        # "Bot is typing…" for the stream duration; reuse the remembered live channel.
+        ch = self._channels.get(msg.location_id)
+        return ch.typing() if ch is not None else contextlib.nullcontext()
+
+    async def send(self, msg: InboundMessage, content: str):
+        ch = await self._channel(msg)
+        return await ch.send(content, allowed_mentions=discord.AllowedMentions.none())
+
+    async def edit(self, message, content: str):
+        return await message.edit(content=content,
+                                  allowed_mentions=discord.AllowedMentions.none())
+
+    async def send_followup(self, msg: InboundMessage, content: str):
+        return await self.send(msg, content)
+
+    async def send_embed(self, msg: InboundMessage, embed_dict: dict):
+        ch = await self._channel(msg)
+        return await ch.send(embed=discord.Embed.from_dict(embed_dict),
+                             allowed_mentions=discord.AllowedMentions.none())
+
+
+def register_handlers(client: discord.Client, app, router: Router, guard) -> None:
+    @client.event
+    async def on_message(message: discord.Message):
+        me = client.user
+        if me is None:                       # not logged in yet — ignore
+            return
+        is_dm = message.guild is None
+        mentioned = me in message.mentions
+        if not should_handle(author_is_bot=message.author.bot, is_dm=is_dm, mentioned=mentioned):
+            return
+        text = _strip_mention(message.content, me.id).strip()
+        if not text:
+            await message.channel.send("Ask me something \U0001f642",
+                                       allowed_mentions=discord.AllowedMentions.none())
+            return
+        app.discord.remember_channel(message.channel)   # reuse the live channel (no REST re-resolve)
+        inbound = InboundMessage(user_id=str(message.author.id),
+                                 location_id=str(message.channel.id),
+                                 text=text, is_dm=is_dm)
+        handler = router.route(inbound)
+        try:
+            await guard.run(inbound.user_id, lambda: handler(inbound, app))
+        except QueueFullError:
+            await message.channel.send("⏳ I'm still working on your previous messages — one moment.",
+                                       allowed_mentions=discord.AllowedMentions.none())
+        except discord.Forbidden:            # spec §6: missing channel perms -> react ❌
+            try:
+                await message.add_reaction("❌")
+            except discord.HTTPException:
+                log.warning("no perms to react or reply for user %s", inbound.user_id)
+        except Exception:
+            log.exception("handler failed for user %s", inbound.user_id)
+
+    @client.event
+    async def on_interaction(interaction: discord.Interaction):
+        # SEAM: future Confirm/Cancel buttons + slash commands. No-op in v1.
+        log.info("interaction received (ignored in v1): %s", getattr(interaction, "type", "?"))

--- a/Concierge/concierge/bot.py
+++ b/Concierge/concierge/bot.py
@@ -24,12 +24,22 @@ def _strip_mention(content: str, bot_id: int) -> str:
 class DiscordIO:
     """Transport-thin wrapper so handlers never import discord.py types."""
 
+    _MAX_CHANNELS = 1024   # bound the cache; an evicted channel re-resolves via get_channel (O(1))
+
     def __init__(self, client: discord.Client) -> None:
         self._client = client
-        self._channels: dict = {}   # location_id -> live channel (avoids per-reply re-resolve)
+        self._channels: dict = {}   # location_id -> live channel (most-recently-used last)
+
+    def _remember(self, location_id: str, channel) -> None:
+        # Re-insert at the end (LRU) and evict the oldest, so the cache can't grow unbounded over
+        # the service lifetime; the active channel is touched every message, so it never evicts.
+        self._channels.pop(location_id, None)
+        self._channels[location_id] = channel
+        while len(self._channels) > self._MAX_CHANNELS:
+            self._channels.pop(next(iter(self._channels)))
 
     def remember_channel(self, channel) -> None:
-        self._channels[str(channel.id)] = channel
+        self._remember(str(channel.id), channel)
 
     async def _channel(self, msg: InboundMessage):
         ch = self._channels.get(msg.location_id)
@@ -37,7 +47,7 @@ class DiscordIO:
             return ch
         cid = int(msg.location_id)
         ch = self._client.get_channel(cid) or await self._client.fetch_channel(cid)
-        self._channels[msg.location_id] = ch
+        self._remember(msg.location_id, ch)
         return ch
 
     def typing(self, msg: InboundMessage):

--- a/Concierge/concierge/config.py
+++ b/Concierge/concierge/config.py
@@ -1,0 +1,32 @@
+from dataclasses import dataclass
+from typing import Mapping, Optional
+
+
+@dataclass(frozen=True)
+class Config:
+    discord_bot_token: str
+    finsearch_api_base: str
+    finsearch_api_key: Optional[str]
+    identity_db_path: str
+    default_model: str = "gpt-4o-mini"
+    request_timeout_s: float = 1260.0
+    cooldown_s: float = 3.0
+    edit_interval_s: float = 1.2
+    edit_min_chars: int = 1500
+    max_queue_per_user: int = 3
+
+
+class ConfigError(ValueError):
+    pass
+
+
+def load_config(env: Mapping[str, str]) -> Config:
+    token = (env.get("DISCORD_BOT_TOKEN") or "").strip()
+    if not token:
+        raise ConfigError("missing required env var: DISCORD_BOT_TOKEN")
+    return Config(
+        discord_bot_token=token,
+        finsearch_api_base=(env.get("FINSEARCH_API_BASE") or "http://localhost:8000").rstrip("/"),
+        finsearch_api_key=((env.get("FINGPT_API_KEY") or "").strip() or None),
+        identity_db_path=(env.get("CONCIERGE_IDENTITY_DB") or "data/identity.sqlite"),
+    )

--- a/Concierge/concierge/finsearch_client.py
+++ b/Concierge/concierge/finsearch_client.py
@@ -17,6 +17,7 @@ class ChatResult:
     used_sources: list
     used_urls: list
     truncated: bool
+    error: Optional[str] = None   # backend in-band failure ({"error": ..., "done": true})
 
 
 def iter_sse_data(lines: Iterable[str]) -> Iterator[dict]:
@@ -45,11 +46,16 @@ def reduce_events(events: Iterable[dict]):
         c = ev.get("content")
         if c:
             acc.append(c)
+    error = final.get("error")
     text = "".join(acc) or (final.get("wrapped_content") or "")
+    # An in-band error frame arrives WITH done:true over an already-200 stream, so
+    # raise_for_status can't see it. Surface `error`, and force truncated so a partial
+    # answer is never rendered as authoritative even if a consumer ignores `error`.
     return acc, ChatResult(text=text,
                            used_sources=final.get("used_sources") or [],
                            used_urls=final.get("used_urls") or [],
-                           truncated=not done)
+                           truncated=(not done) or bool(error),
+                           error=(str(error) if error else None))
 
 
 class FinSearchClient:
@@ -96,11 +102,13 @@ class FinSearchClient:
                         yield ChatChunk(c)
                 if done:
                     break
+        error = final.get("error")
         text = "".join(acc) or (final.get("wrapped_content") or "")
         yield ChatResult(text=text,
                          used_sources=final.get("used_sources") or [],
                          used_urls=final.get("used_urls") or [],
-                         truncated=not done)
+                         truncated=(not done) or bool(error),
+                         error=(str(error) if error else None))
 
     async def aclose(self) -> None:
         if self._session and not self._session.closed:

--- a/Concierge/concierge/finsearch_client.py
+++ b/Concierge/concierge/finsearch_client.py
@@ -1,0 +1,107 @@
+import json
+from dataclasses import dataclass
+from typing import AsyncIterator, Iterable, Iterator, Optional, Union
+from urllib.parse import urlencode
+
+import aiohttp
+
+
+@dataclass(frozen=True)
+class ChatChunk:
+    content: str
+
+
+@dataclass(frozen=True)
+class ChatResult:
+    text: str
+    used_sources: list
+    used_urls: list
+    truncated: bool
+
+
+def iter_sse_data(lines: Iterable[str]) -> Iterator[dict]:
+    for line in lines:
+        line = line.rstrip("\n")
+        if not line.startswith("data:"):
+            continue
+        payload = line[len("data:"):].strip()
+        if not payload or payload == "[DONE]":
+            continue
+        try:
+            obj = json.loads(payload)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(obj, dict):
+            yield obj
+
+
+def reduce_events(events: Iterable[dict]):
+    """Pure reducer -> (content chunks, ChatResult). Mirrors stream_chat's accumulation."""
+    acc, done, final = [], False, {}
+    for ev in events:
+        if ev.get("done") is True:
+            done, final = True, ev
+            break
+        c = ev.get("content")
+        if c:
+            acc.append(c)
+    text = "".join(acc) or (final.get("wrapped_content") or "")
+    return acc, ChatResult(text=text,
+                           used_sources=final.get("used_sources") or [],
+                           used_urls=final.get("used_urls") or [],
+                           truncated=not done)
+
+
+class FinSearchClient:
+    def __init__(self, base_url: str, api_key: Optional[str],
+                 timeout_s: float, default_model: str) -> None:
+        self._base = base_url.rstrip("/")
+        self._api_key = api_key
+        self._timeout = aiohttp.ClientTimeout(total=timeout_s)
+        self._model = default_model
+        self._session: Optional[aiohttp.ClientSession] = None
+
+    async def _ensure_session(self) -> aiohttp.ClientSession:
+        if self._session is None or self._session.closed:
+            headers = {"Authorization": f"Bearer {self._api_key}"} if self._api_key else {}
+            self._session = aiohttp.ClientSession(timeout=self._timeout, headers=headers)
+        return self._session
+
+    async def stream_chat(self, *, question: str, session_id: str,
+                          user_timezone: str, user_time: str
+                          ) -> AsyncIterator[Union[ChatChunk, ChatResult]]:
+        params = {
+            "question": question, "session_id": session_id, "models": self._model,
+            "is_advanced": "false", "use_memory": "true",
+            "current_url": "https://discord.com",
+            "user_timezone": user_timezone, "user_time": user_time,
+        }
+        url = f"{self._base}/get_chat_response_stream/?{urlencode(params)}"
+        session = await self._ensure_session()
+        acc, done, final = [], False, {}
+        async with session.get(url) as resp:
+            resp.raise_for_status()
+            # INVARIANT: resp.content yields ONE line per iteration (aiohttp readline),
+            # so each iter_sse_data() sees a single SSE event and the break-on-done below
+            # cannot strand a sibling content frame. Do NOT switch to iter_chunked()/iter_any()
+            # without restructuring this into a line-buffer reducer.
+            async for raw in resp.content:
+                for ev in iter_sse_data([raw.decode("utf-8", "replace")]):
+                    if ev.get("done") is True:
+                        done, final = True, ev
+                        break
+                    c = ev.get("content")
+                    if c:
+                        acc.append(c)
+                        yield ChatChunk(c)
+                if done:
+                    break
+        text = "".join(acc) or (final.get("wrapped_content") or "")
+        yield ChatResult(text=text,
+                         used_sources=final.get("used_sources") or [],
+                         used_urls=final.get("used_urls") or [],
+                         truncated=not done)
+
+    async def aclose(self) -> None:
+        if self._session and not self._session.closed:
+            await self._session.close()

--- a/Concierge/concierge/finsearch_client.py
+++ b/Concierge/concierge/finsearch_client.py
@@ -49,6 +49,26 @@ def iter_sse_data(lines: Iterable[str]) -> Iterator[dict]:
             yield obj
 
 
+def _finalize(acc: list, done: bool, final: dict) -> ChatResult:
+    """Single source of truth for the terminal ChatResult — shared by the pure reducer and
+    the live streaming path so the text fallback, source lists, and truncated/error policy
+    can never drift between them.
+
+    An in-band error frame arrives WITH done:true over an already-200 stream, so
+    raise_for_status can't see it. We surface `error` and force truncated, so a partial answer
+    is never rendered as authoritative even if a consumer ignores `error`. The text falls back
+    to the final frame's wrapped_content (span markup stripped) only when no chunks streamed.
+    """
+    error = final.get("error")
+    return ChatResult(
+        text="".join(acc) or _unwrap_spans(final.get("wrapped_content") or ""),
+        used_sources=final.get("used_sources") or [],
+        used_urls=final.get("used_urls") or [],
+        truncated=(not done) or bool(error),
+        error=(str(error) if error else None),
+    )
+
+
 def reduce_events(events: Iterable[dict]):
     """Pure reducer -> (content chunks, ChatResult). Mirrors stream_chat's accumulation."""
     acc, done, final = [], False, {}
@@ -59,16 +79,7 @@ def reduce_events(events: Iterable[dict]):
         c = ev.get("content")
         if c:
             acc.append(c)
-    error = final.get("error")
-    text = "".join(acc) or _unwrap_spans(final.get("wrapped_content") or "")
-    # An in-band error frame arrives WITH done:true over an already-200 stream, so
-    # raise_for_status can't see it. Surface `error`, and force truncated so a partial
-    # answer is never rendered as authoritative even if a consumer ignores `error`.
-    return acc, ChatResult(text=text,
-                           used_sources=final.get("used_sources") or [],
-                           used_urls=final.get("used_urls") or [],
-                           truncated=(not done) or bool(error),
-                           error=(str(error) if error else None))
+    return acc, _finalize(acc, done, final)
 
 
 class FinSearchClient:
@@ -126,13 +137,7 @@ class FinSearchClient:
             # handler transport-agnostic and stops it from having to swallow exceptions.
             if not acc:
                 raise
-        error = final.get("error")
-        text = "".join(acc) or _unwrap_spans(final.get("wrapped_content") or "")
-        yield ChatResult(text=text,
-                         used_sources=final.get("used_sources") or [],
-                         used_urls=final.get("used_urls") or [],
-                         truncated=(not done) or bool(error),
-                         error=(str(error) if error else None))
+        yield _finalize(acc, done, final)
 
     async def aclose(self) -> None:
         if self._session and not self._session.closed:

--- a/Concierge/concierge/finsearch_client.py
+++ b/Concierge/concierge/finsearch_client.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 from dataclasses import dataclass
 from typing import AsyncIterator, Iterable, Iterator, Optional, Union
@@ -85,23 +86,32 @@ class FinSearchClient:
         url = f"{self._base}/get_chat_response_stream/?{urlencode(params)}"
         session = await self._ensure_session()
         acc, done, final = [], False, {}
-        async with session.get(url) as resp:
-            resp.raise_for_status()
-            # INVARIANT: resp.content yields ONE line per iteration (aiohttp readline),
-            # so each iter_sse_data() sees a single SSE event and the break-on-done below
-            # cannot strand a sibling content frame. Do NOT switch to iter_chunked()/iter_any()
-            # without restructuring this into a line-buffer reducer.
-            async for raw in resp.content:
-                for ev in iter_sse_data([raw.decode("utf-8", "replace")]):
-                    if ev.get("done") is True:
-                        done, final = True, ev
+        try:
+            async with session.get(url) as resp:
+                resp.raise_for_status()
+                # INVARIANT: resp.content yields ONE line per iteration (aiohttp readline),
+                # so each iter_sse_data() sees a single SSE event and the break-on-done below
+                # cannot strand a sibling content frame. Do NOT switch to iter_chunked()/iter_any()
+                # without restructuring this into a line-buffer reducer.
+                async for raw in resp.content:
+                    for ev in iter_sse_data([raw.decode("utf-8", "replace")]):
+                        if ev.get("done") is True:
+                            done, final = True, ev
+                            break
+                        c = ev.get("content")
+                        if c:
+                            acc.append(c)
+                            yield ChatChunk(c)
+                    if done:
                         break
-                    c = ev.get("content")
-                    if c:
-                        acc.append(c)
-                        yield ChatChunk(c)
-                if done:
-                    break
+        except (aiohttp.ClientError, asyncio.TimeoutError):
+            # Transport-level failure. With NO partial text (backend down / 5xx / pre-stream
+            # drop) re-raise so the caller can show the friendly error. With partial text,
+            # fall through and finalize it as truncated "rather than losing it" (spec §6) —
+            # translating the transport failure into the domain ChatResult here keeps the
+            # handler transport-agnostic and stops it from having to swallow exceptions.
+            if not acc:
+                raise
         error = final.get("error")
         text = "".join(acc) or (final.get("wrapped_content") or "")
         yield ChatResult(text=text,

--- a/Concierge/concierge/finsearch_client.py
+++ b/Concierge/concierge/finsearch_client.py
@@ -1,10 +1,22 @@
 import asyncio
 import json
+import re
 from dataclasses import dataclass
 from typing import AsyncIterator, Iterable, Iterator, Optional, Union
 from urllib.parse import urlencode
 
 import aiohttp
+from aiohttp.http_exceptions import LineTooLong
+
+# The backend's final-frame `wrapped_content` carries claim values wrapped in literal HTML
+# (<span data-claim-id="...">value</span>) meant for the web client. Discord has no HTML, so
+# strip those tags to their inner text before using wrapped_content as a fallback. Only the
+# open/close <span ...> tags are removed; the value text inside is kept.
+_SPAN_TAG_RE = re.compile(r"</?span[^>]*>")
+
+
+def _unwrap_spans(text: str) -> str:
+    return _SPAN_TAG_RE.sub("", text)
 
 
 @dataclass(frozen=True)
@@ -48,7 +60,7 @@ def reduce_events(events: Iterable[dict]):
         if c:
             acc.append(c)
     error = final.get("error")
-    text = "".join(acc) or (final.get("wrapped_content") or "")
+    text = "".join(acc) or _unwrap_spans(final.get("wrapped_content") or "")
     # An in-band error frame arrives WITH done:true over an already-200 stream, so
     # raise_for_status can't see it. Surface `error`, and force truncated so a partial
     # answer is never rendered as authoritative even if a consumer ignores `error`.
@@ -104,16 +116,18 @@ class FinSearchClient:
                             yield ChatChunk(c)
                     if done:
                         break
-        except (aiohttp.ClientError, asyncio.TimeoutError):
-            # Transport-level failure. With NO partial text (backend down / 5xx / pre-stream
-            # drop) re-raise so the caller can show the friendly error. With partial text,
-            # fall through and finalize it as truncated "rather than losing it" (spec §6) —
+        except (aiohttp.ClientError, asyncio.TimeoutError, LineTooLong):
+            # Transport-level failure (dropped connection, timeout, or an oversized SSE line —
+            # LineTooLong is NOT an aiohttp.ClientError, so it must be named explicitly or it
+            # would escape and discard the partial). With NO partial text (backend down / 5xx /
+            # pre-stream drop) re-raise so the caller can show the friendly error. With partial
+            # text, fall through and finalize it as truncated "rather than losing it" (spec §6) —
             # translating the transport failure into the domain ChatResult here keeps the
             # handler transport-agnostic and stops it from having to swallow exceptions.
             if not acc:
                 raise
         error = final.get("error")
-        text = "".join(acc) or (final.get("wrapped_content") or "")
+        text = "".join(acc) or _unwrap_spans(final.get("wrapped_content") or "")
         yield ChatResult(text=text,
                          used_sources=final.get("used_sources") or [],
                          used_urls=final.get("used_urls") or [],

--- a/Concierge/concierge/handlers.py
+++ b/Concierge/concierge/handlers.py
@@ -1,0 +1,47 @@
+from .render import DISCORD_MSG_LIMIT, chunk_message, sources_embed
+from .finsearch_client import ChatChunk, ChatResult
+from .router import InboundMessage
+
+_THINKING = "\U0001f4ad Thinking…"   # 💭 Thinking…
+_ERR = "⚠️ Couldn't reach FinSearch, try again in a moment."
+
+
+def _preview(text: str) -> str:
+    return text[:DISCORD_MSG_LIMIT] if len(text) > DISCORD_MSG_LIMIT else text
+
+
+async def chat_handler(msg: InboundMessage, app) -> None:
+    app.identity.resolve(msg.user_id, now_iso=app.now_iso())
+    session_id = app.make_session(msg.user_id, msg.location_id)
+    placeholder = await app.discord.send(msg, _THINKING)
+    throttle = app.new_throttle()
+    acc, result = "", None
+    try:
+        async with app.discord.typing(msg):          # "Bot is typing…" for the stream duration
+            async for item in app.finsearch.stream_chat(
+                question=msg.text, session_id=session_id,
+                user_timezone="UTC", user_time=app.now_iso(),
+            ):
+                if isinstance(item, ChatChunk):
+                    acc += item.content
+                    now = app.clock()                # read the clock ONCE per chunk
+                    if throttle.should_flush(len(acc), now):
+                        throttle.mark_flushed(len(acc), now)
+                        await app.discord.edit(placeholder, _preview(acc))
+                elif isinstance(item, ChatResult):
+                    result = item
+    except Exception:
+        await app.discord.edit(placeholder, _ERR)
+        raise
+
+    text = (result.text if result else acc) or "*(no response)*"
+    if result and result.truncated:
+        text += "\n\n*(response was cut off)*"
+    parts = chunk_message(text)
+    await app.discord.edit(placeholder, parts[0] if parts else "*(no response)*")
+    for extra in parts[1:]:
+        await app.discord.send_followup(msg, extra)
+    if result:
+        embed = sources_embed(result.used_sources, result.used_urls)
+        if embed:
+            await app.discord.send_embed(msg, embed)

--- a/Concierge/concierge/handlers.py
+++ b/Concierge/concierge/handlers.py
@@ -42,12 +42,10 @@ async def chat_handler(msg: InboundMessage, app) -> None:
                 elif isinstance(item, ChatResult):
                     result = item
     except Exception:
-        # A transport-level drop (connection reset / server restart / read timeout) raises
-        # here. Spec §6 wants already-streamed text kept "rather than losing it"; only fall
-        # back to the generic error when nothing arrived at all.
-        if acc:
-            await _deliver(app, msg, placeholder, acc + _CUTOFF)
-            return
+        # The transport layer already salvages partial output on a mid-stream drop (it yields
+        # a truncated ChatResult), so anything raising here is a hard/unexpected failure
+        # (backend unreachable, a bad edit, a bug). Show the friendly error and RE-RAISE so
+        # on_message records the traceback — never silently mask it as a "cut off".
         await app.discord.edit(placeholder, _ERR)
         raise
 

--- a/Concierge/concierge/handlers.py
+++ b/Concierge/concierge/handlers.py
@@ -4,10 +4,21 @@ from .router import InboundMessage
 
 _THINKING = "\U0001f4ad Thinking…"   # 💭 Thinking…
 _ERR = "⚠️ Couldn't reach FinSearch, try again in a moment."
+_CUTOFF = "\n\n*(response was cut off)*"
+_ERR_NOTE = "\n\n⚠️ *FinSearch hit an error before finishing — this answer may be incomplete.*"
 
 
 def _preview(text: str) -> str:
     return text[:DISCORD_MSG_LIMIT] if len(text) > DISCORD_MSG_LIMIT else text
+
+
+async def _deliver(app, msg, placeholder, text: str) -> None:
+    # Final-edit the placeholder with part 0, post the overflow as followups. Filter empty
+    # pieces — a whitespace-boundary split can produce "" which Discord rejects (400).
+    parts = [p for p in chunk_message(text) if p] or ["*(no response)*"]
+    await app.discord.edit(placeholder, parts[0])
+    for extra in parts[1:]:
+        await app.discord.send_followup(msg, extra)
 
 
 async def chat_handler(msg: InboundMessage, app) -> None:
@@ -31,16 +42,21 @@ async def chat_handler(msg: InboundMessage, app) -> None:
                 elif isinstance(item, ChatResult):
                     result = item
     except Exception:
+        # A transport-level drop (connection reset / server restart / read timeout) raises
+        # here. Spec §6 wants already-streamed text kept "rather than losing it"; only fall
+        # back to the generic error when nothing arrived at all.
+        if acc:
+            await _deliver(app, msg, placeholder, acc + _CUTOFF)
+            return
         await app.discord.edit(placeholder, _ERR)
         raise
 
     text = (result.text if result else acc) or "*(no response)*"
-    if result and result.truncated:
-        text += "\n\n*(response was cut off)*"
-    parts = chunk_message(text)
-    await app.discord.edit(placeholder, parts[0] if parts else "*(no response)*")
-    for extra in parts[1:]:
-        await app.discord.send_followup(msg, extra)
+    if result and result.error:
+        text += _ERR_NOTE          # in-band backend failure ({"error":...,"done":true}) surfaced
+    elif result and result.truncated:
+        text += _CUTOFF
+    await _deliver(app, msg, placeholder, text)
     if result:
         embed = sources_embed(result.used_sources, result.used_urls)
         if embed:

--- a/Concierge/concierge/identity.py
+++ b/Concierge/concierge/identity.py
@@ -1,0 +1,56 @@
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS identity (
+    discord_user_id   TEXT PRIMARY KEY,
+    finsearch_user_id TEXT NOT NULL,
+    created_at        TEXT NOT NULL,
+    atl_account_id    TEXT
+);
+"""
+
+
+@dataclass(frozen=True)
+class Identity:
+    discord_user_id: str
+    finsearch_user_id: str
+    created_at: str
+    atl_account_id: Optional[str]
+
+
+class IdentityStore:
+    def __init__(self, db_path: str) -> None:
+        if db_path != ":memory:":
+            Path(db_path).parent.mkdir(parents=True, exist_ok=True)
+        self._conn = sqlite3.connect(db_path)
+        self._conn.row_factory = sqlite3.Row
+        self._conn.executescript(_SCHEMA)
+        self._conn.commit()
+
+    def get(self, discord_user_id: str) -> Optional[Identity]:
+        row = self._conn.execute(
+            "SELECT * FROM identity WHERE discord_user_id = ?", (discord_user_id,)
+        ).fetchone()
+        if row is None:
+            return None
+        return Identity(row["discord_user_id"], row["finsearch_user_id"],
+                        row["created_at"], row["atl_account_id"])
+
+    def resolve(self, discord_user_id: str, *, now_iso: str) -> Identity:
+        existing = self.get(discord_user_id)
+        if existing is not None:
+            return existing
+        finsearch_user_id = f"discord_{discord_user_id}"
+        self._conn.execute(
+            "INSERT INTO identity (discord_user_id, finsearch_user_id, created_at, atl_account_id) "
+            "VALUES (?, ?, ?, NULL)",
+            (discord_user_id, finsearch_user_id, now_iso),
+        )
+        self._conn.commit()
+        return Identity(discord_user_id, finsearch_user_id, now_iso, None)
+
+    def close(self) -> None:
+        self._conn.close()

--- a/Concierge/concierge/ratelimit.py
+++ b/Concierge/concierge/ratelimit.py
@@ -43,3 +43,12 @@ class InFlightGuard:
                     st.last_done_s = asyncio.get_event_loop().time()
         finally:
             st.waiting -= 1
+            # Evict provably-idle state so _users stays bounded by *active* users, not
+            # every user who ever messaged the bot. No await here -> atomic w.r.t. other
+            # run() coroutines on the single event loop; the identity guard avoids
+            # clobbering a state another waiter just recreated. A later request simply
+            # recreates a (correctly cold-cooldown) state.
+            if (st.waiting == 0
+                    and asyncio.get_running_loop().time() - st.last_done_s >= self._cooldown_s
+                    and self._users.get(user_id) is st):
+                del self._users[user_id]

--- a/Concierge/concierge/ratelimit.py
+++ b/Concierge/concierge/ratelimit.py
@@ -26,29 +26,33 @@ class InFlightGuard:
             self._users[user_id] = st
         return st
 
+    def _evict_expired(self, now: float) -> None:
+        # Drop provably-idle users whose cooldown window has FULLY elapsed, so _users stays
+        # bounded by *recently active* users instead of everyone who ever messaged the bot.
+        # Eviction can't happen in the just-finished request's finally (no time has passed
+        # since last_done_s, so the cooldown never reads as elapsed) — it must run on later
+        # activity. No await here -> atomic w.r.t. other run() coroutines on the single loop.
+        # An entry still inside its cooldown is kept, so a quick re-request is still throttled;
+        # once cooldown has elapsed there is nothing left to preserve.
+        for uid in [u for u, st in self._users.items()
+                    if st.waiting == 0 and now - st.last_done_s >= self._cooldown_s]:
+            del self._users[uid]
+
     async def run(self, user_id: str, coro_factory):
+        loop = asyncio.get_running_loop()
+        self._evict_expired(loop.time())
         st = self._state(user_id)
         if st.waiting >= self._max_queue:
             raise QueueFullError(user_id)
         st.waiting += 1
         try:
             async with st.lock:
-                now = asyncio.get_event_loop().time()
-                wait = self._cooldown_s - (now - st.last_done_s)
+                wait = self._cooldown_s - (loop.time() - st.last_done_s)
                 if wait > 0:
                     await asyncio.sleep(wait)
                 try:
                     return await coro_factory()
                 finally:
-                    st.last_done_s = asyncio.get_event_loop().time()
+                    st.last_done_s = loop.time()
         finally:
             st.waiting -= 1
-            # Evict provably-idle state so _users stays bounded by *active* users, not
-            # every user who ever messaged the bot. No await here -> atomic w.r.t. other
-            # run() coroutines on the single event loop; the identity guard avoids
-            # clobbering a state another waiter just recreated. A later request simply
-            # recreates a (correctly cold-cooldown) state.
-            if (st.waiting == 0
-                    and asyncio.get_running_loop().time() - st.last_done_s >= self._cooldown_s
-                    and self._users.get(user_id) is st):
-                del self._users[user_id]

--- a/Concierge/concierge/ratelimit.py
+++ b/Concierge/concierge/ratelimit.py
@@ -1,0 +1,45 @@
+import asyncio
+from dataclasses import dataclass, field
+
+
+class QueueFullError(Exception):
+    pass
+
+
+@dataclass
+class _UserState:
+    lock: "asyncio.Lock" = field(default_factory=asyncio.Lock)
+    waiting: int = 0
+    last_done_s: float = 0.0
+
+
+class InFlightGuard:
+    def __init__(self, cooldown_s: float, max_queue_per_user: int):
+        self._cooldown_s = cooldown_s
+        self._max_queue = max_queue_per_user
+        self._users: dict = {}
+
+    def _state(self, user_id):
+        st = self._users.get(user_id)
+        if st is None:
+            st = _UserState()
+            self._users[user_id] = st
+        return st
+
+    async def run(self, user_id: str, coro_factory):
+        st = self._state(user_id)
+        if st.waiting >= self._max_queue:
+            raise QueueFullError(user_id)
+        st.waiting += 1
+        try:
+            async with st.lock:
+                now = asyncio.get_event_loop().time()
+                wait = self._cooldown_s - (now - st.last_done_s)
+                if wait > 0:
+                    await asyncio.sleep(wait)
+                try:
+                    return await coro_factory()
+                finally:
+                    st.last_done_s = asyncio.get_event_loop().time()
+        finally:
+            st.waiting -= 1

--- a/Concierge/concierge/render.py
+++ b/Concierge/concierge/render.py
@@ -20,7 +20,9 @@ def chunk_message(text: str, limit: int = DISCORD_MSG_LIMIT) -> list:
             cut = window.rfind(" ")
         if cut <= 0:
             cut = limit            # no boundary: hard split
-        chunks.append(remaining[:cut].rstrip())
+        piece = remaining[:cut].rstrip()
+        if piece:                  # a boundary inside a whitespace run can strip to "";
+            chunks.append(piece)   # Discord rejects empty content, so never emit it
         remaining = remaining[cut:].lstrip()
     if remaining:
         chunks.append(remaining)

--- a/Concierge/concierge/render.py
+++ b/Concierge/concierge/render.py
@@ -1,0 +1,45 @@
+from typing import Optional
+
+DISCORD_MSG_LIMIT = 2000
+EMBED_DESC_LIMIT = 4096
+_MD_SPECIALS = set("\\`*_~|>")
+
+
+def escape_markdown(text: str) -> str:
+    return "".join("\\" + ch if ch in _MD_SPECIALS else ch for ch in text)
+
+
+def chunk_message(text: str, limit: int = DISCORD_MSG_LIMIT) -> list:
+    if not text:
+        return []
+    chunks, remaining = [], text
+    while len(remaining) > limit:
+        window = remaining[:limit]
+        cut = window.rfind("\n")
+        if cut <= 0:
+            cut = window.rfind(" ")
+        if cut <= 0:
+            cut = limit            # no boundary: hard split
+        chunks.append(remaining[:cut].rstrip())
+        remaining = remaining[cut:].lstrip()
+    if remaining:
+        chunks.append(remaining)
+    return chunks
+
+
+def sources_embed(used_sources: list, used_urls: list) -> Optional[dict]:
+    lines, seen = [], set()
+    for src in used_sources or []:
+        url = (src.get("url") or "").strip()
+        title = (src.get("title") or url or "source").strip()
+        if url and url not in seen:
+            seen.add(url)
+            lines.append(f"• [{escape_markdown(title)}]({url})")
+    for url in used_urls or []:
+        url = (url or "").strip()
+        if url and url not in seen:
+            seen.add(url)
+            lines.append(f"• {url}")
+    if not lines:
+        return None
+    return {"title": "Sources", "description": "\n".join(lines)[:EMBED_DESC_LIMIT], "color": 0x2E86C1}

--- a/Concierge/concierge/render.py
+++ b/Concierge/concierge/render.py
@@ -9,23 +9,39 @@ def escape_markdown(text: str) -> str:
     return "".join("\\" + ch if ch in _MD_SPECIALS else ch for ch in text)
 
 
+_FENCE = "```"
+
+
 def chunk_message(text: str, limit: int = DISCORD_MSG_LIMIT) -> list:
     if not text:
         return []
     chunks, remaining = [], text
-    while len(remaining) > limit:
-        window = remaining[:limit]
+    open_fence = False             # is the ORIGINAL text inside an unclosed ``` fence here?
+    while True:
+        prefix = _FENCE + "\n" if open_fence else ""   # reopen a fence carried over from the prior piece
+        # Reserve room for both the (possible) reopen prefix and a (possible) closing fence so
+        # the emitted piece — markers included — never exceeds the limit.
+        budget = limit - len(prefix) - (len(_FENCE) + 1)
+        if len(prefix) + len(remaining) <= limit:      # everything left fits in one final piece
+            piece = prefix + remaining
+            if piece.strip():
+                chunks.append(piece)
+            break
+        window = remaining[:budget]
         cut = window.rfind("\n")
         if cut <= 0:
             cut = window.rfind(" ")
         if cut <= 0:
-            cut = limit            # no boundary: hard split
-        piece = remaining[:cut].rstrip()
-        if piece:                  # a boundary inside a whitespace run can strip to "";
-            chunks.append(piece)   # Discord rejects empty content, so never emit it
+            cut = budget           # no boundary: hard split
+        body = remaining[:cut].rstrip()
+        close_here = open_fence ^ (body.count(_FENCE) % 2 == 1)   # fence state AFTER this body
+        if body:                   # a boundary inside a whitespace run can strip to "";
+            piece = prefix + body  # Discord rejects empty content, so never emit it
+            if close_here:         # ended mid-fence with more to come -> close it so Discord renders cleanly
+                piece += "\n" + _FENCE
+            chunks.append(piece)
+            open_fence = close_here
         remaining = remaining[cut:].lstrip()
-    if remaining:
-        chunks.append(remaining)
     return chunks
 
 
@@ -44,4 +60,21 @@ def sources_embed(used_sources: list, used_urls: list) -> Optional[dict]:
             lines.append(f"• {url}")
     if not lines:
         return None
-    return {"title": "Sources", "description": "\n".join(lines)[:EMBED_DESC_LIMIT], "color": 0x2E86C1}
+    # Append whole bullet lines until the next would overflow, so a Markdown link is never
+    # sliced mid-token by a blind [:limit] cut; surface a count of any sources we dropped.
+    kept, used = [], 0
+    for ln in lines:
+        extra = len(ln) + (1 if kept else 0)         # +1 for the joining newline
+        if used + extra > EMBED_DESC_LIMIT:
+            break
+        kept.append(ln)
+        used += extra
+    if not kept:                                     # pathological single oversized line
+        kept, used = [lines[0][:EMBED_DESC_LIMIT]], EMBED_DESC_LIMIT
+    description = "\n".join(kept)
+    dropped = len(lines) - len(kept)
+    if dropped:
+        marker = f"\n…(+{dropped} more)"
+        if used + len(marker) <= EMBED_DESC_LIMIT:
+            description += marker
+    return {"title": "Sources", "description": description, "color": 0x2E86C1}

--- a/Concierge/concierge/router.py
+++ b/Concierge/concierge/router.py
@@ -1,0 +1,28 @@
+from dataclasses import dataclass
+from typing import Awaitable, Callable
+
+
+@dataclass(frozen=True)
+class InboundMessage:
+    user_id: str
+    location_id: str
+    text: str
+    is_dm: bool
+
+
+Handler = Callable[["InboundMessage", object], Awaitable[None]]
+
+
+class Router:
+    def __init__(self, chat_handler: Handler) -> None:
+        self._chat_handler = chat_handler
+        self._commands: dict = {}
+
+    def register_command(self, name: str, handler: Handler) -> None:
+        self._commands[name] = handler
+
+    def route(self, msg: InboundMessage) -> Handler:
+        token = msg.text.split(maxsplit=1)[0] if msg.text else ""
+        if token.startswith("/") and token in self._commands:
+            return self._commands[token]
+        return self._chat_handler

--- a/Concierge/concierge/session.py
+++ b/Concierge/concierge/session.py
@@ -1,0 +1,24 @@
+from dataclasses import dataclass
+
+_PREFIX = "discord"
+
+
+def make_session_id(discord_user_id: str, location_id: str) -> str:
+    if not discord_user_id or not location_id:
+        raise ValueError("discord_user_id and location_id are required")
+    if ":" in discord_user_id or ":" in location_id:
+        raise ValueError("ids must not contain ':'")
+    return f"{_PREFIX}:{discord_user_id}:{location_id}"
+
+
+@dataclass(frozen=True)
+class SessionRef:
+    discord_user_id: str
+    location_id: str
+
+
+def parse_session_id(session_id: str) -> SessionRef:
+    parts = session_id.split(":")
+    if len(parts) != 3 or parts[0] != _PREFIX or not parts[1] or not parts[2]:
+        raise ValueError(f"malformed session_id: {session_id!r}")
+    return SessionRef(discord_user_id=parts[1], location_id=parts[2])

--- a/Concierge/concierge/throttle.py
+++ b/Concierge/concierge/throttle.py
@@ -1,0 +1,22 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class EditThrottle:
+    interval_s: float
+    min_chars: int
+    _last_flush_s: float = float("-inf")   # first content always clears the interval gate
+    _last_len: int = 0
+
+    def should_flush(self, accumulated_len: int, now_s: float) -> bool:
+        if accumulated_len == 0:
+            return False
+        if now_s - self._last_flush_s >= self.interval_s:
+            return True
+        if accumulated_len - self._last_len >= self.min_chars:
+            return True
+        return False
+
+    def mark_flushed(self, accumulated_len: int, now_s: float) -> None:
+        self._last_flush_s = now_s
+        self._last_len = accumulated_len

--- a/Concierge/pytest.ini
+++ b/Concierge/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+pythonpath = .
+asyncio_mode = auto
+testpaths = tests

--- a/Concierge/requirements.txt
+++ b/Concierge/requirements.txt
@@ -1,4 +1,6 @@
 discord.py>=2.4,<3
+aiohttp>=3.9,<4               # direct dep: finsearch_client uses aiohttp.ClientSession itself,
+                             # not only transitively via discord.py — declare it explicitly
 # dev/test
 pytest>=8
-pytest-asyncio>=0.23,<0.24   # strict mode + explicit @pytest.mark.asyncio (what the tests assume)
+pytest-asyncio>=0.23,<0.24   # auto mode (see pytest.ini); tests also carry explicit @pytest.mark.asyncio

--- a/Concierge/requirements.txt
+++ b/Concierge/requirements.txt
@@ -1,0 +1,4 @@
+discord.py>=2.4,<3
+# dev/test
+pytest>=8
+pytest-asyncio>=0.23,<0.24   # strict mode + explicit @pytest.mark.asyncio (what the tests assume)

--- a/Concierge/systemd/concierge.service
+++ b/Concierge/systemd/concierge.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Agentic FinSearch - Discord conversational chat adapter (Concierge)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=/home/deploy/fingpt/concierge
+EnvironmentFile=/home/deploy/fingpt/envs/.env.concierge
+ExecStart=/home/deploy/fingpt/concierge/.venv/bin/python -m concierge
+Restart=on-failure
+RestartSec=5
+MemoryHigh=256M
+MemoryMax=384M
+
+[Install]
+WantedBy=default.target

--- a/Concierge/systemd/concierge.service
+++ b/Concierge/systemd/concierge.service
@@ -1,7 +1,8 @@
 [Unit]
 Description=Agentic FinSearch - Discord conversational chat adapter (Concierge)
-After=network-online.target
-Wants=network-online.target
+# NOTE: deployed via `systemctl --user` (see README); network-online.target does not exist
+# in the systemd *user* manager, so it is intentionally omitted. discord.py reconnects with
+# backoff if the network is not yet up, and Restart=on-failure covers an initial login crash.
 
 [Service]
 Type=simple
@@ -12,6 +13,11 @@ Restart=on-failure
 RestartSec=5
 MemoryHigh=256M
 MemoryMax=384M
+# Hardening (matches Heartbeat/systemd/finsearch-heartbeat.service): this process holds a
+# long-lived Discord bot token and writes a persistent SQLite identity store. User= is omitted
+# deliberately — a --user unit already runs as the invoking (unprivileged) user.
+NoNewPrivileges=true
+PrivateTmp=true
 
 [Install]
 WantedBy=default.target

--- a/Concierge/tests/fixtures/sse_chat_stream.txt
+++ b/Concierge/tests/fixtures/sse_chat_stream.txt
@@ -1,0 +1,10 @@
+event: connected
+data: {"status": "connected"}
+
+data: {"status": {"label": "Preparing context"}}
+
+data: {"content": "AAPL ", "done": false}
+
+data: {"content": "is Apple.", "done": false}
+
+data: {"content": "", "done": true, "wrapped_content": "AAPL is Apple.", "used_sources": [{"url": "http://x", "title": "X"}], "used_urls": ["http://y"]}

--- a/Concierge/tests/test_bot.py
+++ b/Concierge/tests/test_bot.py
@@ -1,0 +1,14 @@
+from concierge.bot import should_handle, _strip_mention
+
+
+def test_should_handle_rules():
+    assert should_handle(author_is_bot=False, is_dm=True, mentioned=False) is True
+    assert should_handle(author_is_bot=False, is_dm=False, mentioned=True) is True
+    assert should_handle(author_is_bot=False, is_dm=False, mentioned=False) is False
+    assert should_handle(author_is_bot=True, is_dm=True, mentioned=True) is False
+
+
+def test_strip_mention():
+    assert _strip_mention("<@42> hello", 42).strip() == "hello"
+    assert _strip_mention("<@!42> hi", 42).strip() == "hi"
+    assert _strip_mention("no mention", 42) == "no mention"

--- a/Concierge/tests/test_bot.py
+++ b/Concierge/tests/test_bot.py
@@ -1,4 +1,9 @@
-from concierge.bot import should_handle, _strip_mention
+import contextlib
+import pytest
+import discord
+from concierge.bot import should_handle, _strip_mention, register_handlers
+from concierge.router import Router
+from concierge.ratelimit import QueueFullError
 
 
 def test_should_handle_rules():
@@ -12,3 +17,135 @@ def test_strip_mention():
     assert _strip_mention("<@42> hello", 42).strip() == "hello"
     assert _strip_mention("<@!42> hi", 42).strip() == "hi"
     assert _strip_mention("no mention", 42) == "no mention"
+
+
+# --- on_message dispatch coverage (the closure register_handlers wires) ------------------
+
+class _StubClient:
+    """Captures the @client.event coroutines so the on_message closure can be driven directly."""
+    def __init__(self, user): self.user = user; self.events = {}
+    def event(self, coro): self.events[coro.__name__] = coro; return coro
+
+
+class _User:
+    def __init__(self, uid, bot=False): self.id = uid; self.bot = bot
+
+
+class _Channel:
+    def __init__(self, cid=10): self.id = cid; self.sent = []
+    async def send(self, content, **kw): self.sent.append(content)
+    def typing(self): return contextlib.nullcontext()
+
+
+class _Message:
+    def __init__(self, *, content, author, channel, guild=None, mentions=()):
+        self.content = content; self.author = author; self.channel = channel
+        self.guild = guild; self.mentions = list(mentions); self.reactions = []
+    async def add_reaction(self, emoji): self.reactions.append(emoji)
+
+
+class _AppDiscord:
+    def __init__(self): self.remembered = []
+    def remember_channel(self, ch): self.remembered.append(ch)
+
+
+class _App:
+    def __init__(self): self.discord = _AppDiscord()
+
+
+class _Guard:
+    """run() raises `exc` if given, else awaits the factory (the real dispatch)."""
+    def __init__(self, exc=None): self.exc = exc; self.calls = []
+    async def run(self, user_id, factory):
+        self.calls.append(user_id)
+        if self.exc is not None:
+            raise self.exc
+        return await factory()
+
+
+class _Resp:
+    status = 403
+    reason = "Forbidden"
+
+
+def _on_message(app, router, guard, bot_user):
+    client = _StubClient(bot_user)
+    register_handlers(client, app, router, guard)
+    return client.events["on_message"]
+
+
+async def _noop_chat(inbound, app):
+    return None
+
+
+@pytest.mark.asyncio
+async def test_on_message_empty_text_prompts_and_does_not_dispatch():
+    bot_user = _User(42)
+    app, guard = _App(), _Guard()
+    on_message = _on_message(app, Router(_noop_chat), guard, bot_user)
+    ch = _Channel()
+    msg = _Message(content="<@42>", author=_User(1), channel=ch, guild=object(), mentions=[bot_user])
+    await on_message(msg)
+    assert ch.sent and "Ask me something" in ch.sent[0]
+    assert guard.calls == []
+
+
+@pytest.mark.asyncio
+async def test_on_message_ignores_other_bots():
+    bot_user = _User(42)
+    app, guard = _App(), _Guard()
+    on_message = _on_message(app, Router(_noop_chat), guard, bot_user)
+    ch = _Channel()
+    msg = _Message(content="hi", author=_User(2, bot=True), channel=ch, guild=None, mentions=[])
+    await on_message(msg)
+    assert ch.sent == [] and guard.calls == []
+
+
+@pytest.mark.asyncio
+async def test_on_message_dispatches_and_remembers_channel():
+    bot_user = _User(42); app = _App()
+    seen = []
+    async def chat(inbound, app): seen.append(inbound.text)
+    guard = _Guard()
+    on_message = _on_message(app, Router(chat), guard, bot_user)
+    ch = _Channel(cid=77)
+    msg = _Message(content="<@42> what is AAPL", author=_User(1), channel=ch,
+                   guild=object(), mentions=[bot_user])
+    await on_message(msg)
+    assert app.discord.remembered == [ch]
+    assert guard.calls == ["1"]
+    assert seen == ["what is AAPL"]
+
+
+@pytest.mark.asyncio
+async def test_on_message_queue_full_replies():
+    bot_user = _User(42)
+    app, guard = _App(), _Guard(exc=QueueFullError("1"))
+    on_message = _on_message(app, Router(_noop_chat), guard, bot_user)
+    ch = _Channel()
+    msg = _Message(content="hi", author=_User(1), channel=ch, guild=None, mentions=[])
+    await on_message(msg)
+    assert ch.sent and "still working" in ch.sent[0]
+
+
+@pytest.mark.asyncio
+async def test_on_message_forbidden_reacts_cross():
+    bot_user = _User(42)
+    app, guard = _App(), _Guard(exc=discord.Forbidden(_Resp(), "no perms"))
+    on_message = _on_message(app, Router(_noop_chat), guard, bot_user)
+    ch = _Channel()
+    msg = _Message(content="hi", author=_User(1), channel=ch, guild=None, mentions=[])
+    await on_message(msg)
+    assert msg.reactions == ["❌"]
+
+
+@pytest.mark.asyncio
+async def test_on_message_forbidden_then_failed_reaction_is_swallowed():
+    bot_user = _User(42)
+    app, guard = _App(), _Guard(exc=discord.Forbidden(_Resp(), "no perms"))
+    on_message = _on_message(app, Router(_noop_chat), guard, bot_user)
+    ch = _Channel()
+    msg = _Message(content="hi", author=_User(1), channel=ch, guild=None, mentions=[])
+    async def boom(emoji): raise discord.HTTPException(_Resp(), "cannot react")
+    msg.add_reaction = boom
+    await on_message(msg)   # must NOT raise — nested HTTPException is logged + swallowed

--- a/Concierge/tests/test_bot.py
+++ b/Concierge/tests/test_bot.py
@@ -1,9 +1,10 @@
 import contextlib
 import pytest
 import discord
-from concierge.bot import should_handle, _strip_mention, register_handlers
-from concierge.router import Router
+from concierge.bot import should_handle, _strip_mention, register_handlers, DiscordIO
+from concierge.router import Router, InboundMessage
 from concierge.ratelimit import QueueFullError
+from concierge.render import sources_embed
 
 
 def test_should_handle_rules():
@@ -149,3 +150,85 @@ async def test_on_message_forbidden_then_failed_reaction_is_swallowed():
     async def boom(emoji): raise discord.HTTPException(_Resp(), "cannot react")
     msg.add_reaction = boom
     await on_message(msg)   # must NOT raise — nested HTTPException is logged + swallowed
+
+
+# --- DiscordIO transport wrapper (the 'transport-thin' layer this PR exists to provide) ----
+
+class _IOSent:
+    """A sent message that records its edits (DiscordIO.edit -> message.edit(...))."""
+    def __init__(self): self.edits = []
+    async def edit(self, *, content=None, allowed_mentions=None):
+        self.edits.append({"content": content, "allowed_mentions": allowed_mentions})
+
+
+class _IOChannel:
+    def __init__(self, cid): self.id = cid; self.sent = []
+    async def send(self, content=None, *, embed=None, allowed_mentions=None):
+        self.sent.append({"content": content, "embed": embed, "allowed_mentions": allowed_mentions})
+        return _IOSent()
+
+
+class _IOClient:
+    """get_channel hits an in-memory map; a miss forces the REST fetch_channel fallback."""
+    def __init__(self, get_map=None): self._get = get_map or {}; self.fetched = []
+    def get_channel(self, cid): return self._get.get(cid)
+    async def fetch_channel(self, cid): self.fetched.append(cid); return _IOChannel(cid)
+
+
+def _io_msg(cid): return InboundMessage(user_id="1", location_id=str(cid), text="hi", is_dm=True)
+
+
+def _none(am):  # AllowedMentions has no __eq__; assert the suppression flags directly
+    return (am.everyone, am.users, am.roles)
+
+
+@pytest.mark.asyncio
+async def test_discordio_remembered_channel_skips_resolve():
+    client = _IOClient()                     # get_channel would miss; fetch would record
+    io = DiscordIO(client)
+    ch = _IOChannel(77)
+    io.remember_channel(ch)
+    await io.send(_io_msg(77), "yo")
+    assert ch.sent[0]["content"] == "yo"
+    assert client.fetched == []              # remembered live channel -> no get/fetch round-trip
+
+
+@pytest.mark.asyncio
+async def test_discordio_fetch_fallback_on_miss_then_caches():
+    client = _IOClient(get_map={})           # get_channel miss -> REST fetch_channel
+    io = DiscordIO(client)
+    await io.send(_io_msg(88), "a")
+    assert client.fetched == [88]            # fell back to fetch_channel
+    await io.send(_io_msg(88), "b")
+    assert client.fetched == [88]            # second send reuses the cached channel (no 2nd fetch)
+
+
+@pytest.mark.asyncio
+async def test_discordio_get_channel_hit_avoids_fetch():
+    ch = _IOChannel(99)
+    client = _IOClient(get_map={99: ch})
+    await DiscordIO(client).send(_io_msg(99), "x")
+    assert ch.sent[0]["content"] == "x"
+    assert client.fetched == []              # resolved via get_channel, never fetched
+
+
+@pytest.mark.asyncio
+async def test_discordio_send_and_edit_suppress_all_mentions():
+    ch = _IOChannel(5)
+    io = DiscordIO(_IOClient(get_map={5: ch}))
+    sent = await io.send(_io_msg(5), "hello")
+    assert _none(ch.sent[0]["allowed_mentions"]) == (False, False, False)
+    await io.edit(sent, "edited")
+    assert _none(sent.edits[0]["allowed_mentions"]) == (False, False, False)
+
+
+@pytest.mark.asyncio
+async def test_discordio_send_embed_roundtrips_sources_dict():
+    ch = _IOChannel(6)
+    io = DiscordIO(_IOClient(get_map={6: ch}))
+    embed_dict = sources_embed([{"url": "http://x", "title": "X"}], ["http://y"])
+    await io.send_embed(_io_msg(6), embed_dict)
+    sent_embed = ch.sent[0]["embed"]
+    assert isinstance(sent_embed, discord.Embed)   # Embed.from_dict accepted the dict (no raise)
+    assert sent_embed.title == "Sources"
+    assert _none(ch.sent[0]["allowed_mentions"]) == (False, False, False)

--- a/Concierge/tests/test_config.py
+++ b/Concierge/tests/test_config.py
@@ -1,0 +1,22 @@
+import pytest
+from concierge.config import load_config, Config, ConfigError
+
+
+def test_load_full_env():
+    cfg = load_config({"DISCORD_BOT_TOKEN": "tok",
+                       "FINSEARCH_API_BASE": "http://localhost:8000/"})
+    assert isinstance(cfg, Config)
+    assert cfg.discord_bot_token == "tok"
+    assert cfg.finsearch_api_base == "http://localhost:8000"   # trailing slash stripped
+    assert cfg.finsearch_api_key is None                       # absent -> None
+    assert cfg.default_model == "gpt-4o-mini"
+
+
+def test_missing_token_raises():
+    with pytest.raises(ConfigError):
+        load_config({"FINSEARCH_API_BASE": "http://x"})
+
+
+def test_default_base_when_absent():
+    cfg = load_config({"DISCORD_BOT_TOKEN": "tok"})
+    assert cfg.finsearch_api_base == "http://localhost:8000"

--- a/Concierge/tests/test_finsearch_client.py
+++ b/Concierge/tests/test_finsearch_client.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import aiohttp
 import pytest
 from concierge.finsearch_client import iter_sse_data, reduce_events, ChatResult, FinSearchClient
 
@@ -55,3 +56,73 @@ async def test_aclose_closes_session_and_is_idempotent():
     await client.aclose()      # already closed -> no-op, must not raise
     # never-opened client: aclose is a no-op
     await FinSearchClient("http://x", None, 1.0, "m").aclose()
+
+
+# --- stream_chat against a fake aiohttp session (the real async consumer) ----------------
+
+class _FakeContent:
+    """resp.content: async-iterates the given byte lines, then raises `exc` (or stops)."""
+    def __init__(self, lines, exc=None): self._lines = lines; self._exc = exc
+    def __aiter__(self): self._i = 0; return self
+    async def __anext__(self):
+        if self._i < len(self._lines):
+            v = self._lines[self._i]; self._i += 1; return v
+        if self._exc is not None:
+            raise self._exc
+        raise StopAsyncIteration
+
+
+class _FakeResp:
+    def __init__(self, content): self.content = content
+    def raise_for_status(self): pass
+
+
+class _FakeGetCtx:
+    def __init__(self, resp): self._resp = resp
+    async def __aenter__(self): return self._resp
+    async def __aexit__(self, *a): return False
+
+
+class _FakeSession:
+    def __init__(self, resp): self._resp = resp; self.closed = False
+    def get(self, url): return _FakeGetCtx(self._resp)
+    async def close(self): self.closed = True
+
+
+def _client_with(content):
+    c = FinSearchClient("http://x", None, 1.0, "m")
+    c._session = _FakeSession(_FakeResp(content))
+    return c
+
+
+async def _drain(client):
+    return [item async for item in client.stream_chat(
+        question="q", session_id="discord:1:1", user_timezone="UTC", user_time="t")]
+
+
+@pytest.mark.asyncio
+async def test_stream_chat_transport_drop_finalizes_partial_as_truncated():
+    content = _FakeContent([b'data: {"content": "partial", "done": false}\n'],
+                           exc=aiohttp.ClientPayloadError("reset"))
+    out = await _drain(_client_with(content))
+    assert isinstance(out[-1], ChatResult)
+    assert out[-1].text == "partial"        # kept "rather than losing it"
+    assert out[-1].truncated is True
+    assert out[-1].error is None            # a transport drop is not an in-band error
+
+
+@pytest.mark.asyncio
+async def test_stream_chat_drop_before_any_content_reraises():
+    content = _FakeContent([], exc=aiohttp.ServerDisconnectedError())
+    with pytest.raises(aiohttp.ClientError):
+        await _drain(_client_with(content))
+
+
+@pytest.mark.asyncio
+async def test_stream_chat_in_band_error_frame_surfaced():
+    content = _FakeContent([b'data: {"content": "partial", "done": false}\n',
+                            b'data: {"error": "boom", "done": true}\n'])
+    out = await _drain(_client_with(content))
+    assert out[-1].text == "partial"
+    assert out[-1].error == "boom"
+    assert out[-1].truncated is True

--- a/Concierge/tests/test_finsearch_client.py
+++ b/Concierge/tests/test_finsearch_client.py
@@ -1,5 +1,7 @@
+import json
 from pathlib import Path
 import aiohttp
+from aiohttp.http_exceptions import LineTooLong
 import pytest
 from concierge.finsearch_client import iter_sse_data, reduce_events, ChatResult, FinSearchClient
 
@@ -41,6 +43,17 @@ def test_in_band_error_frame_is_surfaced_not_clean():
     assert result.text == "partial "
     assert result.error == "agent crashed"
     assert result.truncated is True
+
+
+def test_reduce_unwraps_span_markup_in_wrapped_content_fallback():
+    # When no content chunks arrive, the text falls back to the final frame's wrapped_content,
+    # which the backend wraps in literal <span data-claim-id=...> HTML for the web client.
+    # Discord has no HTML, so those tags must be stripped to their inner value text.
+    payload = json.dumps({"wrapped_content": 'Revenue <span data-claim-id="c1">$100M</span> grew',
+                          "done": True})
+    acc, result = reduce_events(iter_sse_data(["data: " + payload]))
+    assert "<span" not in result.text and "</span>" not in result.text
+    assert result.text == "Revenue $100M grew"
 
 
 @pytest.mark.asyncio
@@ -126,3 +139,35 @@ async def test_stream_chat_in_band_error_frame_surfaced():
     assert out[-1].text == "partial"
     assert out[-1].error == "boom"
     assert out[-1].truncated is True
+
+
+@pytest.mark.asyncio
+async def test_stream_chat_oversized_line_finalizes_partial_as_truncated():
+    # An oversized SSE line raises aiohttp LineTooLong, which is NOT an aiohttp.ClientError.
+    # It must be salvaged like any transport drop — keep the partial, finalize as truncated —
+    # not escape and discard a successfully-streamed answer.
+    content = _FakeContent([b'data: {"content": "partial", "done": false}\n'],
+                           exc=LineTooLong("oversized SSE line"))
+    out = await _drain(_client_with(content))
+    assert isinstance(out[-1], ChatResult)
+    assert out[-1].text == "partial"        # kept, not lost
+    assert out[-1].truncated is True
+    assert out[-1].error is None            # an oversized line is a transport issue, not in-band
+
+
+@pytest.mark.asyncio
+async def test_stream_chat_oversized_line_before_content_reraises():
+    content = _FakeContent([], exc=LineTooLong("oversized first line"))
+    with pytest.raises(LineTooLong):
+        await _drain(_client_with(content))
+
+
+@pytest.mark.asyncio
+async def test_stream_chat_unwraps_span_markup_in_fallback():
+    payload = json.dumps({"wrapped_content": 'Net margin <span data-claim-id="c2">12.3%</span>',
+                          "done": True})
+    content = _FakeContent([("data: " + payload + "\n").encode("utf-8")])
+    out = await _drain(_client_with(content))
+    assert isinstance(out[-1], ChatResult)
+    assert "<span" not in out[-1].text
+    assert out[-1].text == "Net margin 12.3%"

--- a/Concierge/tests/test_finsearch_client.py
+++ b/Concierge/tests/test_finsearch_client.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+from concierge.finsearch_client import iter_sse_data, reduce_events, ChatResult
+
+FIX = Path(__file__).parent / "fixtures" / "sse_chat_stream.txt"
+
+
+def test_iter_and_reduce_full_stream():
+    lines = FIX.read_text().splitlines()
+    events = list(iter_sse_data(lines))
+    acc, result = reduce_events(events)
+    assert "".join(acc) == "AAPL is Apple."
+    assert isinstance(result, ChatResult)
+    assert result.text == "AAPL is Apple."
+    assert result.truncated is False
+    assert result.used_urls == ["http://y"]
+    assert result.used_sources[0]["url"] == "http://x"
+
+
+def test_partial_stream_is_truncated():
+    lines = ['data: {"content": "half", "done": false}']   # no done frame
+    acc, result = reduce_events(iter_sse_data(lines))
+    assert result.text == "half"
+    assert result.truncated is True
+
+
+def test_iter_skips_non_data_and_bad_json():
+    lines = ["event: connected", "data: not-json", ": comment", 'data: {"content":"x","done":false}']
+    objs = list(iter_sse_data(lines))
+    assert objs == [{"content": "x", "done": False}]

--- a/Concierge/tests/test_finsearch_client.py
+++ b/Concierge/tests/test_finsearch_client.py
@@ -1,5 +1,6 @@
 from pathlib import Path
-from concierge.finsearch_client import iter_sse_data, reduce_events, ChatResult
+import pytest
+from concierge.finsearch_client import iter_sse_data, reduce_events, ChatResult, FinSearchClient
 
 FIX = Path(__file__).parent / "fixtures" / "sse_chat_stream.txt"
 
@@ -27,3 +28,30 @@ def test_iter_skips_non_data_and_bad_json():
     lines = ["event: connected", "data: not-json", ": comment", 'data: {"content":"x","done":false}']
     objs = list(iter_sse_data(lines))
     assert objs == [{"content": "x", "done": False}]
+
+
+def test_in_band_error_frame_is_surfaced_not_clean():
+    # The backend yields {"error": ..., "done": true} over an already-200 stream (it cannot
+    # be caught by raise_for_status). Partial must be kept, error surfaced, and the result
+    # forced truncated so it is never rendered as a complete answer.
+    lines = ['data: {"content": "partial ", "done": false}',
+             'data: {"error": "agent crashed", "done": true}']
+    acc, result = reduce_events(iter_sse_data(lines))
+    assert result.text == "partial "
+    assert result.error == "agent crashed"
+    assert result.truncated is True
+
+
+@pytest.mark.asyncio
+async def test_aclose_closes_session_and_is_idempotent():
+    client = FinSearchClient("http://x", None, 1.0, "gpt-4o-mini")
+    class _S:
+        def __init__(self): self.closed = False
+        async def close(self): self.closed = True
+    s = _S()
+    client._session = s
+    await client.aclose()
+    assert s.closed is True
+    await client.aclose()      # already closed -> no-op, must not raise
+    # never-opened client: aclose is a no-op
+    await FinSearchClient("http://x", None, 1.0, "m").aclose()

--- a/Concierge/tests/test_handlers.py
+++ b/Concierge/tests/test_handlers.py
@@ -97,6 +97,25 @@ async def test_unexpected_error_is_not_masked_as_cutoff():
     assert "cut off" not in d.edits[-1]
 
 
+class _ThrottledApp(FakeApp):
+    def new_throttle(self): return EditThrottle(1.2, 1500)   # production throttle values
+
+
+@pytest.mark.asyncio
+async def test_streaming_edits_are_throttled_and_capped_at_discord_limit():
+    # Drive the streaming-edit loop with the PRODUCTION throttle (1.2s / 1500 chars) and a
+    # deterministic +1.0s/chunk clock, so realistic batching AND the _preview 2000-char cap
+    # are exercised — the other handler tests all use the always-flush EditThrottle(0.0, 1).
+    d = FakeDiscord()
+    chunks = [ChatChunk("a" * 600) for _ in range(5)]            # 3000 chars streamed
+    f = FakeFinSearch(chunks + [ChatResult("a" * 3000, [], [], False)])
+    await chat_handler(_msg(), _ThrottledApp(d, f))
+    assert all(len(e) <= 2000 for e in d.edits)                 # never exceed Discord's limit
+    assert max(len(e) for e in d.edits) == 2000                 # _preview capped a >2000 acc to 2000
+    assert len(d.edits) - 1 < len(chunks)                       # throttled: <1 streaming edit/chunk
+    assert "".join([d.edits[-1]] + d.followups) == "a" * 3000   # full answer delivered, nothing lost
+
+
 @pytest.mark.asyncio
 async def test_overflow_uses_followups():
     # >2000 chars -> placeholder gets part 0, the rest go out as followups.

--- a/Concierge/tests/test_handlers.py
+++ b/Concierge/tests/test_handlers.py
@@ -1,0 +1,70 @@
+import asyncio
+import contextlib
+import pytest
+from concierge.handlers import chat_handler
+from concierge.router import InboundMessage
+from concierge.finsearch_client import ChatChunk, ChatResult
+from concierge.identity import IdentityStore
+from concierge.session import make_session_id
+from concierge.throttle import EditThrottle
+
+
+class FakeDiscord:
+    def __init__(self): self.sent=[]; self.edits=[]; self.embeds=[]; self.followups=[]
+    async def send(self, msg, content): self.sent.append(content); return {"id": len(self.sent)}
+    async def edit(self, ph, content): self.edits.append(content)
+    async def send_followup(self, msg, content): self.followups.append(content)
+    async def send_embed(self, msg, embed): self.embeds.append(embed)
+    def typing(self, msg): return contextlib.nullcontext()   # async-with no-op (Py3.10+)
+
+
+class FakeFinSearch:
+    def __init__(self, items): self._items=items
+    async def stream_chat(self, **kw):
+        for it in self._items: yield it
+
+
+class FakeApp:
+    def __init__(self, discord, finsearch):
+        self.discord=discord; self.finsearch=finsearch
+        self.identity=IdentityStore(":memory:")
+        self._t=0.0
+    def make_session(self, u, l): return make_session_id(u, l)
+    def new_throttle(self): return EditThrottle(0.0, 1)   # always flush -> exercise edit path
+    def clock(self): self._t+=1.0; return self._t
+    def now_iso(self): return "2026-06-28T00:00:00+00:00"
+
+
+def _msg(): return InboundMessage(user_id="1", location_id="2", text="hi", is_dm=True)
+
+
+@pytest.mark.asyncio
+async def test_happy_path_posts_placeholder_then_final_and_sources():
+    d = FakeDiscord()
+    f = FakeFinSearch([ChatChunk("AAPL "), ChatChunk("is Apple."),
+                       ChatResult("AAPL is Apple.", [{"url":"http://x","title":"X"}], [], False)])
+    app = FakeApp(d, f)
+    await chat_handler(_msg(), app)
+    assert d.sent[0] == "\U0001f4ad Thinking…"      # placeholder posted first
+    assert d.edits[-1] == "AAPL is Apple."                # final edit is the full answer
+    assert len(d.embeds) == 1                              # sources embed sent
+
+
+@pytest.mark.asyncio
+async def test_truncated_marks_cutoff():
+    d = FakeDiscord()
+    f = FakeFinSearch([ChatChunk("half"), ChatResult("half", [], [], True)])
+    await chat_handler(_msg(), FakeApp(d, f))
+    assert "cut off" in d.edits[-1]
+
+
+@pytest.mark.asyncio
+async def test_backend_error_shows_friendly_message():
+    d = FakeDiscord()
+    class Boom:
+        async def stream_chat(self, **kw):
+            if False: yield
+            raise RuntimeError("down")
+    with pytest.raises(RuntimeError):
+        await chat_handler(_msg(), FakeApp(d, Boom()))
+    assert "Couldn't reach FinSearch" in d.edits[-1]

--- a/Concierge/tests/test_handlers.py
+++ b/Concierge/tests/test_handlers.py
@@ -83,17 +83,18 @@ async def test_in_band_error_frame_surfaced_with_partial_preserved():
 
 
 @pytest.mark.asyncio
-async def test_midstream_transport_drop_preserves_partial_no_raise():
-    # A transport drop (connection reset) raises mid-stream AFTER content arrived.
-    # Spec §6: keep the partial "rather than losing it" — and recover gracefully (no raise).
+async def test_unexpected_error_is_not_masked_as_cutoff():
+    # A non-transport error mid-stream (e.g. a bug) must surface the friendly error AND
+    # re-raise (so on_message logs it) — never be silently relabeled a "cut off".
     d = FakeDiscord()
-    class Drop:
+    class Bug:
         async def stream_chat(self, **kw):
-            yield ChatChunk("partial answer")
-            raise ConnectionError("reset")
-    await chat_handler(_msg(), FakeApp(d, Drop()))
-    assert "partial answer" in d.edits[-1]
-    assert "cut off" in d.edits[-1]
+            yield ChatChunk("partial")
+            raise AttributeError("boom")
+    with pytest.raises(AttributeError):
+        await chat_handler(_msg(), FakeApp(d, Bug()))
+    assert "Couldn't reach FinSearch" in d.edits[-1]
+    assert "cut off" not in d.edits[-1]
 
 
 @pytest.mark.asyncio

--- a/Concierge/tests/test_handlers.py
+++ b/Concierge/tests/test_handlers.py
@@ -1,4 +1,3 @@
-import asyncio
 import contextlib
 import pytest
 from concierge.handlers import chat_handler
@@ -7,6 +6,7 @@ from concierge.finsearch_client import ChatChunk, ChatResult
 from concierge.identity import IdentityStore
 from concierge.session import make_session_id
 from concierge.throttle import EditThrottle
+from concierge.render import chunk_message
 
 
 class FakeDiscord:
@@ -68,3 +68,42 @@ async def test_backend_error_shows_friendly_message():
     with pytest.raises(RuntimeError):
         await chat_handler(_msg(), FakeApp(d, Boom()))
     assert "Couldn't reach FinSearch" in d.edits[-1]
+
+
+@pytest.mark.asyncio
+async def test_in_band_error_frame_surfaced_with_partial_preserved():
+    # Backend emits {"error": ..., "done": true} mid-stream: partial kept, error shown,
+    # and it must NOT be presented as a clean/complete answer.
+    d = FakeDiscord()
+    f = FakeFinSearch([ChatChunk("partial "),
+                       ChatResult("partial ", [], [], True, error="agent crashed")])
+    await chat_handler(_msg(), FakeApp(d, f))
+    assert "partial " in d.edits[-1]
+    assert "error before finishing" in d.edits[-1]
+
+
+@pytest.mark.asyncio
+async def test_midstream_transport_drop_preserves_partial_no_raise():
+    # A transport drop (connection reset) raises mid-stream AFTER content arrived.
+    # Spec §6: keep the partial "rather than losing it" — and recover gracefully (no raise).
+    d = FakeDiscord()
+    class Drop:
+        async def stream_chat(self, **kw):
+            yield ChatChunk("partial answer")
+            raise ConnectionError("reset")
+    await chat_handler(_msg(), FakeApp(d, Drop()))
+    assert "partial answer" in d.edits[-1]
+    assert "cut off" in d.edits[-1]
+
+
+@pytest.mark.asyncio
+async def test_overflow_uses_followups():
+    # >2000 chars -> placeholder gets part 0, the rest go out as followups.
+    d = FakeDiscord()
+    big = ("A" * 1500) + "\n" + ("B" * 1500)
+    f = FakeFinSearch([ChatResult(big, [], [], False)])
+    await chat_handler(_msg(), FakeApp(d, f))
+    parts = chunk_message(big)
+    assert len(parts) == 2
+    assert d.edits[-1] == parts[0]
+    assert d.followups == [parts[1]]

--- a/Concierge/tests/test_identity.py
+++ b/Concierge/tests/test_identity.py
@@ -1,0 +1,28 @@
+from concierge.identity import IdentityStore, Identity
+
+
+def test_resolve_creates_with_reserved_atl_none():
+    store = IdentityStore(":memory:")
+    ident = store.resolve("123", now_iso="2026-06-28T00:00:00+00:00")
+    assert ident.discord_user_id == "123"
+    assert ident.finsearch_user_id == "discord_123"      # deterministic
+    assert ident.atl_account_id is None                   # reserved
+    store.close()
+
+
+def test_resolve_is_idempotent():
+    store = IdentityStore(":memory:")
+    a = store.resolve("123", now_iso="2026-06-28T00:00:00+00:00")
+    b = store.resolve("123", now_iso="2099-01-01T00:00:00+00:00")  # later — must not overwrite
+    assert a == b
+    assert b.created_at == "2026-06-28T00:00:00+00:00"
+    store.close()
+
+
+def test_persists_across_reopen(tmp_path):
+    db = str(tmp_path / "id.sqlite")
+    s1 = IdentityStore(db); s1.resolve("123", now_iso="2026-06-28T00:00:00+00:00"); s1.close()
+    s2 = IdentityStore(db)
+    assert s2.get("123") is not None
+    assert s2.get("999") is None
+    s2.close()

--- a/Concierge/tests/test_integration.py
+++ b/Concierge/tests/test_integration.py
@@ -1,0 +1,98 @@
+"""End-to-end wiring: a real Discord message driven through the actual
+register_handlers -> Router(chat_handler) -> InFlightGuard.run -> chat_handler -> DiscordIO
+chain, with only the network edges (the gateway client + the FinSearch stream) faked.
+
+The per-component tests stub the *other* half (test_bot uses a _Guard stub + _noop_chat;
+test_handlers uses a FakeApp with no router/guard). This is the only test that exercises the
+seams between them, so a wiring regression (wrong arg to guard.run, a kwarg rename between the
+handler and the client, a router mis-dispatch) surfaces here.
+"""
+import contextlib
+import discord
+import pytest
+
+from concierge.app import AppContext
+from concierge.bot import DiscordIO, register_handlers
+from concierge.config import Config
+from concierge.finsearch_client import ChatChunk, ChatResult
+from concierge.identity import IdentityStore
+from concierge.handlers import chat_handler
+from concierge.ratelimit import InFlightGuard
+from concierge.router import Router
+
+
+class _Sent:
+    def __init__(self): self.edits = []
+    async def edit(self, *, content=None, allowed_mentions=None): self.edits.append(content)
+
+
+class _Channel:
+    def __init__(self, cid):
+        self.id = cid; self.contents = []; self.embeds = []; self.msgs = []
+    async def send(self, content=None, *, embed=None, allowed_mentions=None):
+        if embed is not None:
+            self.embeds.append(embed)
+        else:
+            self.contents.append(content)
+        m = _Sent(); self.msgs.append(m); return m
+    def typing(self): return contextlib.nullcontext()
+
+
+class _User:
+    def __init__(self, uid, bot=False): self.id = uid; self.bot = bot
+
+
+class _Message:
+    def __init__(self, *, content, author, channel, guild=None, mentions=()):
+        self.content = content; self.author = author; self.channel = channel
+        self.guild = guild; self.mentions = list(mentions)
+    async def add_reaction(self, emoji): pass
+
+
+class _StubClient:
+    """Gateway client for register_handlers: captures the on_message coroutine + exposes .user."""
+    def __init__(self, user): self.user = user; self.events = {}
+    def event(self, coro): self.events[coro.__name__] = coro; return coro
+
+
+class _GatewayClient:
+    """The client DiscordIO resolves channels through — must never be hit, because on_message
+    remembers the live channel before dispatch."""
+    def get_channel(self, cid): return None
+    async def fetch_channel(self, cid): raise AssertionError("should reuse the remembered channel")
+
+
+class _FakeFinSearch:
+    def __init__(self, items): self._items = items
+    async def stream_chat(self, **kw):
+        for it in self._items:
+            yield it
+
+
+@pytest.mark.asyncio
+async def test_message_flows_through_router_guard_handler_to_discord():
+    bot_user = _User(42)
+    cfg = Config(discord_bot_token="x", finsearch_api_base="http://x",
+                 finsearch_api_key=None, identity_db_path=":memory:")
+    identity = IdentityStore(":memory:")
+    finsearch = _FakeFinSearch([
+        ChatChunk("AAPL "), ChatChunk("is Apple."),
+        ChatResult("AAPL is Apple.", [{"url": "http://x", "title": "X"}], [], False),
+    ])
+    app = AppContext(cfg, identity, finsearch, DiscordIO(_GatewayClient()))
+    guard = InFlightGuard(cooldown_s=0.0, max_queue_per_user=3)
+
+    client = _StubClient(bot_user)
+    register_handlers(client, app, Router(chat_handler), guard)
+    on_message = client.events["on_message"]
+
+    ch = _Channel(cid=77)
+    msg = _Message(content="<@42> what is AAPL", author=_User(1), channel=ch,
+                   guild=object(), mentions=[bot_user])
+    await on_message(msg)
+
+    assert "Thinking" in ch.contents[0]                 # placeholder posted via the real DiscordIO
+    assert ch.msgs[0].edits[-1] == "AAPL is Apple."      # streamed answer finalized onto it
+    assert len(ch.embeds) == 1                           # sources embed sent
+    assert isinstance(ch.embeds[0], discord.Embed) and ch.embeds[0].title == "Sources"
+    assert identity.get("1") is not None                 # the real guarded handler ran resolve()

--- a/Concierge/tests/test_ratelimit.py
+++ b/Concierge/tests/test_ratelimit.py
@@ -1,0 +1,44 @@
+import asyncio
+import pytest
+from concierge.ratelimit import InFlightGuard, QueueFullError
+
+
+@pytest.mark.asyncio
+async def test_serializes_same_user():
+    order = []
+    guard = InFlightGuard(cooldown_s=0.0, max_queue_per_user=5)
+    async def job(tag):
+        order.append(("start", tag)); await asyncio.sleep(0.01); order.append(("end", tag))
+    await asyncio.gather(
+        guard.run("u1", lambda: job("a")),
+        guard.run("u1", lambda: job("b")),
+    )
+    # Same user: second job must not start before the first ends (queued).
+    assert order in (
+        [("start","a"),("end","a"),("start","b"),("end","b")],
+        [("start","b"),("end","b"),("start","a"),("end","a")],
+    )
+
+
+@pytest.mark.asyncio
+async def test_depth_cap_rejects():
+    guard = InFlightGuard(cooldown_s=0.0, max_queue_per_user=1)
+    async def slow(): await asyncio.sleep(0.05)
+    running = asyncio.create_task(guard.run("u1", slow))   # holds the slot
+    await asyncio.sleep(0.005)
+    with pytest.raises(QueueFullError):                     # 2nd waiter exceeds cap=1
+        await asyncio.gather(
+            guard.run("u1", slow),
+            guard.run("u1", slow),
+        )
+    await running
+
+
+@pytest.mark.asyncio
+async def test_other_users_not_blocked():
+    guard = InFlightGuard(cooldown_s=0.0, max_queue_per_user=5)
+    started = []
+    async def job(tag): started.append(tag); await asyncio.sleep(0.02)
+    await asyncio.gather(guard.run("u1", lambda: job("a")),
+                         guard.run("u2", lambda: job("b")))
+    assert set(started) == {"a", "b"}

--- a/Concierge/tests/test_ratelimit.py
+++ b/Concierge/tests/test_ratelimit.py
@@ -42,3 +42,13 @@ async def test_other_users_not_blocked():
     await asyncio.gather(guard.run("u1", lambda: job("a")),
                          guard.run("u2", lambda: job("b")))
     assert set(started) == {"a", "b"}
+
+
+@pytest.mark.asyncio
+async def test_idle_user_state_is_evicted():
+    # _users must stay bounded by ACTIVE users, not every user who ever messaged the bot.
+    guard = InFlightGuard(cooldown_s=0.0, max_queue_per_user=5)
+    async def job(): await asyncio.sleep(0)
+    await guard.run("u1", job)
+    await guard.run("u2", job)
+    assert guard._users == {}     # provably-idle state dropped after completion

--- a/Concierge/tests/test_ratelimit.py
+++ b/Concierge/tests/test_ratelimit.py
@@ -45,10 +45,34 @@ async def test_other_users_not_blocked():
 
 
 @pytest.mark.asyncio
-async def test_idle_user_state_is_evicted():
-    # _users must stay bounded by ACTIVE users, not every user who ever messaged the bot.
+async def test_idle_state_evicted_after_cooldown_elapses():
+    # The real regression case: cooldown_s > 0 (production default is 3.0). An idle user's
+    # state is RETAINED while its cooldown is live (so a quick re-request is still throttled)
+    # and EVICTED on later activity once the cooldown has fully elapsed.
+    guard = InFlightGuard(cooldown_s=0.02, max_queue_per_user=5)
+    async def job(): await asyncio.sleep(0)
+    await guard.run("u1", job)
+    assert "u1" in guard._users          # within cooldown -> retained
+    await asyncio.sleep(0.03)            # let u1's cooldown elapse
+    await guard.run("u2", job)           # any later activity sweeps expired entries
+    assert "u1" not in guard._users      # u1 evicted; _users bounded by recent activity
+    assert "u2" in guard._users
+
+
+@pytest.mark.asyncio
+async def test_idle_state_evicted_zero_cooldown_on_next_activity():
     guard = InFlightGuard(cooldown_s=0.0, max_queue_per_user=5)
     async def job(): await asyncio.sleep(0)
     await guard.run("u1", job)
-    await guard.run("u2", job)
-    assert guard._users == {}     # provably-idle state dropped after completion
+    await guard.run("u2", job)           # next run sweeps u1 (idle, cooldown 0 already elapsed)
+    assert "u1" not in guard._users
+
+
+@pytest.mark.asyncio
+async def test_state_within_cooldown_is_retained_for_throttling():
+    guard = InFlightGuard(cooldown_s=10.0, max_queue_per_user=5)
+    async def job(): await asyncio.sleep(0)
+    for u in ("u1", "u2", "u3"):
+        await guard.run(u, job)
+    # all three still inside the 10s window -> retained so their cooldown can be enforced
+    assert set(guard._users) == {"u1", "u2", "u3"}

--- a/Concierge/tests/test_render.py
+++ b/Concierge/tests/test_render.py
@@ -34,3 +34,11 @@ def test_sources_embed_none_when_empty():
 
 def test_escape():
     assert escape_markdown("a*b_c") == "a\\*b\\_c"
+
+
+def test_chunk_no_empty_piece_on_whitespace_boundary():
+    # A boundary inside a leading whitespace run must not yield a "" chunk (Discord rejects
+    # empty content with HTTP 400); no characters may be dropped either.
+    parts = chunk_message((" " * 2000) + ("a" * 5), limit=2000)
+    assert "" not in parts
+    assert "".join(parts).strip() == "a" * 5

--- a/Concierge/tests/test_render.py
+++ b/Concierge/tests/test_render.py
@@ -1,4 +1,7 @@
-from concierge.render import chunk_message, sources_embed, escape_markdown
+import pytest
+from concierge.render import (
+    chunk_message, sources_embed, escape_markdown, EMBED_DESC_LIMIT,
+)
 
 
 def test_chunk_under_limit_single():
@@ -32,8 +35,17 @@ def test_sources_embed_none_when_empty():
     assert sources_embed([], []) is None
 
 
-def test_escape():
+@pytest.mark.parametrize("ch", list("\\`*_~|>"))
+def test_escape_covers_every_special(ch):
+    # Every char in _MD_SPECIALS must be backslash-escaped — this is the markdown/spoiler/
+    # code-injection guard for untrusted source titles, so a dropped special is a real hole.
+    assert escape_markdown(ch) == "\\" + ch
+
+
+def test_escape_mixed_and_passthrough():
     assert escape_markdown("a*b_c") == "a\\*b\\_c"
+    assert escape_markdown("a`b|c>d~e") == "a\\`b\\|c\\>d\\~e"
+    assert escape_markdown("plain text 123") == "plain text 123"   # non-specials untouched
 
 
 def test_chunk_no_empty_piece_on_whitespace_boundary():
@@ -42,3 +54,28 @@ def test_chunk_no_empty_piece_on_whitespace_boundary():
     parts = chunk_message((" " * 2000) + ("a" * 5), limit=2000)
     assert "" not in parts
     assert "".join(parts).strip() == "a" * 5
+
+
+def test_chunk_balances_code_fence_across_split():
+    # A fenced code block longer than the limit must not leave a dangling unclosed ```:
+    # every emitted piece is self-contained (an even number of fence markers) and stays
+    # within the limit even after the synthetic close/reopen fences are added.
+    code = "\n".join(f"row {i:03d} " + "x" * 40 for i in range(120))   # ~6 KB, many newlines
+    parts = chunk_message(f"```python\n{code}\n```", limit=2000)
+    assert len(parts) >= 2
+    assert all(len(p) <= 2000 for p in parts)
+    assert all(p.count("```") % 2 == 0 for p in parts)   # no half-open fence in any piece
+
+
+def test_sources_embed_truncates_on_whole_lines_with_more_marker():
+    # An unusually large source set must be budgeted line-wise (never slicing a Markdown link
+    # mid-token) and flagged with a "+N more" marker; description stays within the embed limit.
+    many = [{"url": f"http://example.com/source-{i}", "title": f"Source number {i}"}
+            for i in range(400)]
+    e = sources_embed(many, [])
+    assert len(e["description"]) <= EMBED_DESC_LIMIT
+    assert "more)" in e["description"]                    # dropped-count marker present
+    for line in e["description"].splitlines():
+        if line.startswith("•"):
+            assert line.count("[") == line.count("]")     # no link cut mid-token
+            assert line.count("(") == line.count(")")

--- a/Concierge/tests/test_render.py
+++ b/Concierge/tests/test_render.py
@@ -1,0 +1,36 @@
+from concierge.render import chunk_message, sources_embed, escape_markdown
+
+
+def test_chunk_under_limit_single():
+    assert chunk_message("hello") == ["hello"]
+    assert chunk_message("") == []
+
+
+def test_chunk_splits_on_boundary():
+    text = "a" * 1500 + "\n" + "b" * 1500
+    parts = chunk_message(text, limit=2000)
+    assert len(parts) == 2
+    assert all(len(p) <= 2000 for p in parts)
+    assert parts[0].endswith("a")          # split at the newline, not mid-token
+
+
+def test_chunk_hard_splits_giant_token():
+    parts = chunk_message("x" * 5000, limit=2000)
+    assert len(parts) == 3
+    assert all(len(p) <= 2000 for p in parts)
+
+
+def test_sources_embed_dedups_and_masks():
+    e = sources_embed([{"url": "http://a", "title": "A"},
+                       {"url": "http://a", "title": "dup"}], ["http://b"])
+    assert e["title"] == "Sources"
+    assert e["description"].count("http://a") == 1
+    assert "http://b" in e["description"]
+
+
+def test_sources_embed_none_when_empty():
+    assert sources_embed([], []) is None
+
+
+def test_escape():
+    assert escape_markdown("a*b_c") == "a\\*b\\_c"

--- a/Concierge/tests/test_router.py
+++ b/Concierge/tests/test_router.py
@@ -1,0 +1,24 @@
+import asyncio
+from concierge.router import Router, InboundMessage
+
+
+async def chat(msg, app): return "chat"
+async def research(msg, app): return "research"
+
+
+def _msg(text): return InboundMessage(user_id="1", location_id="2", text=text, is_dm=True)
+
+
+def test_freeform_routes_to_chat():
+    r = Router(chat)
+    assert r.route(_msg("what is AAPL pe?")) is chat
+
+
+def test_registered_command_routes_to_its_handler():
+    r = Router(chat); r.register_command("/research", research)
+    assert r.route(_msg("/research tesla")) is research
+
+
+def test_unknown_slash_falls_back_to_chat():
+    r = Router(chat)
+    assert r.route(_msg("/nope hi")) is chat

--- a/Concierge/tests/test_router.py
+++ b/Concierge/tests/test_router.py
@@ -1,4 +1,3 @@
-import asyncio
 from concierge.router import Router, InboundMessage
 
 

--- a/Concierge/tests/test_session.py
+++ b/Concierge/tests/test_session.py
@@ -1,0 +1,19 @@
+import pytest
+from concierge.session import make_session_id, parse_session_id, SessionRef
+
+
+def test_round_trip():
+    sid = make_session_id("123", "456")
+    assert sid == "discord:123:456"
+    assert parse_session_id(sid) == SessionRef("123", "456")
+
+
+def test_parse_rejects_malformed():
+    for bad in ["", "discord:123", "x:123:456", "discord::456", "discord:123:"]:
+        with pytest.raises(ValueError):
+            parse_session_id(bad)
+
+
+def test_make_rejects_colon_in_ids():
+    with pytest.raises(ValueError):
+        make_session_id("12:3", "456")

--- a/Concierge/tests/test_throttle.py
+++ b/Concierge/tests/test_throttle.py
@@ -1,0 +1,20 @@
+from concierge.throttle import EditThrottle
+
+
+def test_no_flush_when_empty():
+    t = EditThrottle(interval_s=1.2, min_chars=1500)
+    assert t.should_flush(0, now_s=100.0) is False
+
+
+def test_flush_after_interval():
+    t = EditThrottle(interval_s=1.2, min_chars=1500)
+    assert t.should_flush(10, now_s=0.0) is True          # first content, >interval since 0.0
+    t.mark_flushed(10, now_s=0.0)
+    assert t.should_flush(20, now_s=0.5) is False          # too soon, too few chars
+    assert t.should_flush(20, now_s=1.5) is True           # interval elapsed
+
+
+def test_flush_after_min_chars():
+    t = EditThrottle(interval_s=1.2, min_chars=1500)
+    t.mark_flushed(10, now_s=0.0)
+    assert t.should_flush(1600, now_s=0.1) is True         # +1590 chars >= min_chars

--- a/Docs/superpowers/plans/2026-06-28-discord-chat-adapter.md
+++ b/Docs/superpowers/plans/2026-06-28-discord-chat-adapter.md
@@ -1,0 +1,1642 @@
+# Discord Chat Adapter (Concierge) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Turn the passive News Heartbeat into an interactive chatbot — a thin Discord Gateway adapter ("Concierge") that maps free-form @mention/DM messages onto the *existing* FinSearch extension pipeline (`/get_chat_response_stream/`) and posts replies back, with no backend change.
+
+**Architecture:** A separate, persistent `discord.py` service (Approach A from the spec). It is **transport-thin**: a `chat_handler` orchestrates through a tiny `DiscordIO` interface + an injected `AppContext`, so almost all logic is unit-testable with fakes (no Gateway, no network). Two-layer identity (durable SQLite record + ephemeral per-location `session_id`) is the only forward-compat seam built now; strategy control is deferred to backend ATL MCP tools.
+
+**Tech Stack:** Python 3.12, `discord.py` (brings `aiohttp`), `sqlite3` (stdlib), `pytest` + `pytest-asyncio`. Self-contained package; mirrors (does not import) the heartbeat's patterns.
+
+**Spec:** `Docs/superpowers/specs/2026-06-28-discord-chat-adapter-design.md`
+
+**Base branch note:** This plan assumes a build branch off `main` (which carries the live `Heartbeat/` for the shared-bot co-existence and the droplet deploy). The design spec currently lives on `discord-chat-adapter` (off the truthlayer branch); cherry-pick/rebase the spec onto the `main`-based build branch, or merge as convenient.
+
+**✋ Learning-mode note:** Three steps are marked **HANDS-ON** — the throttle policy (Task 6), the in-flight guard (Task 7), and the router dispatch (Task 9). These are genuine UX/cost trade-offs, not boilerplate. Each gives you a failing test + signature + guidance; try authoring the body yourself, then compare against the reference implementation provided below it.
+
+---
+
+## File Structure (interface contract — keep these signatures stable across tasks)
+
+```
+Concierge/
+  concierge/
+    __init__.py
+    __main__.py          entrypoint: load config -> wire stores/client -> client.run()
+    config.py            Config dataclass + load_config(env) -> Config
+    session.py           make_session_id(user, loc) / parse_session_id(s) -> SessionRef
+    identity.py          IdentityStore(db_path): resolve()/get()/close(); Identity dataclass
+    render.py            chunk_message(), sources_embed(), escape_markdown()
+    throttle.py          EditThrottle.should_flush()/mark_flushed()   [HANDS-ON]
+    ratelimit.py         InFlightGuard.run(user, factory); QueueFullError  [HANDS-ON]
+    router.py            InboundMessage, Router.route()/register_command()  [HANDS-ON]
+    finsearch_client.py  iter_sse_data(), reduce_events(), FinSearchClient.stream_chat()
+    handlers.py          chat_handler(msg, app) — orchestration
+    bot.py               DiscordIO, register_handlers(), should_handle(), _strip_mention()
+    app.py               AppContext (binds config + stores + DiscordIO for handlers)
+  tests/
+    test_config.py  test_session.py  test_identity.py  test_render.py
+    test_throttle.py  test_ratelimit.py  test_router.py  test_finsearch_client.py
+    test_bot.py  test_handlers.py
+    fixtures/sse_chat_stream.txt
+  systemd/concierge.service
+  requirements.txt
+  .env.concierge.example
+  README.md
+  .gitignore            (data/)
+```
+
+**Frozen types (defined once, referenced everywhere):**
+
+```python
+# config.py
+@dataclass(frozen=True)
+class Config:
+    discord_bot_token: str
+    finsearch_api_base: str
+    finsearch_api_key: Optional[str]
+    identity_db_path: str
+    default_model: str = "gpt-4o-mini"
+    request_timeout_s: float = 1260.0
+    cooldown_s: float = 3.0
+    edit_interval_s: float = 1.2
+    edit_min_chars: int = 1500
+    max_queue_per_user: int = 3
+
+# session.py
+@dataclass(frozen=True)
+class SessionRef:
+    discord_user_id: str
+    location_id: str
+
+# identity.py
+@dataclass(frozen=True)
+class Identity:
+    discord_user_id: str
+    finsearch_user_id: str
+    created_at: str
+    atl_account_id: Optional[str]   # RESERVED — always None in v1
+
+# finsearch_client.py
+@dataclass(frozen=True)
+class ChatChunk:
+    content: str
+@dataclass(frozen=True)
+class ChatResult:
+    text: str
+    used_sources: list
+    used_urls: list
+    truncated: bool
+
+# router.py
+@dataclass(frozen=True)
+class InboundMessage:
+    user_id: str
+    location_id: str
+    text: str
+    is_dm: bool
+```
+
+**Task order (dependencies):** 0 scaffold → 1 config → 2 session → 3 identity → 4 render → 5 *(none; throttle)* → 6 throttle → 7 ratelimit → 8 finsearch_client → 9 router → 10 handlers → 11 bot → 12 app+entrypoint → 13 infra(systemd/env/README) → 14 CI.
+
+---
+
+## Task 0: Scaffold the package
+
+**Files:**
+- Create: `Concierge/concierge/__init__.py` (empty)
+- Create: `Concierge/requirements.txt`
+- Create: `Concierge/.gitignore`
+- Create: `Concierge/tests/__init__.py` (empty)
+
+- [ ] **Step 1: Create the package skeleton**
+
+```bash
+mkdir -p Concierge/concierge Concierge/tests/fixtures Concierge/systemd
+touch Concierge/concierge/__init__.py Concierge/tests/__init__.py
+```
+
+- [ ] **Step 2: Write `Concierge/requirements.txt`**
+
+```
+discord.py>=2.4,<3
+# dev/test
+pytest>=8
+pytest-asyncio>=0.23,<0.24   # strict mode + explicit @pytest.mark.asyncio (what the tests assume)
+```
+
+- [ ] **Step 3: Write `Concierge/.gitignore`**
+
+```
+data/
+.venv/
+__pycache__/
+*.pyc
+```
+
+- [ ] **Step 4: Create the venv and install**
+
+Run:
+```bash
+cd Concierge && python3.12 -m venv .venv && ./.venv/bin/pip install -q -r requirements.txt && ./.venv/bin/python -c "import discord, pytest; print('ok')"
+```
+Expected: prints `ok`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Concierge/requirements.txt Concierge/.gitignore Concierge/concierge/__init__.py Concierge/tests/__init__.py
+git commit -m "chore(concierge): scaffold Discord chat-adapter package"
+```
+
+---
+
+## Task 1: `config.py` — load + validate env
+
+**Files:**
+- Create: `Concierge/concierge/config.py`
+- Test: `Concierge/tests/test_config.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_config.py
+import pytest
+from concierge.config import load_config, Config, ConfigError
+
+def test_load_full_env():
+    cfg = load_config({"DISCORD_BOT_TOKEN": "tok",
+                       "FINSEARCH_API_BASE": "http://localhost:8000/"})
+    assert isinstance(cfg, Config)
+    assert cfg.discord_bot_token == "tok"
+    assert cfg.finsearch_api_base == "http://localhost:8000"   # trailing slash stripped
+    assert cfg.finsearch_api_key is None                       # absent -> None
+    assert cfg.default_model == "gpt-4o-mini"
+
+def test_missing_token_raises():
+    with pytest.raises(ConfigError):
+        load_config({"FINSEARCH_API_BASE": "http://x"})
+
+def test_default_base_when_absent():
+    cfg = load_config({"DISCORD_BOT_TOKEN": "tok"})
+    assert cfg.finsearch_api_base == "http://localhost:8000"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd Concierge && ./.venv/bin/python -m pytest tests/test_config.py -q`
+Expected: FAIL (`ModuleNotFoundError: concierge.config`). Note: run pytest from `Concierge/` so `concierge` is importable, or add `pythonpath = .` (Task 14 adds `pytest.ini`).
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# concierge/config.py
+from dataclasses import dataclass
+from typing import Mapping, Optional
+
+
+@dataclass(frozen=True)
+class Config:
+    discord_bot_token: str
+    finsearch_api_base: str
+    finsearch_api_key: Optional[str]
+    identity_db_path: str
+    default_model: str = "gpt-4o-mini"
+    request_timeout_s: float = 1260.0
+    cooldown_s: float = 3.0
+    edit_interval_s: float = 1.2
+    edit_min_chars: int = 1500
+    max_queue_per_user: int = 3
+
+
+class ConfigError(ValueError):
+    pass
+
+
+def load_config(env: Mapping[str, str]) -> Config:
+    token = (env.get("DISCORD_BOT_TOKEN") or "").strip()
+    if not token:
+        raise ConfigError("missing required env var: DISCORD_BOT_TOKEN")
+    return Config(
+        discord_bot_token=token,
+        finsearch_api_base=(env.get("FINSEARCH_API_BASE") or "http://localhost:8000").rstrip("/"),
+        finsearch_api_key=((env.get("FINGPT_API_KEY") or "").strip() or None),
+        identity_db_path=(env.get("CONCIERGE_IDENTITY_DB") or "data/identity.sqlite"),
+    )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd Concierge && ./.venv/bin/python -m pytest tests/test_config.py -q`
+Expected: 3 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Concierge/concierge/config.py Concierge/tests/test_config.py
+git commit -m "feat(concierge): config loader with env validation"
+```
+
+---
+
+## Task 2: `session.py` — the per-location session-id contract
+
+**Files:**
+- Create: `Concierge/concierge/session.py`
+- Test: `Concierge/tests/test_session.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_session.py
+import pytest
+from concierge.session import make_session_id, parse_session_id, SessionRef
+
+def test_round_trip():
+    sid = make_session_id("123", "456")
+    assert sid == "discord:123:456"
+    assert parse_session_id(sid) == SessionRef("123", "456")
+
+def test_parse_rejects_malformed():
+    for bad in ["", "discord:123", "x:123:456", "discord::456", "discord:123:"]:
+        with pytest.raises(ValueError):
+            parse_session_id(bad)
+
+def test_make_rejects_colon_in_ids():
+    with pytest.raises(ValueError):
+        make_session_id("12:3", "456")
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd Concierge && ./.venv/bin/python -m pytest tests/test_session.py -q`
+Expected: FAIL (`ModuleNotFoundError`).
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# concierge/session.py
+from dataclasses import dataclass
+
+_PREFIX = "discord"
+
+
+def make_session_id(discord_user_id: str, location_id: str) -> str:
+    if not discord_user_id or not location_id:
+        raise ValueError("discord_user_id and location_id are required")
+    if ":" in discord_user_id or ":" in location_id:
+        raise ValueError("ids must not contain ':'")
+    return f"{_PREFIX}:{discord_user_id}:{location_id}"
+
+
+@dataclass(frozen=True)
+class SessionRef:
+    discord_user_id: str
+    location_id: str
+
+
+def parse_session_id(session_id: str) -> SessionRef:
+    parts = session_id.split(":")
+    if len(parts) != 3 or parts[0] != _PREFIX or not parts[1] or not parts[2]:
+        raise ValueError(f"malformed session_id: {session_id!r}")
+    return SessionRef(discord_user_id=parts[1], location_id=parts[2])
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd Concierge && ./.venv/bin/python -m pytest tests/test_session.py -q`
+Expected: 3 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Concierge/concierge/session.py Concierge/tests/test_session.py
+git commit -m "feat(concierge): per-location session-id contract (make/parse)"
+```
+
+---
+
+## Task 3: `identity.py` — the durable identity store (ATL anchor)
+
+**Files:**
+- Create: `Concierge/concierge/identity.py`
+- Test: `Concierge/tests/test_identity.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_identity.py
+from concierge.identity import IdentityStore, Identity
+
+def test_resolve_creates_with_reserved_atl_none():
+    store = IdentityStore(":memory:")
+    ident = store.resolve("123", now_iso="2026-06-28T00:00:00+00:00")
+    assert ident.discord_user_id == "123"
+    assert ident.finsearch_user_id == "discord_123"      # deterministic
+    assert ident.atl_account_id is None                   # reserved
+    store.close()
+
+def test_resolve_is_idempotent():
+    store = IdentityStore(":memory:")
+    a = store.resolve("123", now_iso="2026-06-28T00:00:00+00:00")
+    b = store.resolve("123", now_iso="2099-01-01T00:00:00+00:00")  # later — must not overwrite
+    assert a == b
+    assert b.created_at == "2026-06-28T00:00:00+00:00"
+    store.close()
+
+def test_persists_across_reopen(tmp_path):
+    db = str(tmp_path / "id.sqlite")
+    s1 = IdentityStore(db); s1.resolve("123", now_iso="2026-06-28T00:00:00+00:00"); s1.close()
+    s2 = IdentityStore(db)
+    assert s2.get("123") is not None
+    assert s2.get("999") is None
+    s2.close()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd Concierge && ./.venv/bin/python -m pytest tests/test_identity.py -q`
+Expected: FAIL (`ModuleNotFoundError`).
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# concierge/identity.py
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS identity (
+    discord_user_id   TEXT PRIMARY KEY,
+    finsearch_user_id TEXT NOT NULL,
+    created_at        TEXT NOT NULL,
+    atl_account_id    TEXT
+);
+"""
+
+
+@dataclass(frozen=True)
+class Identity:
+    discord_user_id: str
+    finsearch_user_id: str
+    created_at: str
+    atl_account_id: Optional[str]
+
+
+class IdentityStore:
+    def __init__(self, db_path: str) -> None:
+        if db_path != ":memory:":
+            Path(db_path).parent.mkdir(parents=True, exist_ok=True)
+        self._conn = sqlite3.connect(db_path)
+        self._conn.row_factory = sqlite3.Row
+        self._conn.executescript(_SCHEMA)
+        self._conn.commit()
+
+    def get(self, discord_user_id: str) -> Optional[Identity]:
+        row = self._conn.execute(
+            "SELECT * FROM identity WHERE discord_user_id = ?", (discord_user_id,)
+        ).fetchone()
+        if row is None:
+            return None
+        return Identity(row["discord_user_id"], row["finsearch_user_id"],
+                        row["created_at"], row["atl_account_id"])
+
+    def resolve(self, discord_user_id: str, *, now_iso: str) -> Identity:
+        existing = self.get(discord_user_id)
+        if existing is not None:
+            return existing
+        finsearch_user_id = f"discord_{discord_user_id}"
+        self._conn.execute(
+            "INSERT INTO identity (discord_user_id, finsearch_user_id, created_at, atl_account_id) "
+            "VALUES (?, ?, ?, NULL)",
+            (discord_user_id, finsearch_user_id, now_iso),
+        )
+        self._conn.commit()
+        return Identity(discord_user_id, finsearch_user_id, now_iso, None)
+
+    def close(self) -> None:
+        self._conn.close()
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd Concierge && ./.venv/bin/python -m pytest tests/test_identity.py -q`
+Expected: 3 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Concierge/concierge/identity.py Concierge/tests/test_identity.py
+git commit -m "feat(concierge): durable identity store (reserved atl_account_id)"
+```
+
+---
+
+## Task 4: `render.py` — chunking, sources embed, escaping
+
+**Files:**
+- Create: `Concierge/concierge/render.py`
+- Test: `Concierge/tests/test_render.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_render.py
+from concierge.render import chunk_message, sources_embed, escape_markdown
+
+def test_chunk_under_limit_single():
+    assert chunk_message("hello") == ["hello"]
+    assert chunk_message("") == []
+
+def test_chunk_splits_on_boundary():
+    text = "a" * 1500 + "\n" + "b" * 1500
+    parts = chunk_message(text, limit=2000)
+    assert len(parts) == 2
+    assert all(len(p) <= 2000 for p in parts)
+    assert parts[0].endswith("a")          # split at the newline, not mid-token
+
+def test_chunk_hard_splits_giant_token():
+    parts = chunk_message("x" * 5000, limit=2000)
+    assert len(parts) == 3
+    assert all(len(p) <= 2000 for p in parts)
+
+def test_sources_embed_dedups_and_masks():
+    e = sources_embed([{"url": "http://a", "title": "A"},
+                       {"url": "http://a", "title": "dup"}], ["http://b"])
+    assert e["title"] == "Sources"
+    assert e["description"].count("http://a") == 1
+    assert "http://b" in e["description"]
+
+def test_sources_embed_none_when_empty():
+    assert sources_embed([], []) is None
+
+def test_escape():
+    assert escape_markdown("a*b_c") == "a\\*b\\_c"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd Concierge && ./.venv/bin/python -m pytest tests/test_render.py -q`
+Expected: FAIL (`ModuleNotFoundError`).
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# concierge/render.py
+from typing import Optional
+
+DISCORD_MSG_LIMIT = 2000
+EMBED_DESC_LIMIT = 4096
+_MD_SPECIALS = set("\\`*_~|>")
+
+
+def escape_markdown(text: str) -> str:
+    return "".join("\\" + ch if ch in _MD_SPECIALS else ch for ch in text)
+
+
+def chunk_message(text: str, limit: int = DISCORD_MSG_LIMIT) -> list:
+    if not text:
+        return []
+    chunks, remaining = [], text
+    while len(remaining) > limit:
+        window = remaining[:limit]
+        cut = window.rfind("\n")
+        if cut <= 0:
+            cut = window.rfind(" ")
+        if cut <= 0:
+            cut = limit            # no boundary: hard split
+        chunks.append(remaining[:cut].rstrip())
+        remaining = remaining[cut:].lstrip()
+    if remaining:
+        chunks.append(remaining)
+    return chunks
+
+
+def sources_embed(used_sources: list, used_urls: list) -> Optional[dict]:
+    lines, seen = [], set()
+    for src in used_sources or []:
+        url = (src.get("url") or "").strip()
+        title = (src.get("title") or url or "source").strip()
+        if url and url not in seen:
+            seen.add(url)
+            lines.append(f"• [{escape_markdown(title)}]({url})")
+    for url in used_urls or []:
+        url = (url or "").strip()
+        if url and url not in seen:
+            seen.add(url)
+            lines.append(f"• {url}")
+    if not lines:
+        return None
+    return {"title": "Sources", "description": "\n".join(lines)[:EMBED_DESC_LIMIT], "color": 0x2E86C1}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd Concierge && ./.venv/bin/python -m pytest tests/test_render.py -q`
+Expected: 6 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Concierge/concierge/render.py Concierge/tests/test_render.py
+git commit -m "feat(concierge): message chunking + sources embed + md escape"
+```
+
+---
+
+## Task 5: *(reserved — render covered the no-dependency tier; proceed to throttle)*
+
+---
+
+## Task 6: `throttle.py` — the streaming edit-throttle policy  ✋ HANDS-ON
+
+**Files:**
+- Create: `Concierge/concierge/throttle.py`
+- Test: `Concierge/tests/test_throttle.py`
+
+**Why this matters:** Discord rate-limits message edits (~5 per 5 s per channel). Edit too often → 429s and a janky UI; too rarely → the answer feels frozen. The policy that balances "feels live" vs "stays under the limit" is yours to set.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_throttle.py
+from concierge.throttle import EditThrottle
+
+def test_no_flush_when_empty():
+    t = EditThrottle(interval_s=1.2, min_chars=1500)
+    assert t.should_flush(0, now_s=100.0) is False
+
+def test_flush_after_interval():
+    t = EditThrottle(interval_s=1.2, min_chars=1500)
+    assert t.should_flush(10, now_s=0.0) is True          # first content, >interval since 0.0
+    t.mark_flushed(10, now_s=0.0)
+    assert t.should_flush(20, now_s=0.5) is False          # too soon, too few chars
+    assert t.should_flush(20, now_s=1.5) is True           # interval elapsed
+
+def test_flush_after_min_chars():
+    t = EditThrottle(interval_s=1.2, min_chars=1500)
+    t.mark_flushed(10, now_s=0.0)
+    assert t.should_flush(1600, now_s=0.1) is True         # +1590 chars >= min_chars
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd Concierge && ./.venv/bin/python -m pytest tests/test_throttle.py -q`
+Expected: FAIL (`ModuleNotFoundError`).
+
+- [ ] **Step 3: ✋ Author `should_flush` yourself**
+
+Signature to implement (in `concierge/throttle.py`):
+```python
+from dataclasses import dataclass
+
+@dataclass
+class EditThrottle:
+    interval_s: float
+    min_chars: int
+    _last_flush_s: float = float("-inf")   # first content always clears the interval gate
+    _last_len: int = 0
+
+    def should_flush(self, accumulated_len: int, now_s: float) -> bool:
+        ...  # YOUR LOGIC: never on empty; flush if enough time passed OR enough new chars
+
+    def mark_flushed(self, accumulated_len: int, now_s: float) -> None:
+        self._last_flush_s = now_s
+        self._last_len = accumulated_len
+```
+Guidance: two independent triggers (time since last flush ≥ `interval_s`, OR chars since last flush ≥ `min_chars`), and never flush when `accumulated_len == 0`.
+
+<details><summary>Reference implementation (compare after your attempt)</summary>
+
+```python
+def should_flush(self, accumulated_len: int, now_s: float) -> bool:
+    if accumulated_len == 0:
+        return False
+    if now_s - self._last_flush_s >= self.interval_s:
+        return True
+    if accumulated_len - self._last_len >= self.min_chars:
+        return True
+    return False
+```
+</details>
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd Concierge && ./.venv/bin/python -m pytest tests/test_throttle.py -q`
+Expected: 3 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Concierge/concierge/throttle.py Concierge/tests/test_throttle.py
+git commit -m "feat(concierge): edit-throttle policy (interval OR char trigger)"
+```
+
+---
+
+## Task 7: `ratelimit.py` — the per-user in-flight guard  ✋ HANDS-ON
+
+**Files:**
+- Create: `Concierge/concierge/ratelimit.py`
+- Test: `Concierge/tests/test_ratelimit.py`
+
+**Why this matters:** The spec chose *queue* (not reject) for a second message while one is in flight, plus a cooldown and a depth cap to bound abuse/token-burn. This is the trickiest hands-on point — concurrency policy.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_ratelimit.py
+import asyncio
+import pytest
+from concierge.ratelimit import InFlightGuard, QueueFullError
+
+@pytest.mark.asyncio
+async def test_serializes_same_user():
+    order = []
+    guard = InFlightGuard(cooldown_s=0.0, max_queue_per_user=5)
+    async def job(tag):
+        order.append(("start", tag)); await asyncio.sleep(0.01); order.append(("end", tag))
+    await asyncio.gather(
+        guard.run("u1", lambda: job("a")),
+        guard.run("u1", lambda: job("b")),
+    )
+    # Same user: second job must not start before the first ends (queued).
+    assert order in (
+        [("start","a"),("end","a"),("start","b"),("end","b")],
+        [("start","b"),("end","b"),("start","a"),("end","a")],
+    )
+
+@pytest.mark.asyncio
+async def test_depth_cap_rejects():
+    guard = InFlightGuard(cooldown_s=0.0, max_queue_per_user=1)
+    async def slow(): await asyncio.sleep(0.05)
+    running = asyncio.create_task(guard.run("u1", slow))   # holds the slot
+    await asyncio.sleep(0.005)
+    with pytest.raises(QueueFullError):                     # 2nd waiter exceeds cap=1
+        await asyncio.gather(
+            guard.run("u1", slow),
+            guard.run("u1", slow),
+        )
+    await running
+
+@pytest.mark.asyncio
+async def test_other_users_not_blocked():
+    guard = InFlightGuard(cooldown_s=0.0, max_queue_per_user=5)
+    started = []
+    async def job(tag): started.append(tag); await asyncio.sleep(0.02)
+    await asyncio.gather(guard.run("u1", lambda: job("a")),
+                         guard.run("u2", lambda: job("b")))
+    assert set(started) == {"a", "b"}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd Concierge && ./.venv/bin/python -m pytest tests/test_ratelimit.py -q`
+Expected: FAIL (`ModuleNotFoundError`).
+
+- [ ] **Step 3: ✋ Author `InFlightGuard` yourself**
+
+Signature to implement (in `concierge/ratelimit.py`):
+```python
+import asyncio
+from dataclasses import dataclass, field
+
+
+class QueueFullError(Exception):
+    pass
+
+
+@dataclass
+class _UserState:
+    lock: "asyncio.Lock" = field(default_factory=asyncio.Lock)
+    waiting: int = 0
+    last_done_s: float = 0.0
+
+
+class InFlightGuard:
+    def __init__(self, cooldown_s: float, max_queue_per_user: int):
+        self._cooldown_s = cooldown_s
+        self._max_queue = max_queue_per_user
+        self._users: dict = {}
+
+    async def run(self, user_id: str, coro_factory):
+        ...  # YOUR LOGIC
+```
+Guidance: get-or-create a `_UserState`; if `waiting >= max_queue` raise `QueueFullError`; else increment `waiting`, `async with state.lock` (this is the *queue* — extras await the lock), enforce `cooldown_s` since `last_done_s` via `asyncio.sleep`, run `await coro_factory()`, record `last_done_s`, decrement `waiting`. Use `asyncio.get_event_loop().time()` for the clock.
+
+<details><summary>Reference implementation (compare after your attempt)</summary>
+
+```python
+def _state(self, user_id):
+    st = self._users.get(user_id)
+    if st is None:
+        st = _UserState()
+        self._users[user_id] = st
+    return st
+
+async def run(self, user_id, coro_factory):
+    st = self._state(user_id)
+    if st.waiting >= self._max_queue:
+        raise QueueFullError(user_id)
+    st.waiting += 1
+    try:
+        async with st.lock:
+            now = asyncio.get_event_loop().time()
+            wait = self._cooldown_s - (now - st.last_done_s)
+            if wait > 0:
+                await asyncio.sleep(wait)
+            try:
+                return await coro_factory()
+            finally:
+                st.last_done_s = asyncio.get_event_loop().time()
+    finally:
+        st.waiting -= 1
+```
+</details>
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd Concierge && ./.venv/bin/python -m pytest tests/test_ratelimit.py -q`
+Expected: 3 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Concierge/concierge/ratelimit.py Concierge/tests/test_ratelimit.py
+git commit -m "feat(concierge): per-user in-flight guard (queue + cooldown + depth cap)"
+```
+
+---
+
+## Task 8: `finsearch_client.py` — SSE client to the extension endpoint
+
+**Files:**
+- Create: `Concierge/concierge/finsearch_client.py`
+- Create: `Concierge/tests/fixtures/sse_chat_stream.txt`
+- Test: `Concierge/tests/test_finsearch_client.py`
+
+**Note:** The protocol logic (`iter_sse_data`, `reduce_events`) is pure and fully tested against recorded frames. `stream_chat` is the thin async wrapper around `aiohttp`. **Re-capture** the fixture from a live call once the backend is reachable (`curl -N "$BASE/get_chat_response_stream/?question=hi&session_id=discord:1:1&models=gpt-4o-mini&use_memory=true"`); the inline fixture below is a representative shape.
+
+- [ ] **Step 1: Write the fixture**
+
+`Concierge/tests/fixtures/sse_chat_stream.txt`:
+```
+event: connected
+data: {"status": "connected"}
+
+data: {"status": {"label": "Preparing context"}}
+
+data: {"content": "AAPL ", "done": false}
+
+data: {"content": "is Apple.", "done": false}
+
+data: {"content": "", "done": true, "wrapped_content": "AAPL is Apple.", "used_sources": [{"url": "http://x", "title": "X"}], "used_urls": ["http://y"]}
+```
+
+- [ ] **Step 2: Write the failing test**
+
+```python
+# tests/test_finsearch_client.py
+from pathlib import Path
+from concierge.finsearch_client import iter_sse_data, reduce_events, ChatResult
+
+FIX = Path(__file__).parent / "fixtures" / "sse_chat_stream.txt"
+
+def test_iter_and_reduce_full_stream():
+    lines = FIX.read_text().splitlines()
+    events = list(iter_sse_data(lines))
+    acc, result = reduce_events(events)
+    assert "".join(acc) == "AAPL is Apple."
+    assert isinstance(result, ChatResult)
+    assert result.text == "AAPL is Apple."
+    assert result.truncated is False
+    assert result.used_urls == ["http://y"]
+    assert result.used_sources[0]["url"] == "http://x"
+
+def test_partial_stream_is_truncated():
+    lines = ['data: {"content": "half", "done": false}']   # no done frame
+    acc, result = reduce_events(iter_sse_data(lines))
+    assert result.text == "half"
+    assert result.truncated is True
+
+def test_iter_skips_non_data_and_bad_json():
+    lines = ["event: connected", "data: not-json", ": comment", 'data: {"content":"x","done":false}']
+    objs = list(iter_sse_data(lines))
+    assert objs == [{"content": "x", "done": False}]
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `cd Concierge && ./.venv/bin/python -m pytest tests/test_finsearch_client.py -q`
+Expected: FAIL (`ModuleNotFoundError`).
+
+- [ ] **Step 4: Write implementation**
+
+```python
+# concierge/finsearch_client.py
+import json
+from dataclasses import dataclass
+from typing import AsyncIterator, Iterable, Iterator, Optional, Union
+from urllib.parse import urlencode
+
+import aiohttp
+
+
+@dataclass(frozen=True)
+class ChatChunk:
+    content: str
+
+
+@dataclass(frozen=True)
+class ChatResult:
+    text: str
+    used_sources: list
+    used_urls: list
+    truncated: bool
+
+
+def iter_sse_data(lines: Iterable[str]) -> Iterator[dict]:
+    for line in lines:
+        line = line.rstrip("\n")
+        if not line.startswith("data:"):
+            continue
+        payload = line[len("data:"):].strip()
+        if not payload or payload == "[DONE]":
+            continue
+        try:
+            obj = json.loads(payload)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(obj, dict):
+            yield obj
+
+
+def reduce_events(events: Iterable[dict]):
+    """Pure reducer -> (content chunks, ChatResult). Mirrors stream_chat's accumulation."""
+    acc, done, final = [], False, {}
+    for ev in events:
+        if ev.get("done") is True:
+            done, final = True, ev
+            break
+        c = ev.get("content")
+        if c:
+            acc.append(c)
+    text = "".join(acc) or (final.get("wrapped_content") or "")
+    return acc, ChatResult(text=text,
+                           used_sources=final.get("used_sources") or [],
+                           used_urls=final.get("used_urls") or [],
+                           truncated=not done)
+
+
+class FinSearchClient:
+    def __init__(self, base_url: str, api_key: Optional[str],
+                 timeout_s: float, default_model: str) -> None:
+        self._base = base_url.rstrip("/")
+        self._api_key = api_key
+        self._timeout = aiohttp.ClientTimeout(total=timeout_s)
+        self._model = default_model
+        self._session: Optional[aiohttp.ClientSession] = None
+
+    async def _ensure_session(self) -> aiohttp.ClientSession:
+        if self._session is None or self._session.closed:
+            headers = {"Authorization": f"Bearer {self._api_key}"} if self._api_key else {}
+            self._session = aiohttp.ClientSession(timeout=self._timeout, headers=headers)
+        return self._session
+
+    async def stream_chat(self, *, question: str, session_id: str,
+                          user_timezone: str, user_time: str
+                          ) -> AsyncIterator[Union[ChatChunk, ChatResult]]:
+        params = {
+            "question": question, "session_id": session_id, "models": self._model,
+            "is_advanced": "false", "use_memory": "true",
+            "current_url": "https://discord.com",
+            "user_timezone": user_timezone, "user_time": user_time,
+        }
+        url = f"{self._base}/get_chat_response_stream/?{urlencode(params)}"
+        session = await self._ensure_session()
+        acc, done, final = [], False, {}
+        async with session.get(url) as resp:
+            resp.raise_for_status()
+            # INVARIANT: resp.content yields ONE line per iteration (aiohttp readline),
+            # so each iter_sse_data() sees a single SSE event and the break-on-done below
+            # cannot strand a sibling content frame. Do NOT switch to iter_chunked()/iter_any()
+            # without restructuring this into a line-buffer reducer.
+            async for raw in resp.content:
+                for ev in iter_sse_data([raw.decode("utf-8", "replace")]):
+                    if ev.get("done") is True:
+                        done, final = True, ev
+                        break
+                    c = ev.get("content")
+                    if c:
+                        acc.append(c)
+                        yield ChatChunk(c)
+                if done:
+                    break
+        text = "".join(acc) or (final.get("wrapped_content") or "")
+        yield ChatResult(text=text,
+                         used_sources=final.get("used_sources") or [],
+                         used_urls=final.get("used_urls") or [],
+                         truncated=not done)
+
+    async def aclose(self) -> None:
+        if self._session and not self._session.closed:
+            await self._session.close()
+```
+
+- [ ] **Step 5: Run test to verify it passes, then commit**
+
+Run: `cd Concierge && ./.venv/bin/python -m pytest tests/test_finsearch_client.py -q`
+Expected: 3 passed.
+```bash
+git add Concierge/concierge/finsearch_client.py Concierge/tests/test_finsearch_client.py Concierge/tests/fixtures/sse_chat_stream.txt
+git commit -m "feat(concierge): SSE client for /get_chat_response_stream/ (pure reducers + async stream)"
+```
+
+---
+
+## Task 9: `router.py` — handler dispatch  ✋ HANDS-ON
+
+**Files:**
+- Create: `Concierge/concierge/router.py`
+- Test: `Concierge/tests/test_router.py`
+
+**Why this matters:** v1 routes everything to chat. The dispatch *shape* determines how cheaply `/research` and `/strategy` slot in later. Keep it a one-liner now, but structured so commands register without touching callers.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_router.py
+import asyncio
+from concierge.router import Router, InboundMessage
+
+async def chat(msg, app): return "chat"
+async def research(msg, app): return "research"
+
+def _msg(text): return InboundMessage(user_id="1", location_id="2", text=text, is_dm=True)
+
+def test_freeform_routes_to_chat():
+    r = Router(chat)
+    assert r.route(_msg("what is AAPL pe?")) is chat
+
+def test_registered_command_routes_to_its_handler():
+    r = Router(chat); r.register_command("/research", research)
+    assert r.route(_msg("/research tesla")) is research
+
+def test_unknown_slash_falls_back_to_chat():
+    r = Router(chat)
+    assert r.route(_msg("/nope hi")) is chat
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd Concierge && ./.venv/bin/python -m pytest tests/test_router.py -q`
+Expected: FAIL (`ModuleNotFoundError`).
+
+- [ ] **Step 3: ✋ Author `Router.route` yourself**
+
+Skeleton (in `concierge/router.py`):
+```python
+from dataclasses import dataclass
+from typing import Awaitable, Callable
+
+@dataclass(frozen=True)
+class InboundMessage:
+    user_id: str
+    location_id: str
+    text: str
+    is_dm: bool
+
+Handler = Callable[["InboundMessage", object], Awaitable[None]]
+
+class Router:
+    def __init__(self, chat_handler: Handler) -> None:
+        self._chat_handler = chat_handler
+        self._commands: dict = {}
+
+    def register_command(self, name: str, handler: Handler) -> None:
+        self._commands[name] = handler
+
+    def route(self, msg: InboundMessage) -> Handler:
+        ...  # YOUR LOGIC: leading "/token" in _commands -> that handler; else chat
+```
+Guidance: take the first whitespace-delimited token; if it starts with `/` and is a registered command, return that handler; otherwise return the chat handler (free-form fallback).
+
+<details><summary>Reference implementation</summary>
+
+```python
+def route(self, msg: InboundMessage) -> Handler:
+    token = msg.text.split(maxsplit=1)[0] if msg.text else ""
+    if token.startswith("/") and token in self._commands:
+        return self._commands[token]
+    return self._chat_handler
+```
+</details>
+
+- [ ] **Step 4: Run test to verify it passes, then commit**
+
+Run: `cd Concierge && ./.venv/bin/python -m pytest tests/test_router.py -q`
+Expected: 3 passed.
+```bash
+git add Concierge/concierge/router.py Concierge/tests/test_router.py
+git commit -m "feat(concierge): handler router (chat now; command seam reserved)"
+```
+
+---
+
+## Task 10: `handlers.py` — `chat_handler` orchestration
+
+**Files:**
+- Create: `Concierge/concierge/handlers.py`
+- Test: `Concierge/tests/test_handlers.py`
+
+**Design:** `chat_handler` talks only to `app` (an `AppContext`-shaped object) and `app.discord` (a `DiscordIO`-shaped object). Tests inject fakes — no discord.py, no network.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_handlers.py
+import asyncio
+import contextlib
+import pytest
+from concierge.handlers import chat_handler
+from concierge.router import InboundMessage
+from concierge.finsearch_client import ChatChunk, ChatResult
+from concierge.identity import IdentityStore
+from concierge.session import make_session_id
+from concierge.throttle import EditThrottle
+
+class FakeDiscord:
+    def __init__(self): self.sent=[]; self.edits=[]; self.embeds=[]; self.followups=[]
+    async def send(self, msg, content): self.sent.append(content); return {"id": len(self.sent)}
+    async def edit(self, ph, content): self.edits.append(content)
+    async def send_followup(self, msg, content): self.followups.append(content)
+    async def send_embed(self, msg, embed): self.embeds.append(embed)
+    def typing(self, msg): return contextlib.nullcontext()   # async-with no-op (Py3.10+)
+
+class FakeFinSearch:
+    def __init__(self, items): self._items=items
+    async def stream_chat(self, **kw):
+        for it in self._items: yield it
+
+class FakeApp:
+    def __init__(self, discord, finsearch):
+        self.discord=discord; self.finsearch=finsearch
+        self.identity=IdentityStore(":memory:")
+        self._t=0.0
+    def make_session(self, u, l): return make_session_id(u, l)
+    def new_throttle(self): return EditThrottle(0.0, 1)   # always flush -> exercise edit path
+    def clock(self): self._t+=1.0; return self._t
+    def now_iso(self): return "2026-06-28T00:00:00+00:00"
+
+def _msg(): return InboundMessage(user_id="1", location_id="2", text="hi", is_dm=True)
+
+@pytest.mark.asyncio
+async def test_happy_path_posts_placeholder_then_final_and_sources():
+    d = FakeDiscord()
+    f = FakeFinSearch([ChatChunk("AAPL "), ChatChunk("is Apple."),
+                       ChatResult("AAPL is Apple.", [{"url":"http://x","title":"X"}], [], False)])
+    app = FakeApp(d, f)
+    await chat_handler(_msg(), app)
+    assert d.sent[0] == "\U0001f4ad Thinking…"      # placeholder posted first
+    assert d.edits[-1] == "AAPL is Apple."                # final edit is the full answer
+    assert len(d.embeds) == 1                              # sources embed sent
+
+@pytest.mark.asyncio
+async def test_truncated_marks_cutoff():
+    d = FakeDiscord()
+    f = FakeFinSearch([ChatChunk("half"), ChatResult("half", [], [], True)])
+    await chat_handler(_msg(), FakeApp(d, f))
+    assert "cut off" in d.edits[-1]
+
+@pytest.mark.asyncio
+async def test_backend_error_shows_friendly_message():
+    d = FakeDiscord()
+    class Boom:
+        async def stream_chat(self, **kw):
+            if False: yield
+            raise RuntimeError("down")
+    with pytest.raises(RuntimeError):
+        await chat_handler(_msg(), FakeApp(d, Boom()))
+    assert "Couldn't reach FinSearch" in d.edits[-1]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd Concierge && ./.venv/bin/python -m pytest tests/test_handlers.py -q`
+Expected: FAIL (`ModuleNotFoundError`).
+
+- [ ] **Step 3: Write implementation**
+
+```python
+# concierge/handlers.py
+from .render import DISCORD_MSG_LIMIT, chunk_message, sources_embed
+from .finsearch_client import ChatChunk, ChatResult
+from .router import InboundMessage
+
+_THINKING = "\U0001f4ad Thinking…"   # 💭 Thinking…
+_ERR = "⚠️ Couldn't reach FinSearch, try again in a moment."
+
+
+def _preview(text: str) -> str:
+    return text[:DISCORD_MSG_LIMIT] if len(text) > DISCORD_MSG_LIMIT else text
+
+
+async def chat_handler(msg: InboundMessage, app) -> None:
+    app.identity.resolve(msg.user_id, now_iso=app.now_iso())
+    session_id = app.make_session(msg.user_id, msg.location_id)
+    placeholder = await app.discord.send(msg, _THINKING)
+    throttle = app.new_throttle()
+    acc, result = "", None
+    try:
+        async with app.discord.typing(msg):          # "Bot is typing…" for the stream duration
+            async for item in app.finsearch.stream_chat(
+                question=msg.text, session_id=session_id,
+                user_timezone="UTC", user_time=app.now_iso(),
+            ):
+                if isinstance(item, ChatChunk):
+                    acc += item.content
+                    now = app.clock()                # read the clock ONCE per chunk
+                    if throttle.should_flush(len(acc), now):
+                        throttle.mark_flushed(len(acc), now)
+                        await app.discord.edit(placeholder, _preview(acc))
+                elif isinstance(item, ChatResult):
+                    result = item
+    except Exception:
+        await app.discord.edit(placeholder, _ERR)
+        raise
+
+    text = (result.text if result else acc) or "*(no response)*"
+    if result and result.truncated:
+        text += "\n\n*(response was cut off)*"
+    parts = chunk_message(text)
+    await app.discord.edit(placeholder, parts[0] if parts else "*(no response)*")
+    for extra in parts[1:]:
+        await app.discord.send_followup(msg, extra)
+    if result:
+        embed = sources_embed(result.used_sources, result.used_urls)
+        if embed:
+            await app.discord.send_embed(msg, embed)
+```
+
+- [ ] **Step 4: Run test to verify it passes, then commit**
+
+Run: `cd Concierge && ./.venv/bin/python -m pytest tests/test_handlers.py -q`
+Expected: 3 passed.
+```bash
+git add Concierge/concierge/handlers.py Concierge/tests/test_handlers.py
+git commit -m "feat(concierge): chat_handler orchestration (placeholder -> stream -> final + sources)"
+```
+
+---
+
+## Task 11: `bot.py` — discord.py wiring + `DiscordIO`
+
+**Files:**
+- Create: `Concierge/concierge/bot.py`
+- Test: `Concierge/tests/test_bot.py`
+
+**Design:** the pure decision helpers (`should_handle`, `_strip_mention`) are unit-tested; the discord.py event wiring (`register_handlers`) and `DiscordIO` are thin and verified by the live smoke test in the README (Task 13).
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_bot.py
+from concierge.bot import should_handle, _strip_mention
+
+def test_should_handle_rules():
+    assert should_handle(author_is_bot=False, is_dm=True, mentioned=False) is True
+    assert should_handle(author_is_bot=False, is_dm=False, mentioned=True) is True
+    assert should_handle(author_is_bot=False, is_dm=False, mentioned=False) is False
+    assert should_handle(author_is_bot=True, is_dm=True, mentioned=True) is False
+
+def test_strip_mention():
+    assert _strip_mention("<@42> hello", 42).strip() == "hello"
+    assert _strip_mention("<@!42> hi", 42).strip() == "hi"
+    assert _strip_mention("no mention", 42) == "no mention"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd Concierge && ./.venv/bin/python -m pytest tests/test_bot.py -q`
+Expected: FAIL (`ModuleNotFoundError`).
+
+- [ ] **Step 3: Write implementation**
+
+```python
+# concierge/bot.py
+import contextlib
+import logging
+
+import discord
+
+from .ratelimit import QueueFullError
+from .router import InboundMessage, Router
+
+log = logging.getLogger("concierge")
+
+
+def should_handle(*, author_is_bot: bool, is_dm: bool, mentioned: bool) -> bool:
+    if author_is_bot:
+        return False
+    return is_dm or mentioned
+
+
+def _strip_mention(content: str, bot_id: int) -> str:
+    for token in (f"<@{bot_id}>", f"<@!{bot_id}>"):
+        content = content.replace(token, "")
+    return content
+
+
+class DiscordIO:
+    """Transport-thin wrapper so handlers never import discord.py types."""
+
+    def __init__(self, client: discord.Client) -> None:
+        self._client = client
+        self._channels: dict = {}   # location_id -> live channel (avoids per-reply re-resolve)
+
+    def remember_channel(self, channel) -> None:
+        self._channels[str(channel.id)] = channel
+
+    async def _channel(self, msg: InboundMessage):
+        ch = self._channels.get(msg.location_id)
+        if ch is not None:
+            return ch
+        cid = int(msg.location_id)
+        ch = self._client.get_channel(cid) or await self._client.fetch_channel(cid)
+        self._channels[msg.location_id] = ch
+        return ch
+
+    def typing(self, msg: InboundMessage):
+        # "Bot is typing…" for the stream duration; reuse the remembered live channel.
+        ch = self._channels.get(msg.location_id)
+        return ch.typing() if ch is not None else contextlib.nullcontext()
+
+    async def send(self, msg: InboundMessage, content: str):
+        ch = await self._channel(msg)
+        return await ch.send(content, allowed_mentions=discord.AllowedMentions.none())
+
+    async def edit(self, message, content: str):
+        return await message.edit(content=content,
+                                  allowed_mentions=discord.AllowedMentions.none())
+
+    async def send_followup(self, msg: InboundMessage, content: str):
+        return await self.send(msg, content)
+
+    async def send_embed(self, msg: InboundMessage, embed_dict: dict):
+        ch = await self._channel(msg)
+        return await ch.send(embed=discord.Embed.from_dict(embed_dict),
+                             allowed_mentions=discord.AllowedMentions.none())
+
+
+def register_handlers(client: discord.Client, app, router: Router, guard) -> None:
+    @client.event
+    async def on_message(message: discord.Message):
+        me = client.user
+        if me is None:                       # not logged in yet — ignore
+            return
+        is_dm = message.guild is None
+        mentioned = me in message.mentions
+        if not should_handle(author_is_bot=message.author.bot, is_dm=is_dm, mentioned=mentioned):
+            return
+        text = _strip_mention(message.content, me.id).strip()
+        if not text:
+            await message.channel.send("Ask me something \U0001f642",
+                                       allowed_mentions=discord.AllowedMentions.none())
+            return
+        app.discord.remember_channel(message.channel)   # reuse the live channel (no REST re-resolve)
+        inbound = InboundMessage(user_id=str(message.author.id),
+                                 location_id=str(message.channel.id),
+                                 text=text, is_dm=is_dm)
+        handler = router.route(inbound)
+        try:
+            await guard.run(inbound.user_id, lambda: handler(inbound, app))
+        except QueueFullError:
+            await message.channel.send("⏳ I'm still working on your previous messages — one moment.",
+                                       allowed_mentions=discord.AllowedMentions.none())
+        except discord.Forbidden:            # spec §6: missing channel perms -> react ❌
+            try:
+                await message.add_reaction("❌")
+            except discord.HTTPException:
+                log.warning("no perms to react or reply for user %s", inbound.user_id)
+        except Exception:
+            log.exception("handler failed for user %s", inbound.user_id)
+
+    @client.event
+    async def on_interaction(interaction: discord.Interaction):
+        # SEAM: future Confirm/Cancel buttons + slash commands. No-op in v1.
+        log.info("interaction received (ignored in v1): %s", getattr(interaction, "type", "?"))
+```
+
+- [ ] **Step 4: Run test to verify it passes, then commit**
+
+Run: `cd Concierge && ./.venv/bin/python -m pytest tests/test_bot.py -q`
+Expected: 2 passed.
+```bash
+git add Concierge/concierge/bot.py Concierge/tests/test_bot.py
+git commit -m "feat(concierge): discord.py wiring (on_message filter, DiscordIO, on_interaction seam)"
+```
+
+---
+
+## Task 12: `app.py` + `__main__.py` — context + entrypoint
+
+**Files:**
+- Create: `Concierge/concierge/app.py`
+- Create: `Concierge/concierge/__main__.py`
+
+- [ ] **Step 1: Write `app.py`**
+
+```python
+# concierge/app.py
+import asyncio
+import datetime as dt
+
+from .config import Config
+from .identity import IdentityStore
+from .finsearch_client import FinSearchClient
+from .session import make_session_id
+from .throttle import EditThrottle
+
+
+class AppContext:
+    """Everything chat_handler needs, injectable for tests."""
+
+    def __init__(self, cfg: Config, identity: IdentityStore,
+                 finsearch: FinSearchClient, discord_io) -> None:
+        self.cfg = cfg
+        self.identity = identity
+        self.finsearch = finsearch
+        self.discord = discord_io
+
+    def make_session(self, user_id: str, location_id: str) -> str:
+        return make_session_id(user_id, location_id)
+
+    def new_throttle(self) -> EditThrottle:
+        return EditThrottle(self.cfg.edit_interval_s, self.cfg.edit_min_chars)
+
+    def clock(self) -> float:
+        return asyncio.get_event_loop().time()
+
+    def now_iso(self) -> str:
+        return dt.datetime.now(dt.timezone.utc).isoformat()
+```
+
+- [ ] **Step 2: Write `__main__.py`**
+
+```python
+# concierge/__main__.py
+import logging
+import os
+
+import discord
+
+from .app import AppContext
+from .bot import DiscordIO, register_handlers
+from .config import load_config
+from .finsearch_client import FinSearchClient
+from .handlers import chat_handler
+from .identity import IdentityStore
+from .ratelimit import InFlightGuard
+from .router import Router
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO,
+                        format="%(asctime)s %(levelname)s %(name)s: %(message)s")
+    cfg = load_config(os.environ)
+
+    identity = IdentityStore(cfg.identity_db_path)
+    finsearch = FinSearchClient(cfg.finsearch_api_base, cfg.finsearch_api_key,
+                                cfg.request_timeout_s, cfg.default_model)
+    guard = InFlightGuard(cfg.cooldown_s, cfg.max_queue_per_user)
+    router = Router(chat_handler)
+
+    intents = discord.Intents.default()
+    # Message content is delivered ONLY for DMs + messages that @mention us (Discord
+    # platform exemption) — so we need NO privileged Message Content intent. A future
+    # NON-mentioning trigger (prefix command, history scan) would read empty content
+    # until that privileged intent is enabled.
+    intents.message_content = False
+    client = discord.Client(intents=intents)
+
+    app = AppContext(cfg, identity, finsearch, DiscordIO(client))
+    register_handlers(client, app, router, guard)
+
+    try:
+        client.run(cfg.discord_bot_token, log_handler=None)
+    finally:
+        identity.close()
+
+
+if __name__ == "__main__":
+    main()
+```
+
+- [ ] **Step 3: Verify it imports + Discord intents are correct**
+
+Run:
+```bash
+cd Concierge && ./.venv/bin/python -c "import os; os.environ['DISCORD_BOT_TOKEN']='x'; from concierge.__main__ import main; from concierge.app import AppContext; print('import ok')"
+```
+Expected: prints `import ok` (no network; we don't call `main()`).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Concierge/concierge/app.py Concierge/concierge/__main__.py
+git commit -m "feat(concierge): AppContext + entrypoint wiring (no privileged intent)"
+```
+
+---
+
+## Task 13: Runtime — systemd unit, env example, README, pytest config
+
+**Files:**
+- Create: `Concierge/systemd/concierge.service`
+- Create: `Concierge/.env.concierge.example`
+- Create: `Concierge/README.md`
+- Create: `Concierge/pytest.ini`
+
+- [ ] **Step 1: Write `Concierge/pytest.ini`** (so `pytest` finds the package + async mode)
+
+```ini
+[pytest]
+pythonpath = .
+asyncio_mode = auto
+testpaths = tests
+```
+
+- [ ] **Step 2: Write `Concierge/systemd/concierge.service`** (a `deploy`-user service)
+
+```ini
+[Unit]
+Description=Agentic FinSearch - Discord conversational chat adapter (Concierge)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=/home/deploy/fingpt/concierge
+EnvironmentFile=/home/deploy/fingpt/envs/.env.concierge
+ExecStart=/home/deploy/fingpt/concierge/.venv/bin/python -m concierge
+Restart=on-failure
+RestartSec=5
+MemoryHigh=256M
+MemoryMax=384M
+
+[Install]
+WantedBy=default.target
+```
+
+- [ ] **Step 3: Write `Concierge/.env.concierge.example`**
+
+```
+# The SAME Discord application/token as the Heartbeat bot (the Heartbeat opens no
+# Gateway connection, so one identity / two processes coexist). Enable the Gateway
+# + the two NON-privileged intents (GUILD_MESSAGES, DIRECT_MESSAGES) in the Dev Portal.
+DISCORD_BOT_TOKEN=
+
+# Co-located API container; prefer localhost over the public host.
+FINSEARCH_API_BASE=http://localhost:8000
+
+# Optional. Usually unset — the extension endpoints aren't Bearer-gated.
+# FINGPT_API_KEY=
+
+# Optional. Durable identity store (the ATL anchor). Default: data/identity.sqlite
+# CONCIERGE_IDENTITY_DB=data/identity.sqlite
+```
+
+- [ ] **Step 4: Write `Concierge/README.md`**
+
+````markdown
+# Concierge — Agentic FinSearch Discord chat adapter
+
+Interactive sibling of the News Heartbeat. A persistent `discord.py` Gateway service
+that maps free-form @mention/DM messages onto the **existing** FinSearch extension
+pipeline (`/get_chat_response_stream/`) and posts replies back. Backend is unchanged.
+
+See `Docs/superpowers/specs/2026-06-28-discord-chat-adapter-design.md`.
+
+## Develop & test
+```bash
+cd Concierge
+python3.12 -m venv .venv && ./.venv/bin/pip install -r requirements.txt
+./.venv/bin/python -m pytest -q          # all tests, no network
+```
+
+## Run locally
+```bash
+cp .env.concierge.example .env.concierge   # fill DISCORD_BOT_TOKEN
+set -a && . ./.env.concierge && set +a
+./.venv/bin/python -m concierge
+```
+
+## Live smoke (manual)
+1. Start the FinSearch backend reachable at `FINSEARCH_API_BASE`.
+2. Run the service; in Discord, DM the bot or `@mention` it in a channel: "what is AAPL's PE?"
+3. Expect a `💭 Thinking…` placeholder that streams into the answer, then a Sources embed.
+
+## Deploy (droplet, `deploy` user — manual, mirrors the Heartbeat)
+```bash
+ssh finsearch-deploy 'mkdir -p ~/fingpt/concierge ~/fingpt/envs ~/.config/systemd/user'
+rsync -a --exclude .venv --exclude data Concierge/ finsearch-deploy:/home/deploy/fingpt/concierge/
+ssh finsearch-deploy 'cd ~/fingpt/concierge && python3.12 -m venv .venv && ./.venv/bin/pip install -r requirements.txt'
+scp Concierge/.env.concierge.example finsearch-deploy:/home/deploy/fingpt/envs/.env.concierge   # then fill + chmod 600
+scp Concierge/systemd/concierge.service finsearch-deploy:/home/deploy/.config/systemd/user/
+ssh finsearch-deploy 'chmod 600 ~/fingpt/envs/.env.concierge && systemctl --user daemon-reload && systemctl --user enable --now concierge.service'
+```
+
+## Discord-side config (separate session — out of scope here)
+Same application as the Heartbeat. Enable **Gateway** + the **non-privileged**
+`GUILD_MESSAGES` and `DIRECT_MESSAGES` intents. **Do not** enable the privileged
+Message Content intent — mentions & DMs deliver content without it.
+````
+
+- [ ] **Step 5: Re-run the full suite (pytest.ini now active) + commit**
+
+Run: `cd Concierge && ./.venv/bin/python -m pytest -q`
+Expected: all tests pass (run from `Concierge/` — `pytest.ini` sets `pythonpath=.`).
+```bash
+git add Concierge/pytest.ini Concierge/systemd/concierge.service Concierge/.env.concierge.example Concierge/README.md
+git commit -m "chore(concierge): systemd unit, env example, README, pytest config"
+```
+
+---
+
+## Task 14: CI — gate `Concierge/**`
+
+**Files:**
+- Create: `.github/workflows/concierge-tests.yml`
+
+- [ ] **Step 1: Write the workflow** (mirrors `heartbeat-tests.yml` path-partitioning)
+
+```yaml
+name: concierge-tests
+on:
+  push:
+    paths: ["Concierge/**", ".github/workflows/concierge-tests.yml"]
+  pull_request:
+    paths: ["Concierge/**", ".github/workflows/concierge-tests.yml"]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: Concierge
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install -r requirements.txt
+      - run: python -m pytest -q
+```
+
+- [ ] **Step 2: Validate the workflow locally (YAML well-formed)**
+
+Run: `cd Concierge && ./.venv/bin/python -c "import yaml,sys; yaml.safe_load(open('../.github/workflows/concierge-tests.yml')); print('yaml ok')"`
+Expected: `yaml ok`. (If `yaml` isn't installed: `./.venv/bin/pip install pyyaml` first, dev-only.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/concierge-tests.yml
+git commit -m "ci(concierge): gate Concierge/** with the pytest suite"
+```
+
+---
+
+## Final verification
+
+- [ ] **Run the whole suite**
+
+Run: `cd Concierge && ./.venv/bin/python -m pytest -q`
+Expected: all tests pass (~24 across 10 files).
+
+- [ ] **Confirm no privileged intent + no backend change**
+
+Run: `cd Concierge && grep -rn "message_content" concierge/` → expect exactly `intents.message_content = False`.
+Confirm: nothing under `Main/backend/` was modified (this plan touches only `Concierge/` and `.github/workflows/`).
+
+---
+
+## Spec coverage map (self-review)
+
+| Spec section | Task(s) |
+|---|---|
+| §2 Approach A (reuse extension endpoint) | 8 (`stream_chat` → `/get_chat_response_stream/`), 12 |
+| §2 free-form @mention/DM, no privileged intent | 11 (`should_handle`, `_strip_mention`), 12 (`message_content=False`) |
+| §2 thinking-only; research deferred | 8 (`is_advanced=false`), 9 (command seam) |
+| §4 durable identity (reserved `atl_account_id`) | 3 |
+| §4 ephemeral per-location `session_id` contract | 2 |
+| §5 flow (placeholder + typing → stream → throttled edits → final + sources) | 10, 11 |
+| §6 backend-down / truncated / friendly errors; `Forbidden → ❌ react` | 8, 10, 11 |
+| §6 `allowed_mentions:none`; cost guard; 429 `Retry-After` (discord.py rate-limiter) | 11 (AllowedMentions.none), 7 (in-flight guard) |
+| §7 handler router seam; `on_interaction` skeleton | 9, 11 |
+| §8 module layout; same-token coexistence; discord.py venv | 0, 12, 13 |
+| §9 logic-first tests + recorded SSE fixture + CI gating | 1–11, 8 (fixture), 14 |
+
+**Deferred per spec (no task, intentional):** `/research` & `/strategy` slash commands, ATL MCP tools, the Confirm/Cancel *flow* (only the `on_interaction` seam exists), per-thread scoping, a Validate button. **Adaptive 429 throttle-widening** is also deferred — discord.py's built-in rate-limiter already respects `Retry-After` (the spec's core 429 requirement); only the *adaptive widening* refinement is dropped for v1.

--- a/Docs/superpowers/specs/2026-06-28-discord-chat-adapter-design.md
+++ b/Docs/superpowers/specs/2026-06-28-discord-chat-adapter-design.md
@@ -1,0 +1,186 @@
+# Discord Chat Adapter — Conversational FinSearch on Discord (reuse the extension pipeline) — Design
+
+- **Date:** 2026-06-28
+- **Status:** Approved (design); implementation plan to follow
+- **Author:** FlyMiss
+- **Scope:** v1 conversational bridge (free-form @mention/DM → thinking mode) over the **existing** FinSearch pipeline, plus the forward-compat seams for future strategy control (ATL). Discord-side application/permission/intent configuration is **out of scope** (handled in a separate session).
+- **Related:** `Heartbeat/news_heartbeat.py` (the passive feed this complements); central-db `decisions/2026-03.md` (2026-03-21 OpenClaw channel-adapter precedent); central-db `knowledge/xbrl-truth-layer-atl-forward-compat.md` (ATL bridge + `as_of` forward-compat philosophy); `2026-06-26-xbrl-truth-layer-p0p1-design`.
+
+## 1. Context & goal
+
+**Today.** Two relevant pieces exist, and they don't touch:
+
+- **News Heartbeat** (`Heartbeat/news_heartbeat.py`) — a stdlib-only, REST-only **one-way poster**. A systemd *timer* runs it daily; it fires `POST`s to Discord's REST API and exits. It opens **no** Gateway connection, so it *cannot receive messages*. This is the "passive feed" the user wants to make interactive — but this file structurally can't be, so the interactive surface is a new component.
+- **FinSearch backend** — Django REST at `agenticfinsearch.org`. The browser extension calls `/get_chat_response_stream/` (thinking, SSE) and `/get_adv_response_stream/` (research, SSE). Sessions are keyed by a client-supplied `session_id` → `UnifiedContextManager` (Django cache, **1 h TTL**) holding conversation history + fetched context. The agent entry point is `datascraper.create_agent_response()`.
+- **Strategies / portfolios** are **not** in the backend. "Control your strategies" maps to **ATL** (Agent Trading Lab — separate FastAPI+SQLite+Alpaca platform; the FinSearch→ATL bridge is forward-compat-*designed* but not built). Strategy control will arrive as the **backend agent gaining ATL MCP tools** (backtest / paper-trade / live-trade), not as logic in this adapter.
+
+**Goal of this unit.** Turn the passive feed into a chatbot users **talk to directly** on Discord, by adding a thin **ingress adapter** that maps Discord events onto the *same request contract the extension already speaks*, and posts replies back. **No second pipeline. The backend is untouched.**
+
+**Governing principle (OpenClaw precedent, 2026-03-21).** A channel adapter does *transport only*, decoupled from the executor, holding no credentials/logic — "security blast radius contained." Here: the adapter holds only a Discord token + the FinSearch API base URL (+ an optional, currently-unused API key). The agent, the model API keys, and the context manager all stay in the backend.
+
+## 2. Locked decisions (and why)
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Runtime / reuse shape | **Approach A — a separate Gateway adapter service that calls the existing extension HTTP endpoints** ("headless extension") | Only option satisfying both *free-form chat* and the *thin-decoupled-adapter* constraint. Rejected: (B) importing `datascraper` in-process (the bot would need every backend dep + the model keys → blast radius; re-implements the view layer); (C) a Django `/discord/interactions/` endpoint (slash-commands only — conflicts with free-form; 15-min follow-up window can't cover 20-min research calls). |
+| Invocation | **Free-form @mention + DM** | "Talk directly" = natural language. Gateway bot, but **no privileged Message Content intent** — Discord grants message content for @mentions and DMs without it, so no app verification. |
+| Mode routing | **Every free-form message → thinking mode** (`/get_chat_response_stream/`) | Keeps normal chat a single, fast path with zero extra user gesture. Research is deferred to a future `/research` *slash command* — no reaction/keyword hack bolted onto normal chat (explicit user call). |
+| Identity model | **Two layers: durable identity (never expires) + ephemeral conversation session (rides the 1 h cache TTL)** | A future ATL brokerage binding must be permanent; conversation context is *meant* to evaporate. Conflating them would make a broker link vanish every idle hour. Same "separate the permanent from the point-in-time" instinct as the truth-layer `as_of` work. |
+| Conversation scoping | **Per-location** — `session_id = "discord:{discord_user_id}:{location_id}"`, `location_id` = channel/DM id | A DM is one continuous thread; each channel keeps its own memory. The format is a written-down contract that also lets the backend later recover *who is acting* for ATL tool calls. |
+| Dependency posture | **Adopt `discord.py`** in its own venv on the droplet | Deliberate, documented break from the heartbeat's stdlib-only rule. A hand-rolled stdlib Gateway client (WebSocket + resume + rate-limits) is hundreds of lines of fragile protocol code; `discord.py` is the maintained standard. |
+| Bot identity | **Same Discord application/token as the heartbeat** | Discord allows one Gateway connection per bot; the heartbeat opens *none* (REST-only). So one "Agentic FinSearch" identity, two processes, no conflict — and the bot stops showing permanently offline. |
+| Backend changes | **None** | The whole point: a new ingress on the same body. |
+
+## 3. Architecture & data flow
+
+```
+  Discord  ──@mention / DM──▶  ┌──────────────────────────────────────────────┐
+                               │   Concierge — Discord Adapter Service         │
+                               │   [droplet, systemd *service*, persistent]    │
+                               │                                              │
+                               │   bot.py        Gateway client: on_message    │
+                               │                 (DM + mention; no priv intent)│
+                               │                 on_interaction (skeleton)     │
+                               │   identity.py   Layer-1 durable store ◀── SQLite
+                               │   session.py    Layer-2 session_id fmt/parse   │
+                               │   router.py     handler dispatch (chat now)    │
+                               │   ratelimit.py  per-user in-flight guard       │
+                               │   finsearch_client.py  SSE → chunks + final ──┐│
+                               │   render.py     chunks→throttled edits,       ││
+                               │                 2000-char split, sources embed││
+                               └───────────────────────────────────────────────┼┘
+                                                                               │ HTTP, same
+                                                                               │ contract as
+                                                                               ▼ the extension
+                               ┌──────────────────────────────────────────────┐
+                               │   EXISTING FinSearch backend (UNCHANGED)      │
+                               │   /get_chat_response_stream/ → datascraper    │
+                               │   agent → (future) ATL MCP tools.             │
+                               │   Holds the model keys, the agent, the cache. │
+                               └──────────────────────────────────────────────┘
+```
+
+Flow: `Discord message → resolve identity + session_id → SSE call to the extension endpoint → stream chunks back as throttled message edits → final edit with sources embed`. The adapter persists nothing beyond the Layer-1 identity record; the backend owns all conversation state.
+
+## 4. Identity & session model (two layers)
+
+**Layer 1 — durable identity (the ATL anchor).** One record per Discord user, **never expires**, stored in SQLite on the droplet:
+
+```
+identity(
+  discord_user_id  TEXT PRIMARY KEY,
+  finsearch_user_id TEXT,            -- stable id we mint on first contact
+  created_at        TEXT,            -- ISO 8601
+  atl_account_id    TEXT             -- RESERVED: NULL today, bound when ATL arrives
+)
+```
+
+`atl_account_id` is a reserved column nobody reads yet — the exact pattern as the truth layer's reserved `entity_tickers` history: write the column now, fill it later. This is the *one expensive-to-undo* seam, so it is built in v1.
+
+**Layer 2 — conversation session (the context window).** A `session_id` handed to the backend's existing endpoints, **ephemeral** (rides the backend's 1 h cache TTL → bounded memory, natural reset after idle):
+
+```
+session_id = "discord:{discord_user_id}:{location_id}"
+  location_id = DM channel id  (DMs)  |  text channel id  (guild mentions)
+```
+
+The format is a **written-down contract** doing double duty: same user + same place ⇒ continuity, *and* the backend can parse "who is acting" from the session string later when the agent calls an ATL tool. `parse_session_id()` is provided so that contract is testable from day one.
+
+## 5. Message flow (free-form chat — the v1 happy path)
+
+1. **`on_message`** — keep only (a) DMs and (b) guild messages mentioning the bot; drop the bot's own messages and other bots; strip the mention prefix to recover the raw question. Empty question → "Ask me something 🙂".
+2. **Resolve** Layer-1 identity (create on first contact) and the Layer-2 `session_id`.
+3. **In-flight guard** — if this user already has a request running, politely defer/queue (see §6); else mark in-flight.
+4. **Instant feedback** — post a `💭 Thinking…` placeholder and start the typing indicator (Gateway has no hard ack deadline; UX should feel instant).
+5. **Call the pipeline** — open an SSE connection to `/get_chat_response_stream/` with the extension's exact params: `question`, `session_id`, `models` (default `gpt-4o-mini`), `is_advanced=false`, `use_memory=true`, `current_url="https://discord.com"`, and `user_timezone`/`user_time` (default UTC / now — we don't know the user's tz).
+6. **Stream → edit** — accumulate `content` chunks; edit the placeholder on a **throttle** (~every 1.2 s or ~1500 chars) to stay under Discord's ~5-edits / 5 s / channel ceiling.
+7. **Finish** — on the `done:true` frame, final-edit with the complete answer split into ≤2000-char messages on word boundaries; render `used_sources` / `used_urls` as a compact embed (reuse the heartbeat's escape/embed helpers). `has_axiom_claims:true` is reserved to later attach a "Validate" button (a seam, not built).
+8. **Release** the in-flight guard.
+
+**Concurrency.** Each request runs as its own `asyncio` task so the Gateway heartbeat never blocks (research can run ~20 min). The per-user in-flight guard prevents spam and context races on the shared per-location session.
+
+## 6. Error handling, resilience & safety
+
+| Failure | Handling |
+|---|---|
+| Backend down / 5xx / restart (deploys bounce the API) | Edit placeholder → `⚠️ Couldn't reach FinSearch, try again in a moment.` Bot stays up. Client read timeout ~1260 s (just above the backend's 1200 s gunicorn ceiling). |
+| SSE drops mid-stream (no `done`) | Finalize with the partial text + a `(response cut off)` marker rather than losing it. |
+| Discord **429** on edits | Respect `Retry-After`, widen the edit throttle — reuse the heartbeat's backoff logic. |
+| Missing channel perms (`Forbidden`) | React ❌ on the user's message, or fall back to DM. |
+| Gateway disconnect | `discord.py` auto-resumes; an in-flight reply that fails to post just logs. |
+| Crash | systemd `Restart=on-failure`; the on-disk identity store survives; in-flight requests are lost (acceptable — user re-asks). |
+| Second request while one is in flight | In-flight guard: queue (preferred) or politely reject with a one-line notice. |
+
+**Safety (reusing the heartbeat's hardening):**
+- Every reply sets `allowed_mentions:{parse:[]}` so the bot cannot be weaponized to mass-ping `@everyone`.
+- Output escaping reuses the heartbeat's helpers; user text is passed only as the `question` param (the agent already handles arbitrary web input — no new injection surface the backend doesn't already own).
+- The adapter holds **no model keys** → a compromised bot cannot drain OpenAI/Anthropic credits (OpenClaw blast-radius containment).
+- **Cost/abuse:** the per-user in-flight guard + a simple per-user cooldown. Token burn is a known project issue, so this knob is first-class.
+
+## 7. Forward-compat seams (build now / write down now / defer)
+
+| Seam | v1 action | Why |
+|---|---|---|
+| **Durable identity (Layer 1)** | **Build now** | Only expensive-to-undo thing; a future ATL account binds here. |
+| **Parseable `session_id` contract** | **Write down now** (`make/parse_session_id`) | Backend can recover "who is acting" for ATL tool calls later — a contract, not early code. |
+| **Handler router** (dispatch) | **Build now (thin)** | `/research`, `/strategy` slot in additively; the abstraction costs ~nothing. |
+| **Interactive Confirm/Cancel buttons** | **Skeleton + documented contract, not built** | Money-touching ATL actions need a human-in-the-loop confirm. Wire an empty `on_interaction` and write down the flow: *agent emits a "needs confirmation" payload → adapter renders buttons → click sends a confirmation back to the agent*. |
+| **ATL MCP layer** (backtest / paper / live tools) | **Out of scope** | Backend concern. The agent *gains tools*; the adapter never changes. |
+| `/research`, `/strategy` slash commands | **Out of scope (declared)** | Additive later, no spine change. |
+
+**Punchline:** strategy control = the backend agent + ATL MCP tools. The adapter stays pure transport; the *only* strategy-related work it will ever need is identity (built now) and a confirmation UI (skeletoned now).
+
+## 8. Module layout & runtime
+
+```
+Concierge/                         (name TBD — interactive counterpart to Heartbeat/)
+  bot.py               discord.py client; on_message (DM+mention), on_interaction skeleton; wiring
+  identity.py          Layer-1 durable store (SQLite): resolve_user(discord_id) -> finsearch_user_id
+  session.py           Layer-2: make_session_id(discord_id, location_id) / parse_session_id(s)
+  router.py            handler dispatch (chat now; /research, /strategy declared) — the seam
+  finsearch_client.py  async SSE client → yields content chunks + the final {sources, urls, ...}
+  render.py            chunk_2000(text), sources_embed(...), throttle policy, escaping (reuse heartbeat helpers)
+  ratelimit.py         per-user in-flight guard + cooldown
+  config.py            env loading: DISCORD_BOT_TOKEN, FINSEARCH_API_BASE, FINGPT_API_KEY (optional)
+  data/                identity.sqlite (gitignored)
+  tests/               pure-logic units + recorded SSE fixtures
+  systemd/concierge.service
+  .env.concierge.example
+  README.md
+```
+
+**Runtime:** systemd **service** (not a timer) — `Restart=on-failure`, `MemoryHigh≈256M` (discord.py needs more headroom than the heartbeat's 96 M), runs as `deploy`, own venv. Env file mode 600 at `/home/deploy/fingpt/envs/.env.concierge`. `FINSEARCH_API_BASE` prefers `localhost`/the co-located API container over the public host. `FINGPT_API_KEY` is optional/reserved (the extension endpoints aren't Bearer-gated; the adapter calls them exactly as the extension does).
+
+**Discord-side (out of scope, documented for the other session):** enable the Gateway + the two *non-privileged* intents `GUILD_MESSAGES` and `DIRECT_MESSAGES` on the existing application; keep the heartbeat's REST-only flow as-is.
+
+## 9. Testing strategy
+
+Keep the bulk **logic-first, transport-thin** so it is fast pure-Python:
+
+- **Unit (no network):** identity resolution + first-contact creation; `session_id` format/parse round-trip; 2000-char word-boundary chunking; mention-stripping; the edit-throttle policy; the in-flight guard / cooldown; sources→embed rendering; `allowed_mentions` invariant. Mirrors the heartbeat's ~50 stdlib tests.
+- **SSE client:** test `finsearch_client.py` against **recorded real frames** captured from `/get_chat_response_stream/` (the way the heartbeat captured live RSS fixtures) — including the partial-stream / no-`done` case.
+- **Handlers:** `discord.py` `on_message` via mocked `Message` objects (DM, mention, bot-self, empty).
+- **CI:** a new workflow gating the `Concierge/**` path, `paths`-partitioned from the API pipeline like `heartbeat-tests.yml`.
+
+## 10. Out of scope / deferred
+
+- Discord application/permission/intent configuration (separate session).
+- `/research` and `/strategy` slash commands (declared seams only).
+- The ATL MCP layer and any trade/backtest/paper-trade logic.
+- The interactive confirmation *flow* (skeleton + contract only).
+- A "Validate" button on claim-bearing answers (`has_axiom_claims` reserved).
+- Discord-thread-scoped conversations (per-thread scoping — a possible later UX upgrade over per-location).
+
+## 11. Open items (defaults chosen; override on review)
+
+- **Service directory name** — proposed `Concierge/` (the one that serves users, vs `Heartbeat/` the passive pulse). Alternatives: `DiscordBot/`, `ChatBridge/`.
+- **Per-user rate-limit defaults** — proposed: 1 in-flight request + a short cooldown (e.g. a few seconds); tune against observed token burn.
+- **In-flight collision behavior** — proposed: *queue* the second request (vs. reject with a notice).
+
+## 12. Implementation decision points (hands-on)
+
+Spots where the meaningful logic — business rules with multiple valid approaches — is best authored by hand rather than scaffolded, and is small (~5–10 lines each):
+
+- **`ratelimit.py` — the in-flight guard / cooldown policy** (queue vs. reject; cooldown window; per-user vs. global). A UX-vs-cost trade-off.
+- **`render.py` — the streaming edit-throttle policy** (flush cadence vs. Discord's edit rate-limit; how to batch). A responsiveness-vs-rate-limit trade-off.
+- **`router.py` — the dispatch shape** (how chat / future `/research` / `/strategy` are selected) — the abstraction that determines how cheaply later commands slot in.


### PR DESCRIPTION
## Summary

Adds **Concierge** — a thin, persistent `discord.py` Gateway service that turns the passive News Heartbeat into an interactive chatbot. It maps free-form **@mention / DM** messages onto the **existing** FinSearch extension pipeline (`/get_chat_response_stream/`) and streams replies back. **The backend is untouched** (Approach A from the design spec).

- **Transport-thin:** a `chat_handler` orchestrates through a tiny `DiscordIO` interface + an injected `AppContext`, so almost all logic is unit-testable with fakes (no Gateway, no network).
- **No privileged Message Content intent** — Discord delivers content for @mentions and DMs without it.
- **Same bot identity as the Heartbeat** (which is REST-only and opens no Gateway), so one application / two processes / no conflict — and the bot stops showing permanently offline.
- **Two-layer identity:** a durable SQLite record (with the reserved `atl_account_id` ATL anchor) + an ephemeral per-location `session_id` riding the backend's 1 h cache TTL.
- **Forward-compat seams, built thin:** a handler router (so `/research`, `/strategy` slot in additively) and an `on_interaction` skeleton for the future Confirm/Cancel flow.

## What's here

- `Concierge/concierge/` — `config`, `session`, `identity`, `render`, `throttle`, `ratelimit`, `finsearch_client` (SSE), `router`, `handlers`, `bot` (discord.py wiring), `app`, `__main__`.
- `Concierge/tests/` — **50 tests, logic-first / no network** (recorded SSE fixture + injected fakes).
- `Concierge/systemd/concierge.service`, `.env.concierge.example`, `README.md`, `pytest.ini`.
- `.github/workflows/concierge-tests.yml` — gates `Concierge/**` (mirrors `heartbeat-tests.yml`).
- `Docs/superpowers/{specs,plans}/2026-06-28-discord-chat-adapter*` — the design spec + TDD plan this implements.

## Test plan

- [x] `cd Concierge && ./.venv/bin/python -m pytest -q` → **50 passed** (Python 3.12)
- [x] No privileged intent: `grep -rn message_content concierge/` → exactly `intents.message_content = False`
- [x] Backend untouched: zero tracked changes under `Main/backend/`
- [ ] **Live smoke (manual)** — needs the FinSearch backend reachable + the Discord token: DM or @mention the bot → `💭 Thinking…` placeholder streams into the answer → Sources embed. Re-capture `tests/fixtures/sse_chat_stream.txt` from a live call at this point.

## Self-review (3 adversarial rounds; every finding addressed in-branch)

Round 1 raised 13 → **7 confirmed & fixed**, 5 rejected as speculative/style-only. Notable:
- **Backend in-band error frame** (`{"error":…,"done":true}` arrives over an already-200 stream, so `raise_for_status` can't see it) was silently swallowed — a *truncated* answer rendered as *complete*. Now surfaced + forced-truncated.
- A mid-stream transport drop discarded the partial answer (spec §6 wants it kept). Recovery now lives in the SSE client; the partial is finalized as truncated.
- Unbounded `_users` in the in-flight guard; an empty-chunk Discord 400 on whitespace boundaries; the aiohttp session never closed on shutdown; the whole `on_message` dispatch path untested.

Round 2 caught **2 majors in those very fixes**: the `_users` eviction was *dead* for the production `cooldown_s=3.0` (the test passed only because it used `0.0`); the partial-recovery over-caught `Exception`, masking real bugs. Both corrected — transport-drop recovery moved into the transport layer (handler stays transport-agnostic and re-raises unexpected errors), eviction rewritten as a cooldown-correct sweep. Round 3: **clean**.

## Deferred (by design, per spec §7/§10)

`/research` & `/strategy` slash commands, the ATL MCP tools, the Confirm/Cancel *flow* (only the `on_interaction` seam exists), per-thread scoping, a Validate button, and adaptive 429 throttle-widening (discord.py's rate-limiter already honors `Retry-After`). **Discord-side application/intent configuration is a separate session.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
