### PR TITLE
ci: harden all deploy workflows (SHA-pin, centralize droplet coords, scope backend trigger)

### DIFF
--- a/.github/workflows/backend-deploy.yml
+++ b/.github/workflows/backend-deploy.yml
@@ -4,21 +4,24 @@ on:
   push:
     branches:
       - main
-    # Heartbeat and docs changes don't feed the backend image, so skip the
-    # rebuild/restart for them. Heartbeat merges run heartbeat-tests.yml
-    # (tests + script deploy) instead; docs-only merges run nothing.
-    paths-ignore:
-      - "Heartbeat/**"
-      - "Docs/**"
-      - ".github/workflows/heartbeat-tests.yml"
+    # Allowlist the backend image's actual inputs so unrelated changes (heartbeat, docs,
+    # the other deploy workflows) can't rebuild/restart the backend. The image is built
+    # solely from Main/backend/ (Dockerfile + that build context); the workflow file is
+    # included so its own edits still ship. Previously a broad paths-ignore let any
+    # non-heartbeat/docs change (e.g. a concierge workflow edit) bounce the backend.
+    paths:
+      - "Main/backend/**"
+      - ".github/workflows/backend-deploy.yml"
   workflow_dispatch:
 
 env:
   BACKEND_DIR: Main/backend
   PYTHON_VERSION: "3.12"
   REGISTRY: ghcr.io
-  DROPLET_HOST: agenticfinsearch.org
-  DROPLET_USER: deploy
+  # Shared droplet coordinates as repo-level Actions variables (see heartbeat/concierge),
+  # so a host/user change is one repo setting, not an edit across three workflows.
+  DROPLET_HOST: ${{ vars.DROPLET_HOST }}
+  DROPLET_USER: ${{ vars.DROPLET_USER }}
   SYSTEMD_UNIT: fingpt-api
   RUN_TESTS: "false" # Toggle to "true" to re-enable backend tests
 
@@ -145,7 +148,7 @@ jobs:
 
       - name: Deploy to Fedora droplet
         if: ${{ steps.deploy-gate.outputs.enabled == 'true' }}
-        uses: appleboy/ssh-action@v0.1.10
+        uses: appleboy/ssh-action@334f9259f2f8eb3376d33fa4c684fff373f2c2a6  # v0.1.10, SHA-pinned (holds the prod SSH key)
         env:
           REMOTE_IMAGE: ${{ needs.build.outputs.main_tag }}
           GHCR_USERNAME: ${{ github.repository_owner }}
@@ -177,7 +180,7 @@ jobs:
 
       - name: Verify deployment health
         if: ${{ steps.deploy-gate.outputs.enabled == 'true' }}
-        uses: appleboy/ssh-action@v0.1.10
+        uses: appleboy/ssh-action@334f9259f2f8eb3376d33fa4c684fff373f2c2a6  # v0.1.10, SHA-pinned (holds the prod SSH key)
         with:
           host: ${{ env.DROPLET_HOST }}
           username: ${{ env.DROPLET_USER }}

--- a/.github/workflows/concierge-tests.yml
+++ b/.github/workflows/concierge-tests.yml
@@ -7,8 +7,10 @@ on:
   workflow_dispatch:
 
 env:
-  DROPLET_HOST: agenticfinsearch.org
-  DROPLET_USER: deploy
+  # Shared droplet coordinates as repo-level Actions variables (see heartbeat/backend),
+  # so a host/user change is one repo setting, not an edit across three workflows.
+  DROPLET_HOST: ${{ vars.DROPLET_HOST }}
+  DROPLET_USER: ${{ vars.DROPLET_USER }}
   CONCIERGE_HOME: /home/deploy/fingpt/concierge
 
 jobs:

--- a/.github/workflows/heartbeat-tests.yml
+++ b/.github/workflows/heartbeat-tests.yml
@@ -14,8 +14,10 @@ on:
   workflow_dispatch:
 
 env:
-  DROPLET_HOST: agenticfinsearch.org
-  DROPLET_USER: deploy
+  # Shared droplet coordinates as repo-level Actions variables (see backend/concierge),
+  # so a host/user change is one repo setting, not an edit across three workflows.
+  DROPLET_HOST: ${{ vars.DROPLET_HOST }}
+  DROPLET_USER: ${{ vars.DROPLET_USER }}
   HEARTBEAT_HOME: /home/deploy/fingpt/heartbeat
 
 jobs:
@@ -77,7 +79,7 @@ jobs:
       # managed — see "Deploy" in Heartbeat/README.md.
       - name: Deploy heartbeat script to droplet
         if: ${{ steps.deploy-gate.outputs.enabled == 'true' }}
-        uses: appleboy/ssh-action@v0.1.10
+        uses: appleboy/ssh-action@334f9259f2f8eb3376d33fa4c684fff373f2c2a6  # v0.1.10, SHA-pinned (holds the prod SSH key)
         env:
           REPO: ${{ github.repository }}
           COMMIT_SHA: ${{ github.sha }}


### PR DESCRIPTION
## What

Cross-workflow follow-up to #311. Applies the concierge hardening across **all three** deploy workflows (heartbeat, backend, concierge) so the family is consistent.

### 1. SHA-pin `appleboy/ssh-action`
Pinned to `334f9259f2f8eb3376d33fa4c684fff373f2c2a6` (== `v0.1.10`, verified via the GitHub API) in **heartbeat** (1 step) and **backend** (2 steps). Concierge was pinned in #311. The action receives the prod SSH deploy key, so a moved/compromised floating tag must not be able to redirect it.

### 2. Centralize droplet coordinates → repo `vars.*`
`DROPLET_HOST` / `DROPLET_USER` were hardcoded identically in all three workflows. Now sourced from repo-level Actions variables, so a host/user change is one repo setting instead of three file edits. **The repo variables are already created** (`DROPLET_HOST=agenticfinsearch.org`, `DROPLET_USER=deploy`) — verified present, so deploys won't see an empty host.

### 3. Scope backend's trigger (the one behavior change — please eyeball)
`backend-deploy.yml` used a broad `paths-ignore` denylist that only excluded heartbeat/docs — so **any** other change (e.g. a concierge workflow edit, or merging #311) incidentally rebuilt/restarted the backend. Switched to a precise `paths` **allowlist**:
```yaml
paths:
  - "Main/backend/**"
  - ".github/workflows/backend-deploy.yml"
```
This is provably complete: the image is built from the `Main/backend` Docker build context, and Docker can only read files inside its context — so nothing outside `Main/backend/` can feed the image. The workflow file is included so its own edits still ship.

## Blast radius on merge
Merging redeploys all three services **once** (each deploy workflow lists itself in its triggers), each an idempotent re-pin/restart of unchanged code. Droplet env files are untouched.

## Out of scope
The shared deploy scaffolding (the `deploy-gate` step + ssh-action wiring) is still duplicated across the three workflows; a composite action could factor it out, but that's a larger refactor deferred until it clearly pays off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)