### PR TITLE
fix(concierge): send X-Forwarded-Proto so the bot can reach the backend

### DIFF
--- a/Concierge/concierge/finsearch_client.py
+++ b/Concierge/concierge/finsearch_client.py
@@ -93,7 +93,14 @@ class FinSearchClient:
 
     async def _ensure_session(self) -> aiohttp.ClientSession:
         if self._session is None or self._session.closed:
-            headers = {"Authorization": f"Bearer {self._api_key}"} if self._api_key else {}
+            # FINSEARCH_API_BASE points at the co-located backend over a plain-HTTP loopback, but
+            # the backend (Django SECURE_SSL_REDIRECT) 301-redirects any request it doesn't deem
+            # secure. The edge proxy stamps X-Forwarded-Proto for browser traffic; we present it
+            # too so this direct loopback call is treated as already-HTTPS and served — not bounced
+            # into an https:// redirect that would strand us in a doomed TLS handshake.
+            headers = {"X-Forwarded-Proto": "https"}
+            if self._api_key:
+                headers["Authorization"] = f"Bearer {self._api_key}"
             self._session = aiohttp.ClientSession(timeout=self._timeout, headers=headers)
         return self._session
 
@@ -110,8 +117,15 @@ class FinSearchClient:
         session = await self._ensure_session()
         acc, done, final = [], False, {}
         try:
-            async with session.get(url) as resp:
+            # allow_redirects=False: we already assert HTTPS via the X-Forwarded-Proto header, so a
+            # 3xx here means the backend is misrouting this client. Following it (e.g. http->https on
+            # a plain-HTTP port) strands us in a ~60s TLS handshake before it aborts — refuse it and
+            # fail fast into the friendly error instead.
+            async with session.get(url, allow_redirects=False) as resp:
                 resp.raise_for_status()
+                if resp.status >= 300:
+                    raise aiohttp.ClientError(
+                        f"unexpected {resp.status} redirect to {resp.headers.get('Location')!r}")
                 # INVARIANT: resp.content yields ONE line per iteration (aiohttp readline),
                 # so each iter_sse_data() sees a single SSE event and the break-on-done below
                 # cannot strand a sibling content frame. Do NOT switch to iter_chunked()/iter_any()

--- a/Concierge/tests/test_finsearch_client.py
+++ b/Concierge/tests/test_finsearch_client.py
@@ -86,7 +86,8 @@ class _FakeContent:
 
 
 class _FakeResp:
-    def __init__(self, content): self.content = content
+    def __init__(self, content, status=200, headers=None):
+        self.content = content; self.status = status; self.headers = headers or {}
     def raise_for_status(self): pass
 
 
@@ -98,7 +99,7 @@ class _FakeGetCtx:
 
 class _FakeSession:
     def __init__(self, resp): self._resp = resp; self.closed = False
-    def get(self, url): return _FakeGetCtx(self._resp)
+    def get(self, url, **kwargs): return _FakeGetCtx(self._resp)
     async def close(self): self.closed = True
 
 
@@ -171,3 +172,30 @@ async def test_stream_chat_unwraps_span_markup_in_fallback():
     assert isinstance(out[-1], ChatResult)
     assert "<span" not in out[-1].text
     assert out[-1].text == "Net margin 12.3%"
+
+
+@pytest.mark.asyncio
+async def test_session_presents_x_forwarded_proto_header():
+    # The co-located backend force-redirects HTTP->HTTPS unless the request looks already-secure,
+    # so the client must present X-Forwarded-Proto: https on its plain-HTTP loopback call. The
+    # optional Bearer key, when set, must still be sent alongside it.
+    client = FinSearchClient("http://x", "k", 1.0, "m")
+    try:
+        session = await client._ensure_session()
+        assert session.headers.get("X-Forwarded-Proto") == "https"
+        assert session.headers.get("Authorization") == "Bearer k"
+    finally:
+        await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_stream_chat_refuses_redirect_and_reraises():
+    # With allow_redirects=False a 3xx (e.g. Django's SSL redirect to https on our plain-HTTP
+    # loopback call) must fail fast as a ClientError — never be followed into a hanging TLS
+    # handshake. Nothing streamed, so it re-raises and the handler shows the friendly error.
+    resp = _FakeResp(_FakeContent([]), status=301,
+                     headers={"Location": "https://localhost:8000/x"})
+    client = FinSearchClient("http://x", None, 1.0, "m")
+    client._session = _FakeSession(resp)
+    with pytest.raises(aiohttp.ClientError):
+        await _drain(client)


### PR DESCRIPTION
## What was broken

Every Concierge chat message failed with **⚠️ Couldn't reach FinSearch**. Root-caused from the live droplet:

- The bot calls the co-located backend over plain-HTTP loopback (`FINSEARCH_API_BASE=http://localhost:8000`).
- Django's `SECURE_SSL_REDIRECT=True` **301-redirects** any request it doesn't consider secure. `/get_chat_response_stream/` is **not** in `SECURE_REDIRECT_EXEMPT` (only `/health/` is — which is why the healthcheck stayed green and masked this).
- aiohttp **followed** the `301 → https://localhost:8000/...`, attempted a TLS handshake against plain-HTTP gunicorn, **hung the full 60s**, then raised `ClientConnectorError` → no partial → `_ERR`.

Backend log at the moment of failure:
```
"GET /get_chat_response_stream/?question=..." 301 0 "Python/3.13 aiohttp/3.14.1"
```
The backend was healthy (200 on `/health/`); this was **not** a restart blip — it fails deterministically for every message.

## The fix (bot-only)

1. Present **`X-Forwarded-Proto: https`** on the client session — the same header Caddy stamps for browser traffic — so Django (`SECURE_PROXY_SSL_HEADER`) treats the loopback call as already-HTTPS and serves `200` instead of redirecting. Safe: gunicorn binds `127.0.0.1:8000`, so there's no external path to forge the header.
2. Set **`allow_redirects=False`** and **fail fast on any 3xx**, so a future redirect surfaces as an instant friendly error rather than a 60s hang.

Backend and web client are untouched. (The broader posture review — the endpoint being publicly routed + unauthenticated — is deferred to its own session.)

## Tests
- Added `test_session_presents_x_forwarded_proto_header` and `test_stream_chat_refuses_redirect_and_reraises`.
- Full suite green locally (72 passed). CI runs the 3.12/3.13 matrix (3.13 = droplet parity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)