### PR TITLE
fix(tests): make test_ratelimit_429 hermetic re: SECURE_SSL_REDIRECT (unblocks stuck deploy)

### DIFF
--- a/Main/backend/tests/test_ratelimit_429.py
+++ b/Main/backend/tests/test_ratelimit_429.py
@@ -41,6 +41,13 @@ RL_429 = override_settings(
     # Bare pytest (no Django test runner) never calls setup_test_environment(), so 'testserver'
     # is not auto-added to ALLOWED_HOSTS; add it or CommonMiddleware raises DisallowedHost first.
     ALLOWED_HOSTS=["testserver"],
+    # These tests drive a REAL request through the full middleware stack, which includes
+    # SecurityMiddleware. With DEBUG=False (CI runs with no .env, so DJANGO_DEBUG is unset)
+    # SECURE_SSL_REDIRECT defaults True, and SecurityMiddleware 301-redirects the plain-HTTP
+    # test-client request to https BEFORE it reaches the limited view -- so the assertions below
+    # would see 301 instead of 200/429. Pin it off to keep the suite hermetic (independent of
+    # DEBUG / a local .env). We're exercising the rate-limit wiring, not the SSL redirect.
+    SECURE_SSL_REDIRECT=False,
     CACHES={
         "default": {
             "BACKEND": "django.core.cache.backends.locmem.LocMemCache",


### PR DESCRIPTION
## Why this is urgent

The backend **deploy job is gated on the `test` job**, and `test` has been **red on `main` since `56999f6` (2026-06-30)**. As a result the last two Backend runs — `f420c28` and **`ebfafac` (PR #316, the CIDR `TRUSTED_PROXIES` SNAT fix)** — failed at `test` and **skipped deploy**. The 2026-06-30 security batch (PR #316 + the ultrareview hardening) merged to `main` but **never reached the droplet**. Last green Backend run: `b2558f2` (2026-06-29).

## Root cause

`Ratelimit429Tests` drives real requests through the full middleware stack via the test client. CI runs from a fresh checkout with **no `.env`**, so `DJANGO_DEBUG` is unset → `DEBUG=False` → `SECURE_SSL_REDIRECT` defaults `True`. `SecurityMiddleware` then **301-redirects** the plain-HTTP test request to https before it reaches the limited view, so the suite sees `301` instead of `200`/`429`:

```
test_rate_limited_request_returns_429_with_retry_after      AssertionError: 301 != 200
test_distinct_identities_are_not_collaterally_limited       AssertionError: 301 != 429
```

Locally the tests pass only because the dev checkout has a `.env` with `DJANGO_DEBUG=True`. `test_ratelimit_enforced` was never affected — it uses `RequestFactory`, bypassing `SecurityMiddleware`.

## Fix

Pin `SECURE_SSL_REDIRECT=False` in the `RL_429` `override_settings` so the suite is **hermetic** — independent of `DEBUG` / a local `.env`. The suite exercises the rate-limit wiring, not the SSL redirect. Test-only change; no production code touched.

## Verification

Under CI-exact conditions (fresh worktree, **no `.env`**, `DJANGO_DEBUG` unset):

```
$ env -u DJANGO_DEBUG uv run pytest tests/test_ratelimit_429.py -q
3 passed
```

## Impact of merging

Turns `main`'s `test` job green → the `deploy` job runs → the droplet finally receives PR #316 and the rest of the 2026-06-30 security batch. Please confirm you're ready for that deploy before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)