### PR TITLE
fix(research): close streaming synthesis via aclose()-or-close() (unblocks deploy)

### DIFF
--- a/Main/backend/datascraper/research_engine.py
+++ b/Main/backend/datascraper/research_engine.py
@@ -461,7 +461,18 @@ class Synthesizer:
                     if delta.content:
                         yield delta.content
             finally:
-                await stream.close()
+                # Release the stream. OpenAI's AsyncStream exposes close(); a raw async
+                # generator (e.g. a test's mock stream) exposes aclose() instead. Prefer
+                # aclose() when present, else close() -- the real SDK object has no aclose,
+                # so production still calls close() exactly as before. Best-effort: a cleanup
+                # failure must not bubble up and wrongly trigger the non-streaming fallback,
+                # since every token already streamed successfully.
+                closer = getattr(stream, "aclose", None) or getattr(stream, "close", None)
+                if closer is not None:
+                    try:
+                        await closer()
+                    except Exception:  # noqa: BLE001 -- cleanup is best-effort
+                        pass
         except Exception as exc:
             logger.warning(f"[RESEARCH] Streaming synthesis failed, falling back: {exc}")
             response = await _call_synthesis(messages=messages, model=self.model)


### PR DESCRIPTION
## Why

`#317` fixed 2 of the **5** tests that were failing the backend-deploy `test` job on `main`. The other **3** are still red, so the deploy pipeline remains blocked (prod is still on pre-2026-06-30 code, missing the security batch incl. `#316`):

```
FAILED tests/test_research_engine.py::test_streaming_status_event_format
FAILED tests/test_research_engine.py::test_streaming_phases_in_order
FAILED tests/test_research_engine.py::test_streaming_sources_before_synthesis
  RuntimeError: OPENAI_API_KEY not set; research engine unavailable.
```

## Root cause

`Synthesizer.synthesize_streaming` did `await stream.close()` in its `finally`. The real OpenAI `AsyncStream` exposes `close()`, but a **raw async generator** (what the streaming tests mock `_call_synthesis_streaming` with) exposes `aclose()` instead:

| object | `close()` | `aclose()` |
|---|---|---|
| `openai.AsyncStream` (prod, v2.20.0) | ✅ | ❌ |
| raw async generator (test mock) | ❌ | ✅ |

So the mock raised `AttributeError` → it propagated out → tripped the non-streaming fallback → the fallback needs `OPENAI_API_KEY` (absent in CI) → `RuntimeError`. The `backend-deploy` `test` job only runs on **push to `main`** (not PRs), so this was invisible on PR checks.

## Fix

Prefer `aclose()` when present, else `close()`, and make cleanup **best-effort** so a close failure can't discard an already-fully-streamed response. The real SDK object has **no** `aclose`, so **production still calls `close()` exactly as before** — zero behavior change in prod; the test's mock now closes cleanly and never touches the fallback.

## Verification (CI-exact env: no `.env`, `DJANGO_DEBUG` unset, `OPENAI_API_KEY` unset)

- The 3 streaming tests + `test_ratelimit_429`: **20 passed**
- Full suite (`pytest tests -q`, the deploy gate): **458 passed, 1 skipped**

This is the **last** gate. Merging turns `main` green → deploy pipeline ships the stuck 2026-06-30 security batch (incl. `#316`). `#318` (truthlayer) can then merge without hitting the same wall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)