### PR TITLE
fix(truthlayer): make /app/truthlayer/data writable by the non-root runtime user (restore prod)

### DIFF
--- a/Main/backend/Dockerfile
+++ b/Main/backend/Dockerfile
@@ -41,7 +41,7 @@ COPY . .
 
 RUN sed -i 's/\r$//' /app/entrypoint.sh && chmod +x /app/entrypoint.sh
 
-RUN mkdir -p /app/staticfiles /app/media /app/logs /tmp/fingpt_cache
+RUN mkdir -p /app/staticfiles /app/media /app/logs /tmp/fingpt_cache /app/truthlayer/data
 
 RUN ln -sf /ms-playwright/chromium_headless_shell-*/chrome-headless-shell-linux64/chrome-headless-shell /usr/bin/chromium-bundled
 
@@ -54,9 +54,16 @@ RUN echo "Verifying Playwright browsers..." && \
 # Create a non-root runtime user and own ONLY the writable runtime dirs.
 # The application source under /app stays root-owned so a compromised
 # process cannot rewrite code at runtime (P0 Root A.3: no-write-under-/app).
+# /app/truthlayer/data is the one deliberate exception: entrypoint.sh builds the
+# DuckDB truth-layer store there at startup (from the root-owned, still-read-only
+# vendored companyfacts JSON) BEFORE gunicorn forks. That build runs as `fingpt`,
+# so the directory must be fingpt-writable -- otherwise duckdb.connect() aborts with
+# "Permission denied" and the container exits 1. Only the regenerable .duckdb artifact
+# is written here; no application code (.py) becomes writable, so the no-write-under-
+# /app code-integrity intent is preserved.
 RUN groupadd --system --gid 1001 fingpt \
     && useradd --system --uid 1001 --gid fingpt --no-create-home fingpt \
-    && chown -R fingpt:fingpt /app/staticfiles /app/media /app/logs /tmp/fingpt_cache
+    && chown -R fingpt:fingpt /app/staticfiles /app/media /app/logs /tmp/fingpt_cache /app/truthlayer/data
 
 USER fingpt
 


### PR DESCRIPTION
## Incident
The #318 (truthlayer) deploy **failed its health check and took prod down**. `fingpt-api.service` is `failed`; the `--replace` restart already removed the previously-healthy container.

**Root cause** (from the droplet journal in the failed deploy log):
```
File "/app/truthlayer/store.py", line 110, in connect
    con = duckdb.connect(str(db_path), read_only=read_only)
_duckdb.IOException: IO Error: Cannot open file "/app/truthlayer/data/truthlayer.duckdb": Permission denied
ERROR: failed to build truth-layer store
fingpt-api.service: Main process exited, code=exited, status=1/FAILURE
```
`entrypoint.sh` builds the DuckDB truth-layer store into `/app/truthlayer/data` at startup (before gunicorn forks). The container runs as non-root `fingpt`, but that dir is root-owned (P0 `no-write-under-/app`), so the build's `duckdb.connect(read_only=False)` aborts with *Permission denied* → container exits 1 → crash-loop.

## Fix
Add `/app/truthlayer/data` to the `mkdir` + `chown -R fingpt:fingpt` of writable runtime dirs (alongside `staticfiles/media/logs/cache`). Only the **regenerable `.duckdb` artifact** is written there; the vendored `companyfacts/*.json` and all application `.py` stay root-owned, so the *code-integrity* intent of `no-write-under-/app` is preserved (documented inline).

## Why CI didn't catch it
The backend `test` job runs as **root** in the build container, so the non-root permission boundary that exists in the deployed container never applies there. This surfaces only on the droplet deploy's health check.

## Verification
- `.dockerignore` keeps the vendored `companyfacts/*.json` (excludes only `truthlayer.duckdb`/`.wal`/`.building-*`), so `build_from_vendored()` has its offline input in-image — no SEC network.
- Store build logic already proven green in the backend suite (458 passed) on the merged branch; the only prod gap was this write permission, which the chown deterministically closes.

Restores prod **with truthlayer intact**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)