### PR TITLE
fix(deploy): widen health-check window past the truth-layer cold start (restore prod)

### DIFF
--- a/.github/workflows/backend-deploy.yml
+++ b/.github/workflows/backend-deploy.yml
@@ -220,20 +220,28 @@ jobs:
               exit 1
             }
 
-            echo "Waiting 30s for service to start..."
-            sleep 30
+            # Cold start is dominated by entrypoint.sh building the XBRL truth-layer
+            # DuckDB store BEFORE gunicorn forks (~45s observed), on top of collectstatic
+            # + Playwright verification. `systemctl is-active` only proves the container
+            # launched, not that gunicorn is listening -- so poll /health/ across a window
+            # comfortably above the measured cold start (~130s) instead of a fixed ~45s
+            # wait, which raced the store build and failed the deploy even though the
+            # container was healthy. Succeeds as soon as the endpoint answers.
+            echo "Waiting 10s before first health probe..."
+            sleep 10
 
-            echo "Checking health endpoint..."
-            for i in 1 2 3; do
+            echo "Checking health endpoint (up to ~130s for cold start)..."
+            for i in $(seq 1 24); do
               if curl -sf -m 10 http://localhost:8000/health/; then
                 echo ""
-                echo "Deployment verification successful!"
+                echo "Deployment verification successful (attempt $i)!"
                 exit 0
               fi
-              echo "Attempt $i/3 failed, retrying in 5s..."
+              echo "Attempt $i/24 failed, retrying in 5s..."
               sleep 5
             done
 
             echo "ERROR: Health check failed"
             systemctl --user status "$SYSTEMD_UNIT" || true
+            journalctl --user -u "$SYSTEMD_UNIT" --no-pager -n 80 || true
             exit 1


### PR DESCRIPTION
## Incident (continuation)
After #320 fixed the DuckDB permission error, the container now **starts healthy** — but the redeploy still failed its health check and prod is still down. This is a **false negative**, not an app fault.

## Root cause: the health window raced the cold start
`entrypoint.sh` builds the XBRL truth-layer DuckDB store **before gunicorn forks** (~45s observed on the droplet), on top of `collectstatic` + Playwright verification. The deploy's check was `sleep 30` + `3×5s` (~45s) then fail. The journal proves the container was fine — the probes just ran too early:

```
08:26:16  Attempt 1/3 failed
08:26:22  Attempt 2/3 failed
08:26:27  Attempt 3/3 failed
08:26:30  [1] Starting gunicorn 25.1.0 / Listening at 0.0.0.0:8000 / Booting worker
08:26:32  ERROR: Health check failed
```

All 3 probes completed **before** gunicorn bound `:8000`.

## Fix
Widen the health window to `sleep 10` + `24×5s` (~130s, ~2.8× the measured cold start) and succeed as soon as `/health/` answers. Also dump `journalctl -n 80` on failure so future startup regressions are diagnosable straight from the deploy log.

## Deliberately *not* touching gunicorn
The `Control server error: [Errno 13] Permission denied` is gunicorn 25.x's new **control socket** defaulting to `gunicorn.ctl` under the root-owned CWD (`/app`) — auxiliary, **non-fatal**: f86604d8 ran the identical gunicorn/config/user/CWD and served fine (health 200). Silencing that control socket is a separate, lower-priority follow-up (avoid risking a bad CLI flag that could break startup during an outage).

## Follow-ups (not in this PR)
- Persist the store on the writable `/app/runtime` volume so it's built once (skip the ~45s rebuild on every restart), not just on deploys.
- Disable/relocate the gunicorn control socket to a writable path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)