### PR TITLE
Persist truth-layer store on /app/runtime + silence gunicorn control socket

### DIFF
--- a/Main/backend/Dockerfile
+++ b/Main/backend/Dockerfile
@@ -35,13 +35,14 @@ ENV PATH="/app/.venv/bin:$PATH" \
     PLAYWRIGHT_BROWSERS_PATH=/ms-playwright \
     PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 \
     PIP_NO_CACHE_DIR=1 \
-    PIP_DISABLE_PIP_VERSION_CHECK=1
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    TRUTHLAYER_DB_PATH=/app/runtime/truthlayer.duckdb
 
 COPY . .
 
 RUN sed -i 's/\r$//' /app/entrypoint.sh && chmod +x /app/entrypoint.sh
 
-RUN mkdir -p /app/staticfiles /app/media /app/logs /tmp/fingpt_cache /app/truthlayer/data
+RUN mkdir -p /app/staticfiles /app/media /app/logs /tmp/fingpt_cache /app/runtime
 
 RUN ln -sf /ms-playwright/chromium_headless_shell-*/chrome-headless-shell-linux64/chrome-headless-shell /usr/bin/chromium-bundled
 
@@ -54,16 +55,16 @@ RUN echo "Verifying Playwright browsers..." && \
 # Create a non-root runtime user and own ONLY the writable runtime dirs.
 # The application source under /app stays root-owned so a compromised
 # process cannot rewrite code at runtime (P0 Root A.3: no-write-under-/app).
-# /app/truthlayer/data is the one deliberate exception: entrypoint.sh builds the
-# DuckDB truth-layer store there at startup (from the root-owned, still-read-only
-# vendored companyfacts JSON) BEFORE gunicorn forks. That build runs as `fingpt`,
-# so the directory must be fingpt-writable -- otherwise duckdb.connect() aborts with
-# "Permission denied" and the container exits 1. Only the regenerable .duckdb artifact
-# is written here; no application code (.py) becomes writable, so the no-write-under-
-# /app code-integrity intent is preserved.
+# /app/runtime is the writable runtime-data volume mountpoint: entrypoint.sh builds the
+# regenerable DuckDB truth-layer store there (from the root-owned, still-read-only
+# vendored companyfacts JSON in the truthlayer/data package dir) BEFORE gunicorn forks, and in
+# production it is a persistent bind mount (podman -v ...:/app/runtime:U) so the store
+# survives restarts. Owning it in the image keeps it writable even with no mount
+# (compose/CI/bare docker run). Only this regenerable artifact dir is fingpt-writable;
+# no application code (.py) becomes writable, so the no-write-under-/app intent holds.
 RUN groupadd --system --gid 1001 fingpt \
     && useradd --system --uid 1001 --gid fingpt --no-create-home fingpt \
-    && chown -R fingpt:fingpt /app/staticfiles /app/media /app/logs /tmp/fingpt_cache /app/truthlayer/data
+    && chown -R fingpt:fingpt /app/staticfiles /app/media /app/logs /tmp/fingpt_cache /app/runtime
 
 USER fingpt
 

--- a/Main/backend/entrypoint.sh
+++ b/Main/backend/entrypoint.sh
@@ -21,15 +21,17 @@ fi
 # Ensure cache directory exists (shared across gunicorn workers)
 mkdir -p "${CACHE_FILE_PATH:-/tmp/fingpt_cache}"
 
-# Build the XBRL truth-layer store ONCE, before gunicorn forks its workers. DuckDB's
-# read-write lock is exclusive across processes, so the workers must all open the
-# store read-only — which requires it to already exist. Building here (single process,
-# connection closed immediately) avoids a cold-start lock fight between workers.
-# Gate on _store_is_current (NOT mere existence): an image-baked store built under an
-# older fact_id recipe / registry version must be rebuilt here, not lazily in a
-# concurrent post-fork window. This mirrors the request-path gate in retrieve._ensure_built.
-echo "Building XBRL truth-layer store..."
-python -c "from truthlayer import ingest, retrieve; ingest.build_from_vendored().close() if not retrieve._store_is_current() else print('truth-layer store already current')" || {
+# Ensure the XBRL truth-layer store exists ONCE, before gunicorn forks its workers.
+# DuckDB's read-write lock is exclusive across processes, so the workers must all open
+# the store read-only — which requires it to already exist. retrieve._ensure_built() is
+# a no-op fast path when a version-current store is already present (e.g. persisted on
+# the /app/runtime volume from a previous start); otherwise it builds into a private
+# temp file and atomically renames it into place, so a build killed mid-write can never
+# leave a corrupt store on the persistent volume. Its _store_is_current gate also rebuilds
+# an image-baked store from an older recipe/registry version rather than trusting it.
+# Single source of truth with the request-path builder.
+echo "Ensuring XBRL truth-layer store is present..."
+python -c "from truthlayer import retrieve; retrieve._ensure_built()" || {
     echo "ERROR: failed to build truth-layer store" >&2
     exit 1
 }

--- a/Main/backend/entrypoint.sh
+++ b/Main/backend/entrypoint.sh
@@ -28,7 +28,7 @@ mkdir -p "${CACHE_FILE_PATH:-/tmp/fingpt_cache}"
 # the /app/runtime volume from a previous start); otherwise it builds into a private
 # temp file and atomically renames it into place, so a build killed mid-write can never
 # leave a corrupt store on the persistent volume. Its _store_is_current gate also rebuilds
-# an image-baked store from an older recipe/registry version rather than trusting it.
+# a volume-persisted store from an older recipe/registry version rather than trusting it.
 # Single source of truth with the request-path builder.
 echo "Ensuring XBRL truth-layer store is present..."
 python -c "from truthlayer import retrieve; retrieve._ensure_built()" || {

--- a/Main/backend/gunicorn.conf.py
+++ b/Main/backend/gunicorn.conf.py
@@ -32,6 +32,13 @@ user = None
 group = None
 tmp_upload_dir = None
 
+# gunicorn 25.1+ opens a Unix control socket (default: ./gunicorn.ctl in WORKDIR /app,
+# which is root-owned) for the `gunicornc` management CLI we don't use. As the non-root
+# runtime user (uid 1001) that path is unwritable, so the arbiter logs a recurring
+# "Failed to start control socket: [Errno 13] Permission denied" warning on every start
+# and reload. Disable it: removes the noise and the unused socket's small attack surface.
+control_socket_disable = True
+
 
 # ── Memory monitoring hooks ───────────────────────────────────────
 

--- a/Main/backend/tests/test_dockerfile_nonroot.py
+++ b/Main/backend/tests/test_dockerfile_nonroot.py
@@ -16,7 +16,7 @@ DEPLOY_WORKFLOW = os.path.join(
     _HERE, "..", "..", "..", ".github", "workflows", "backend-deploy.yml"
 )
 
-RUNTIME_DIRS = ["/app/staticfiles", "/app/media", "/app/logs", "/tmp/fingpt_cache"]
+RUNTIME_DIRS = ["/app/staticfiles", "/app/media", "/app/logs", "/tmp/fingpt_cache", "/app/runtime"]
 
 
 def _read(path):
@@ -58,6 +58,9 @@ class DockerfileNonRootTests(SimpleTestCase):
         self.assertNotIn("chown -R fingpt:fingpt /app ", chown + " ")
         self.assertNotIn("/app/api", chown)
         self.assertNotIn("/app/.venv", chown)
+        # The store no longer builds under /app: /app/truthlayer/data (vendored
+        # snapshots) stays root-owned and read-only, restoring no-write-under-/app.
+        self.assertNotIn("/app/truthlayer/data", chown)
 
     def test_user_switch_after_last_root_run_before_entrypoint(self):
         ln_idx = self._index_of("ln -sf /ms-playwright")
@@ -71,6 +74,19 @@ class DockerfileNonRootTests(SimpleTestCase):
         self.assertGreater(user_idx, verify_idx)
         self.assertGreater(user_idx, chown_idx)
         self.assertLess(user_idx, entry_idx)
+
+    def test_store_persisted_on_runtime_volume(self):
+        # The regenerable DuckDB store must build onto the /app/runtime volume
+        # (persisted across restarts) — not the ephemeral image layer — and nothing
+        # under /app/truthlayer stays writable.
+        self.assertIn("TRUTHLAYER_DB_PATH=/app/runtime/truthlayer.duckdb", self.text)
+        mkdir_lines = [l for l in self.lines if "mkdir -p" in l and "/app/runtime" in l]
+        self.assertEqual(
+            len(mkdir_lines), 1, f"expected /app/runtime in one mkdir line, got {mkdir_lines}"
+        )
+        # /app/truthlayer/data is no longer referenced in the Dockerfile at all
+        # (the snapshots arrive via COPY and stay root-owned / read-only).
+        self.assertNotIn("/app/truthlayer/data", self.text)
 
 
 class DeployUserNamespaceTests(SimpleTestCase):

--- a/Main/backend/tests/test_entrypoint_store_build.py
+++ b/Main/backend/tests/test_entrypoint_store_build.py
@@ -1,0 +1,27 @@
+"""Static guard: entrypoint.sh builds the store through the atomic path.
+
+Once the store persists on the /app/runtime volume, a build killed mid-write must
+never leave a corrupt file. retrieve._ensure_built() builds into a temp file and
+atomically renames it into place; the old inline build_from_vendored() wrote directly
+into DB_PATH and is unsafe on a persistent volume. This locks that choice.
+"""
+import os
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+ENTRYPOINT = os.path.join(_HERE, "..", "entrypoint.sh")
+
+
+def _read():
+    with open(ENTRYPOINT, "r", encoding="utf-8") as fh:
+        return fh.read()
+
+
+def test_entrypoint_builds_store_via_ensure_built():
+    text = _read()
+    assert "retrieve._ensure_built()" in text
+
+
+def test_entrypoint_does_not_build_store_directly():
+    text = _read()
+    # The old direct build wrote straight into DB_PATH — unsafe on the persistent volume.
+    assert "build_from_vendored()" not in text

--- a/Main/backend/tests/test_entrypoint_store_build.py
+++ b/Main/backend/tests/test_entrypoint_store_build.py
@@ -23,5 +23,8 @@ def test_entrypoint_builds_store_via_ensure_built():
 
 def test_entrypoint_does_not_build_store_directly():
     text = _read()
-    # The old direct build wrote straight into DB_PATH — unsafe on the persistent volume.
-    assert "build_from_vendored()" not in text
+    # The entrypoint must not call build_from_vendored in ANY form: it writes straight
+    # into DB_PATH (no temp-file + atomic rename) and is unsafe on the persistent volume.
+    # Match the bare name so the arg-passing form build_from_vendored(store.DB_PATH) is
+    # caught too — not just the zero-arg build_from_vendored() the old entrypoint used.
+    assert "build_from_vendored" not in text

--- a/Main/backend/tests/test_gunicorn_conf.py
+++ b/Main/backend/tests/test_gunicorn_conf.py
@@ -1,0 +1,24 @@
+"""Static guard: the gunicorn config disables the unused control socket.
+
+gunicorn 25.1's control_socket defaults to ./gunicorn.ctl in WORKDIR /app, which is
+root-owned; as the non-root runtime user (uid 1001) that path is unwritable and the
+arbiter logs a recurring "Failed to start control socket: Permission denied" warning on
+every start and reload. We don't use the gunicornc management CLI, so it is disabled.
+"""
+import importlib.util
+import os
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+GUNICORN_CONF = os.path.join(_HERE, "..", "gunicorn.conf.py")
+
+
+def _load_gunicorn_conf():
+    spec = importlib.util.spec_from_file_location("gunicorn_conf_under_test", GUNICORN_CONF)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_control_socket_disabled():
+    mod = _load_gunicorn_conf()
+    assert mod.control_socket_disable is True

--- a/Main/backend/tests/test_gunicorn_conf.py
+++ b/Main/backend/tests/test_gunicorn_conf.py
@@ -22,3 +22,14 @@ def _load_gunicorn_conf():
 def test_control_socket_disabled():
     mod = _load_gunicorn_conf()
     assert mod.control_socket_disable is True
+
+
+def test_control_socket_disable_is_a_real_gunicorn_setting():
+    # The check above passes even if gunicorn never recognizes the name (a typo, or a
+    # future rename/removal): gunicorn silently ignores unknown config attributes, so the
+    # socket would stay enabled and the "Permission denied" warning would return while the
+    # test above stayed green. Assert the name is an actual gunicorn setting so a version
+    # bump that drops it fails loudly here instead of silently in production.
+    from gunicorn.config import KNOWN_SETTINGS
+
+    assert "control_socket_disable" in {s.name for s in KNOWN_SETTINGS}

--- a/Main/backend/tests/test_truthlayer_store.py
+++ b/Main/backend/tests/test_truthlayer_store.py
@@ -146,3 +146,21 @@ def test_store_is_current_detects_version_drift(built_store_db, monkeypatch):
     assert retrieve._store_is_current() is True
     monkeypatch.setattr(store, "FACT_ID_RECIPE_VERSION", "0000-00-00")  # simulate a bump
     assert retrieve._store_is_current() is False
+
+
+def test_db_path_honors_env_override(monkeypatch, tmp_path):
+    # Production points the built artifact at the /app/runtime volume via
+    # TRUTHLAYER_DB_PATH; dev/tests/offline default to the in-package data/ dir.
+    # DB_PATH is computed at import, so reload the module under the patched env.
+    import importlib
+
+    override = tmp_path / "custom" / "store.duckdb"
+    monkeypatch.setenv("TRUTHLAYER_DB_PATH", str(override))
+    try:
+        importlib.reload(store)
+        assert store.DB_PATH == override
+    finally:
+        # Restore the in-package default so later tests in this session are unaffected.
+        monkeypatch.delenv("TRUTHLAYER_DB_PATH", raising=False)
+        importlib.reload(store)
+    assert store.DB_PATH == store.DATA_DIR / "truthlayer.duckdb"

--- a/Main/backend/truthlayer/store.py
+++ b/Main/backend/truthlayer/store.py
@@ -1,12 +1,18 @@
 from __future__ import annotations
 
 import hashlib
+import os
 from pathlib import Path
 
 import duckdb
 
 DATA_DIR = Path(__file__).resolve().parent / "data"
-DB_PATH = DATA_DIR / "truthlayer.duckdb"
+# The built store is a writable, regenerable artifact; its path is env-overridable so
+# production can place it on the mounted /app/runtime volume (persisted across restarts)
+# while dev/tests/offline checkouts default to the in-package data/ dir. DATA_DIR itself
+# stays in-package: ingest reads the committed companyfacts/ snapshots from it (the
+# read-only build *source*), which must not move onto the initially-empty volume.
+DB_PATH = Path(os.environ.get("TRUTHLAYER_DB_PATH", DATA_DIR / "truthlayer.duckdb"))
 
 # Bump whenever make_fact_id's serialization changes. A built store bakes its
 # fact_ids at ingest time, so retrieve._store_is_current() rebuilds any store stamped


### PR DESCRIPTION
## Summary
Build the DuckDB truth-layer store **once** onto the already-mounted `/app/runtime` volume (persisted across restarts) instead of rebuilding ~45s on every restart, and disable the unused gunicorn 25.1 control socket that logs a recurring `Permission denied` warning as the non-root user.

- **`store.py`** — `DB_PATH` reads `TRUTHLAYER_DB_PATH` (default = in-package `data/`). `DATA_DIR` (the vendored companyfacts build *source*) stays in-package.
- **`entrypoint.sh`** — one-time pre-fork build now routes through `retrieve._ensure_built()` (temp file + atomic rename) so a build killed mid-write can't corrupt the now-persistent store; it's a no-op fast path when a version-current store already exists.
- **`Dockerfile`** — set `TRUTHLAYER_DB_PATH=/app/runtime/truthlayer.duckdb`, create+chown `/app/runtime`, and **drop #320's `/app/truthlayer/data` chown**, restoring the no-write-under-`/app` invariant (the vendored snapshots there are read-only build input).
- **`gunicorn.conf.py`** — `control_socket_disable = True` (verified a real gunicorn 25.1.0 setting, so it actually takes effect).

## Notes
- The `/app/runtime` bind mount already exists on the droplet (`...:/app/runtime:U`, locked by `DeployUserNamespaceTests`); this PR points the container's store at it.
- Plan self-review missed one internal contradiction, caught here by the new `test_store_persisted_on_runtime_volume` guard (asserts `/app/truthlayer/data` appears nowhere in the Dockerfile): the runtime-user comment now refers to the vendored snapshots by their relative package path (`truthlayer/data`) rather than the absolute path.

## Test plan
- [x] `uv run pytest tests -q` → 526 passed, 1 skipped, 4 subtests (the CI `test` gate)
- [x] `uv run python manage.py check` → no issues (exit 0)
- [x] `uv run python verify_deployment.py` → all checks PASS (incl. Gunicorn Config)
- [x] New static guards: entrypoint atomic-build, dockerfile persistence, gunicorn control-socket, store env-override

## Post-merge validation (droplet, after push-to-main deploy)
First deploy: empty `/home/deploy/fingpt/runtime` → one ~45s build (health window tolerates via #321) → store persisted. Then `systemctl --user restart fingpt-api` should show a **fast** start (no rebuild) and **no** `Failed to start control socket` line.

Docs (spec + plan) already landed on `main` (`242c16f`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)