### PR TITLE
Hotfix: add :Z SELinux relabel to /app/runtime mount (prod down)

### DIFF
--- a/.github/workflows/backend-deploy.yml
+++ b/.github/workflows/backend-deploy.yml
@@ -184,16 +184,21 @@ jobs:
               docker.io/library/redis:7-alpine redis-server --save '' --appendonly no
 
             # Update systemd override to run the image we just pulled.
-            # The image now runs as non-root uid 1001 (Dockerfile USER fingpt), so
-            # the runtime bind mount below carries the ':U' suffix: rootless podman
-            # then recursively chowns the host dir to the in-container uid, otherwise
-            # the non-root process could not write the mount.
+            # The image now runs as non-root uid 1001 (Dockerfile USER fingpt), so the
+            # runtime bind mount below needs BOTH relabel suffixes for the non-root process
+            # to write it on this SELinux-enforcing Fedora host:
+            #   :U  rootless podman recursively chowns the host dir to the in-container uid
+            #       (DAC/ownership); without it the write is EACCES.
+            #   :Z  relabels the (private) host dir to container_file_t (MAC/SELinux);
+            #       without it container_t is denied and the write is *also* EACCES -- which
+            #       crash-looped the truth-layer store build the first time a deploy actually
+            #       wrote this mount (#322). Ownership alone is not enough; both are required.
             OVERRIDE_DIR="$HOME/.config/systemd/user/${SYSTEMD_UNIT}.service.d"
             mkdir -p "$OVERRIDE_DIR"
             cat > "$OVERRIDE_DIR/override.conf" <<EOF
             [Service]
             ExecStart=
-            ExecStart=/usr/bin/podman run --name ${SYSTEMD_UNIT} --replace --rm --cgroups=split --sdnotify=conmon -d --memory=1.7g --memory-swap=2g --network fingpt-net -v /home/deploy/fingpt/runtime:/app/runtime:U --publish 127.0.0.1:8000:8000 --env-file /home/deploy/fingpt/envs/.env.production --env REDIS_URL=redis://fingpt-redis:6379/0 ${REMOTE_IMAGE}
+            ExecStart=/usr/bin/podman run --name ${SYSTEMD_UNIT} --replace --rm --cgroups=split --sdnotify=conmon -d --memory=1.7g --memory-swap=2g --network fingpt-net -v /home/deploy/fingpt/runtime:/app/runtime:U,Z --publish 127.0.0.1:8000:8000 --env-file /home/deploy/fingpt/envs/.env.production --env REDIS_URL=redis://fingpt-redis:6379/0 ${REMOTE_IMAGE}
             EOF
 
             systemctl --user daemon-reload

--- a/Main/backend/tests/test_dockerfile_nonroot.py
+++ b/Main/backend/tests/test_dockerfile_nonroot.py
@@ -96,3 +96,14 @@ class DeployUserNamespaceTests(SimpleTestCase):
         # uid (1001) so the non-root process can write it.
         self.assertIn("/home/deploy/fingpt/runtime:/app/runtime:U", text)
         self.assertNotIn("/home/deploy/fingpt/runtime:/app/runtime ", text)
+
+    def test_runtime_bind_mount_selinux_relabel_for_nonroot(self):
+        text = _read(DEPLOY_WORKFLOW)
+        # The droplet is SELinux-enforcing Fedora. :U relabels OWNERSHIP (DAC) but leaves
+        # the host dir's SELinux label untouched, so the non-root container's container_t
+        # domain is denied write access (MAC) — surfacing as the same generic EACCES. The
+        # first deploy that actually WROTE the /app/runtime mount (the truth-layer store
+        # build, #322) crash-looped on "Permission denied" for exactly this reason. :Z
+        # relabels the (private, this-container-only) mount to container_file_t so the
+        # container can write it. Ownership AND SELinux must both be handled: ship :U,Z.
+        self.assertIn("/home/deploy/fingpt/runtime:/app/runtime:U,Z", text)


### PR DESCRIPTION
## Incident
The #322 deploy took the beta droplet's `fingpt-api` **down** (crash loop). No auto-rollback exists, so prod is currently down until this ships.

```
_duckdb.IOException: IO Error: Cannot open file
"/app/runtime/.building-3-truthlayer.duckdb": Permission denied
```

## Root cause (systematic-debugging)
#322 was the **first deploy to actually write** the `/app/runtime` bind mount — previously the store built into the image layer (`/app/truthlayer/data`, chowned by #320). The mount carried `:U` (rootless podman recursive chown to the in-container uid — **DAC/ownership**) but **not `:Z`**. On the SELinux-enforcing Fedora host the host dir keeps its non-container label, so the non-root `container_t` domain is **denied write (MAC)** → DuckDB `EACCES` → entrypoint `exit 1` → systemd restart loop → health check never passes → deploy fails, prod down.

Both `:U` and `:Z` surface failure as the same generic "Permission denied", which is why `:U` alone looked sufficient and passed every prior deploy (nothing had ever written the mount).

## Fix
Mount `/app/runtime:U,Z`. `:Z` relabels the **private** (this-container-only) host dir to `container_file_t` so `container_t` may write it. Ownership **and** SELinux must both be handled.

## Self-review
- `:Z` (private) is correct over `:z` (shared): only `fingpt-api` uses `/app/runtime`.
- Existing `test_runtime_bind_mount_uses_U_relabel_for_nonroot` still passes (`:U` is a substring of `:U,Z`).
- No injection surface added (static literal in the podman command).
- New `test_runtime_bind_mount_selinux_relabel_for_nonroot` guard locks the `:U,Z` form; full `test_dockerfile_nonroot.py` green (7 passed).

## Why this was invisible pre-merge
`build`+`test` run as root on ubuntu runners; the non-root SELinux write path only exists on the droplet, and the deploy gate runs on push-to-main, not PRs. The push-to-main deploy is the only integration test — so this hotfix is validated by watching its own deploy go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)