### PR TITLE
refactor(security): centralize Playwright route-guard in factory

### DIFF
--- a/Main/backend/api/views.py
+++ b/Main/backend/api/views.py
@@ -938,6 +938,12 @@ def auto_scrape(request: HttpRequest) -> JsonResponse:
             return JsonResponse({'error': 'No URL provided'}, status=400)
 
         try:
+            # Intentional fail-fast (kept, not redundant): refuse a blocked URL
+            # with a 400 before any scrape/session work. scrape_url validates
+            # transitively too, but dropping this would surface the refusal as a
+            # 500 and run session work first (pinned by test_ssrf_wire
+            # AutoScrapeSinkTests). The openai_views url-init path differs — it
+            # silently continues on a scrape error, so its precedent doesn't apply.
             ssrf_guard.validate_fetch_url(current_url)
         except ssrf_guard.UnsafeURLError as exc:
             logger.warning(f"[SSRF] Refused auto_scrape target {current_url}: {exc}")

--- a/Main/backend/datascraper/playwright_tools.py
+++ b/Main/backend/datascraper/playwright_tools.py
@@ -46,6 +46,10 @@ async def PlaywrightBrowser(timeout: int = 30000):
         context.set_default_timeout(timeout)
 
         page = await context.new_page()
+        # Every page is born guarded: install the SSRF route guard here so all
+        # async entrypoints (and any future one) are pinned without each having
+        # to remember the call. See datascraper.ssrf_guard.install_route_guard.
+        await ssrf_guard.install_route_guard(page)
 
         yield page
 
@@ -86,7 +90,6 @@ async def navigate_to_url(url: str) -> str:
     try:
         ssrf_guard.validate_fetch_url(url)
         async with PlaywrightBrowser() as page:
-            await ssrf_guard.install_route_guard(page)
             logger.info(f"Navigating to: {url}")
 
             response = await page.goto(url, wait_until='load')
@@ -136,7 +139,6 @@ async def click_element(url: str, selector: str) -> str:
     try:
         ssrf_guard.validate_fetch_url(url)
         async with PlaywrightBrowser() as page:
-            await ssrf_guard.install_route_guard(page)
             logger.info(f"Navigating to {url} to click: {selector}")
 
             # Navigate first - use 'load' event, not networkidle
@@ -243,7 +245,6 @@ async def extract_page_content(url: str, content_selector: str = "") -> str:
     try:
         ssrf_guard.validate_fetch_url(url)
         async with PlaywrightBrowser() as page:
-            await ssrf_guard.install_route_guard(page)
             logger.info(f"Extracting content from: {url}")
 
             await page.goto(url, wait_until='load')

--- a/Main/backend/tests/test_ssrf_wire.py
+++ b/Main/backend/tests/test_ssrf_wire.py
@@ -7,7 +7,7 @@ integration are all mocked, so no DB and no network are touched.
 """
 import asyncio
 import json
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from django.test import RequestFactory, SimpleTestCase
 
@@ -164,3 +164,36 @@ class AutoScrapeSinkTests(SimpleTestCase):
         mock_scrape.assert_not_called()
         mock_sid.assert_not_called()
         mock_validate.assert_called_once_with(BLOCKED)
+
+
+class PlaywrightFactoryGuardTests(SimpleTestCase):
+    """The PlaywrightBrowser factory must install the SSRF route guard on every
+    page it yields, so all three async tools are guarded centrally and a future
+    4th entrypoint cannot silently reopen the rebinding hole."""
+
+    def test_factory_installs_route_guard_on_yielded_page(self):
+        import datascraper.playwright_tools as pt
+
+        page = MagicMock(name="page")
+        context = MagicMock(name="context")
+        context.new_page = AsyncMock(return_value=page)
+        browser = MagicMock(name="browser")
+        browser.new_context = AsyncMock(return_value=context)
+        browser.close = AsyncMock()
+        playwright = MagicMock(name="playwright")
+        playwright.chromium.launch = AsyncMock(return_value=browser)
+        playwright.stop = AsyncMock()
+        ap = MagicMock()
+        ap.start = AsyncMock(return_value=playwright)
+
+        async def run():
+            with patch("playwright.async_api.async_playwright", return_value=ap), \
+                 patch("datascraper.ssrf_guard.install_route_guard",
+                       new=AsyncMock()) as mock_guard:
+                async with pt.PlaywrightBrowser() as yielded:
+                    # Installed on the yielded page BEFORE the caller's body runs
+                    # (i.e. before any goto).
+                    mock_guard.assert_awaited_once_with(page)
+                    self.assertIs(yielded, page)
+
+        asyncio.run(run())


### PR DESCRIPTION
## Summary
Item 2 of the two SSRF fetch-path follow-ups deferred from PR #314 (see `Docs/superpowers/specs/2026-06-30-ssrf-fetch-efficiency-design.md`).

Moves `ssrf_guard.install_route_guard` into the `PlaywrightBrowser` async factory so **every page is born guarded**, and deletes the 3 now-redundant per-tool installs in `navigate_to_url` / `click_element` / `extract_page_content`. This removes the altitude risk that a future 4th async entrypoint silently reopens the DNS-rebinding hole.

**Deliberately unchanged:**
- Seed `validate_fetch_url` pre-checks in the 3 tools (test-pinned fail-fast *before* browser launch).
- `assert_safe_page_url` post-checks (JS/meta redirects).
- `views.py:auto_scrape` pre-check — **kept**, with a new explanatory comment: it's test-pinned to a 400 before any scrape/session work; the `openai_views` silent-continue precedent does not transfer.

## Test plan
- [x] New `PlaywrightFactoryGuardTests` (factory installs guard on yielded page) — RED then GREEN
- [x] `PlaywrightNavigateSinkTests` / `PlaywrightFallbackRouteGuardTests` / `AutoScrapeSinkTests` still green
- [x] Full backend suite: 544 passed, 1 skipped (543 baseline + 1 new test), no regressions