### PR TITLE
perf(security): skip non-text subresources + per-page pinned-session cache

### DIFF
--- a/Main/backend/datascraper/ssrf_guard.py
+++ b/Main/backend/datascraper/ssrf_guard.py
@@ -31,6 +31,9 @@ import ipaddress
 import logging
 import os
 import socket
+import threading
+import time
+from http.cookiejar import DefaultCookiePolicy
 from typing import List, Optional, Tuple
 from urllib.parse import urljoin, urlparse
 
@@ -116,12 +119,10 @@ def _resolve_ips(host: str) -> List[str]:
     return ips
 
 
-def _check_and_resolve(url: str) -> Tuple[str, str]:
-    """Validate ``url`` and resolve it with a SINGLE DNS lookup, returning
-    ``(host, pinned_ip)``. Enforces http/https scheme, a present host, and that
-    EVERY resolved IP is publicly routable. ``pinned_ip`` is one of the IPs that
-    just passed the block-check, so safe_get can connect to exactly that address
-    with no second, rebind-vulnerable lookup."""
+def _validated_host(url: str) -> str:
+    """Enforce http/https scheme and a present host on ``url`` and return the
+    host. Raises :class:`UnsafeURLError`. DNS resolution + block-check is a
+    separate step (see :func:`_resolve_and_pin`)."""
     parsed = urlparse(url)
     if parsed.scheme not in _ALLOWED_SCHEMES:
         raise UnsafeURLError(
@@ -130,13 +131,29 @@ def _check_and_resolve(url: str) -> Tuple[str, str]:
     host = parsed.hostname
     if not host:
         raise UnsafeURLError(f"Missing host in URL {url!r}")
+    return host
+
+
+def _resolve_and_pin(host: str) -> str:
+    """Resolve ``host`` with a SINGLE DNS lookup and return its first IP after
+    verifying EVERY resolved IP is publicly routable. Raises
+    :class:`UnsafeURLError` otherwise. The returned IP just passed the
+    block-check, so a caller can pin the connection to exactly that address with
+    no second, rebind-vulnerable lookup."""
     ips = _resolve_ips(host)
     for ip in ips:
         if _is_blocked_ip(ip):
             raise UnsafeURLError(
                 f"Blocked host {host!r}: resolves to non-routable IP {ip}"
             )
-    return host, ips[0]
+    return ips[0]
+
+
+def _check_and_resolve(url: str) -> Tuple[str, str]:
+    """Validate ``url`` and resolve it with a SINGLE DNS lookup, returning
+    ``(host, pinned_ip)``."""
+    host = _validated_host(url)
+    return host, _resolve_and_pin(host)
 
 
 def validate_fetch_url(url: str) -> str:
@@ -224,6 +241,27 @@ def _enforce_byte_cap(response: requests.Response, max_bytes: int) -> requests.R
     return response
 
 
+def _follow_redirects(url, fetch_one, max_bytes, max_redirects):
+    """Drive the redirect + byte-cap loop shared by :func:`safe_get` and
+    :meth:`_PinnedSessionCache.fetch`. ``fetch_one(current_url)`` MUST return a
+    streaming, non-redirecting response whose connection is pinned to a
+    freshly-validated public IP for ``current_url``'s host — that per-hop
+    re-validation is what makes following a ``Location`` header safe. Returns the
+    final :class:`requests.Response` with a bounded, buffered body."""
+    current = url
+    for _ in range(max_redirects + 1):
+        response = fetch_one(current)
+        location = response.headers.get("Location")
+        if response.status_code in _REDIRECT_STATUSES and location:
+            response.close()
+            current = urljoin(current, location)
+            continue
+        return _enforce_byte_cap(response, max_bytes)
+    raise UnsafeURLError(
+        f"Exceeded maximum of {max_redirects} redirects starting from {url!r}"
+    )
+
+
 def safe_get(
     url: str,
     headers: Optional[dict] = None,
@@ -237,20 +275,13 @@ def safe_get(
     (original Host preserved), follows at most ``max_redirects`` hops while
     RE-VALIDATING each ``Location`` BEFORE it is fetched, streams the body, and
     aborts once Content-Length or cumulative bytes exceed ``max_bytes``. Returns
-    the final :class:`requests.Response` with a bounded, buffered body."""
-    current = url
-    for _ in range(max_redirects + 1):
+    the final :class:`requests.Response` with a bounded, buffered body. Stateless:
+    each hop builds a fresh pinned session (see ``_PinnedSessionCache`` for the
+    keep-alive variant used by the in-browser route guards)."""
+    def _fetch_one(current):
         _host, ip = _check_and_resolve(current)
-        response = _pinned_fetch(current, ip, headers, timeout)
-        location = response.headers.get("Location")
-        if response.status_code in _REDIRECT_STATUSES and location:
-            response.close()
-            current = urljoin(current, location)
-            continue
-        return _enforce_byte_cap(response, max_bytes)
-    raise UnsafeURLError(
-        f"Exceeded maximum of {max_redirects} redirects starting from {url!r}"
-    )
+        return _pinned_fetch(current, ip, headers, timeout)
+    return _follow_redirects(url, _fetch_one, max_bytes, max_redirects)
 
 
 def _fulfill_headers(response: requests.Response) -> dict:

--- a/Main/backend/datascraper/ssrf_guard.py
+++ b/Main/backend/datascraper/ssrf_guard.py
@@ -318,6 +318,13 @@ class _PinnedSessionCache:
         self._lock = threading.Lock()
         # host -> (pinned_ip, session, expiry_monotonic)
         self._entries = {}
+        # Sessions displaced by a TTL re-resolve, retained (NOT closed inline)
+        # until close(): a session is returned under the lock but used outside it,
+        # so a concurrent same-host fetch may still be mid-``session.get`` on the
+        # one being displaced — closing it here would be a use-after-close (a
+        # spurious fail-closed abort of a legitimate subresource). Per page +
+        # bounded by page_lifetime/ttl per host, so retaining until close is cheap.
+        self._stale = []
 
     @staticmethod
     def _build_session(ip: str, host: str) -> requests.Session:
@@ -349,7 +356,10 @@ class _PinnedSessionCache:
             # a now-blocked host raises without evicting/replacing a good entry.
             pinned_ip = _resolve_and_pin(host)
             if entry is not None:
-                entry[1].close()
+                # Retain, don't close: a concurrent fetch may still hold this
+                # session (returned under the lock, used outside it). Closed in
+                # close() at page teardown instead — see self._stale.
+                self._stale.append(entry[1])
             session = self._build_session(pinned_ip, host)
             self._entries[host] = (pinned_ip, session, time.monotonic() + self._ttl)
             return session
@@ -378,15 +388,19 @@ class _PinnedSessionCache:
         return _follow_redirects(url, _fetch_one, max_bytes, max_redirects)
 
     def close(self) -> None:
-        """Close every cached session (its keep-alive sockets). Called when the
-        page closes."""
+        """Close every cached session (its keep-alive sockets), including those
+        displaced by a TTL re-resolve (``self._stale``). Called when the page
+        closes, by which point no fetch is still borrowing a session."""
         with self._lock:
-            for _ip, session, _exp in self._entries.values():
+            sessions = [session for _ip, session, _exp in self._entries.values()]
+            sessions.extend(self._stale)
+            for session in sessions:
                 try:
                     session.close()
                 except Exception:
                     pass
             self._entries.clear()
+            self._stale.clear()
 
 
 def _fulfill_headers(response: requests.Response) -> dict:

--- a/Main/backend/datascraper/ssrf_guard.py
+++ b/Main/backend/datascraper/ssrf_guard.py
@@ -51,6 +51,23 @@ _ALLOWED_SCHEMES = ("http", "https")
 _REDIRECT_STATUSES = (301, 302, 303, 307, 308)
 _STREAM_CHUNK_BYTES = 65536
 
+# In-browser subresource types the route guard aborts outright: they never feed
+# page.inner_text, so fetching them only burns DNS+TLS and egress. Deliberately
+# NOT stylesheet/script/xhr/fetch/document — dropping CSS can leak display:none
+# boilerplate into inner_text, and JS/XHR drive SPA rendering.
+_SKIP_RESOURCE_TYPES = frozenset(
+    t.strip()
+    for t in os.getenv("SCRAPE_SKIP_RESOURCE_TYPES", "image,media,font").split(",")
+    if t.strip()
+)
+# Seconds a per-page resolved+validated host entry stays usable before it must be
+# re-resolved and re-block-checked. Per-page cache scope already bounds reuse to a
+# single scrape; this is a defense-in-depth staleness ceiling.
+_DNS_CACHE_TTL = float(os.getenv("SCRAPE_DNS_CACHE_TTL", "30"))
+# Keep-alive pool size for each cached per-host pinned session, so a same-host
+# subresource burst reuses connections instead of serializing on one.
+_POOL_MAXSIZE = int(os.getenv("SCRAPE_POOL_MAXSIZE", "20"))
+
 # Response headers that must NOT be forwarded when fulfilling a Playwright route
 # from a safe_get response: requests has already decoded the body (so a stale
 # Content-Encoding would make Chromium try to gunzip plaintext), and the framing
@@ -282,6 +299,94 @@ def safe_get(
         _host, ip = _check_and_resolve(current)
         return _pinned_fetch(current, ip, headers, timeout)
     return _follow_redirects(url, _fetch_one, max_bytes, max_redirects)
+
+
+class _PinnedSessionCache:
+    """Per-page cache of resolved+validated hosts and their keep-alive,
+    IP-pinned ``requests.Session``s, used by the Playwright route guards to skip
+    re-resolving DNS and re-handshaking TLS on every subresource.
+
+    A cached entry stores ONLY an IP that already passed the block-check, and the
+    session stays pinned to that IP, so reuse cannot reach a private address even
+    if the host later rebinds — re-resolution (and the next block-check) only
+    happens after the entry's TTL expires. Per page, NEVER global. Thread-safe:
+    the async route guard dispatches :meth:`fetch` via ``asyncio.to_thread``, so
+    concurrent same-host subresources may call it at once."""
+
+    def __init__(self, ttl: float = _DNS_CACHE_TTL):
+        self._ttl = ttl
+        self._lock = threading.Lock()
+        # host -> (pinned_ip, session, expiry_monotonic)
+        self._entries = {}
+
+    @staticmethod
+    def _build_session(ip: str, host: str) -> requests.Session:
+        """A keep-alive Session whose adapter pins every connection to ``ip``
+        (Host/SNI preserved for ``host``). Its cookie jar is disabled: cookies
+        flow through Chromium (fulfilled Set-Cookie -> stored -> replayed via the
+        forwarded Cookie header), never through this session, so disabling it both
+        removes the only per-request mutable shared state (making concurrent
+        ``session.get`` thread-safe) and prevents cross-subresource cookie bleed."""
+        session = requests.Session()
+        session.cookies.set_policy(DefaultCookiePolicy(allowed_domains=[]))
+        adapter = _PinnedHTTPAdapter(
+            ip, host, pool_connections=_POOL_MAXSIZE, pool_maxsize=_POOL_MAXSIZE
+        )
+        session.mount("http://", adapter)
+        session.mount("https://", adapter)
+        return session
+
+    def _session_for(self, host: str) -> requests.Session:
+        """Return a keep-alive Session pinned to a freshly-validated public IP for
+        ``host``, resolving + block-checking on a cache miss or after TTL expiry.
+        Holds the lock across the whole get-or-create so a concurrent same-host
+        burst resolves exactly once."""
+        with self._lock:
+            entry = self._entries.get(host)
+            if entry is not None and time.monotonic() < entry[2]:
+                return entry[1]
+            # Miss or expired: resolve + block-check BEFORE mutating the cache, so
+            # a now-blocked host raises without evicting/replacing a good entry.
+            pinned_ip = _resolve_and_pin(host)
+            if entry is not None:
+                entry[1].close()
+            session = self._build_session(pinned_ip, host)
+            self._entries[host] = (pinned_ip, session, time.monotonic() + self._ttl)
+            return session
+
+    def fetch(
+        self,
+        url: str,
+        headers: Optional[dict] = None,
+        timeout: int = 15,
+        max_bytes: int = MAX_FETCH_BYTES,
+        max_redirects: int = MAX_REDIRECTS,
+    ) -> requests.Response:
+        """:func:`safe_get`'s redirect + byte-cap contract, but each hop reuses
+        the host's pinned keep-alive session. Validates scheme + host per hop and
+        resolves/block-checks per host (cache miss or expiry)."""
+        def _fetch_one(current):
+            host = _validated_host(current)
+            session = self._session_for(host)
+            return session.get(
+                current,
+                headers=headers,
+                timeout=timeout,
+                stream=True,
+                allow_redirects=False,
+            )
+        return _follow_redirects(url, _fetch_one, max_bytes, max_redirects)
+
+    def close(self) -> None:
+        """Close every cached session (its keep-alive sockets). Called when the
+        page closes."""
+        with self._lock:
+            for _ip, session, _exp in self._entries.values():
+                try:
+                    session.close()
+                except Exception:
+                    pass
+            self._entries.clear()
 
 
 def _fulfill_headers(response: requests.Response) -> dict:

--- a/Main/backend/datascraper/ssrf_guard.py
+++ b/Main/backend/datascraper/ssrf_guard.py
@@ -409,6 +409,17 @@ def _should_proxy(route) -> bool:
     return urlparse(request.url).scheme in _ALLOWED_SCHEMES
 
 
+def _should_skip_resource(route) -> bool:
+    """True for in-browser subresource types we never need for text extraction
+    (image/media/font by default — see ``_SKIP_RESOURCE_TYPES``). Aborting them
+    cuts DNS+TLS work and egress with no effect on ``page.inner_text``; aborting
+    more requests is also strictly less egress, so there is no SSRF downside."""
+    try:
+        return route.request.resource_type in _SKIP_RESOURCE_TYPES
+    except Exception:
+        return False
+
+
 def _forward_headers(route) -> dict:
     """The browser request's headers to replay through ``safe_get``, minus the
     framing/encoding headers requests must control (see
@@ -426,20 +437,20 @@ def _forward_headers(route) -> dict:
     }
 
 
-def _proxied_response_kwargs(request_url: str, headers: dict):
-    """Fetch an intercepted in-browser GET through the IP-pinned, byte-capped
-    ``safe_get`` and return the kwargs to fulfill the Playwright route with, or
-    ``None`` to fail closed (abort). Blocking — the async guard dispatches it via
-    ``asyncio.to_thread``. Both route guards share this one fail-closed policy
-    (which exceptions abort, what gets logged, which headers fulfill) so the sync
-    and async paths cannot drift. ``headers`` are the browser's own request
-    headers (UA/Accept/...) so the IP-pinned fetch stays indistinguishable to the
-    origin."""
+def _proxied_response_kwargs(cache: "_PinnedSessionCache", request_url: str, headers: dict):
+    """Fetch an intercepted in-browser GET through the per-page IP-pinned,
+    byte-capped ``cache`` and return the kwargs to fulfill the Playwright route
+    with, or ``None`` to fail closed (abort). Blocking — the async guard
+    dispatches it via ``asyncio.to_thread``. Both route guards share this one
+    fail-closed policy (which exceptions abort, what gets logged, which headers
+    fulfill) so the sync and async paths cannot drift. ``headers`` are the
+    browser's own request headers (UA/Accept/...) so the IP-pinned fetch stays
+    indistinguishable to the origin."""
     try:
-        # safe_get validates, pins to the resolved IP, follows redirects
-        # re-validating each, and byte-caps the body — raising UnsafeURLError on
-        # any violation.
-        response = safe_get(request_url, headers=headers)
+        # cache.fetch validates, pins to the resolved IP (reusing a per-host
+        # keep-alive session), follows redirects re-validating each, and byte-caps
+        # the body — raising UnsafeURLError on any violation.
+        response = cache.fetch(request_url, headers=headers)
     except UnsafeURLError as exc:
         logger.warning(
             "[ssrf_guard] aborting in-browser request to %s: %s",
@@ -464,24 +475,30 @@ def _proxied_response_kwargs(request_url: str, headers: dict):
 async def install_route_guard(page) -> None:
     """Register an async Playwright route handler on ALL URLs that fetches each
     intercepted in-browser request (top-level navigation OR subresource) through
-    the IP-pinned, byte-capped ``safe_get`` and fulfills Chromium with the
-    buffered response. For these HTTP(S) requests Chromium therefore never opens
-    its own socket and cannot be redirected to a private address by a
-    DNS-rebinding answer.
+    a per-page IP-pinned, byte-capped, keep-alive cache and fulfills Chromium with
+    the buffered response. For these HTTP(S) requests Chromium therefore never
+    opens its own socket and cannot be redirected to a private address by a
+    DNS-rebinding answer. image/media/font requests are aborted outright (they
+    never feed text extraction); non-GET and non-http(s) requests fail closed.
 
-    MUST be called BEFORE the first ``page.goto`` in every Playwright entrypoint
-    so EVERY navigation/subresource is pinned, not just the seed URL. Non-GET and
-    non-http(s) requests fail closed (aborted). WebSocket/WebRTC are not routed
-    through ``page.route`` and are out of scope (see module docstring)."""
+    MUST be called BEFORE the first ``page.goto`` so EVERY navigation/subresource
+    is pinned, not just the seed URL. Installed centrally by the PlaywrightBrowser
+    factory. WebSocket/WebRTC are not routed through ``page.route`` and are out of
+    scope (see module docstring)."""
+    cache = _PinnedSessionCache()
+    page.on("close", lambda *_: cache.close())
 
     async def _handler(route):
+        if _should_skip_resource(route):
+            await route.abort()
+            return
         if not _should_proxy(route):
             await route.abort()
             return
-        # _proxied_response_kwargs is blocking (it calls safe_get); run it off the
-        # event loop. route.request.* is read here on the loop before dispatch.
+        # _proxied_response_kwargs is blocking (it calls cache.fetch); run it off
+        # the event loop. route.request.* is read here on the loop before dispatch.
         kwargs = await asyncio.to_thread(
-            _proxied_response_kwargs, route.request.url, _forward_headers(route)
+            _proxied_response_kwargs, cache, route.request.url, _forward_headers(route)
         )
         if kwargs is None:  # fetch was unsafe or failed — fail closed.
             await route.abort()
@@ -493,17 +510,23 @@ async def install_route_guard(page) -> None:
 
 def install_route_guard_sync(page) -> None:
     """Synchronous twin of :func:`install_route_guard` for the sync Playwright
-    fallback (``url_tools.scrape_with_playwright``). Same guarantee: every
-    in-browser GET is fulfilled from the IP-pinned ``safe_get`` so Chromium never
-    re-resolves DNS on its own socket; non-GET / non-http(s) fail closed.
+    fallback (``url_tools.scrape_with_playwright``). Same guarantees: every
+    in-browser GET is fulfilled from a per-page IP-pinned, keep-alive cache so
+    Chromium never re-resolves DNS on its own socket; image/media/font are
+    aborted outright; non-GET / non-http(s) fail closed.
 
     MUST be called BEFORE the first ``page.goto``."""
+    cache = _PinnedSessionCache()
+    page.on("close", lambda *_: cache.close())
 
     def _handler(route):
+        if _should_skip_resource(route):
+            route.abort()
+            return
         if not _should_proxy(route):
             route.abort()
             return
-        kwargs = _proxied_response_kwargs(route.request.url, _forward_headers(route))
+        kwargs = _proxied_response_kwargs(cache, route.request.url, _forward_headers(route))
         if kwargs is None:  # fetch was unsafe or failed — fail closed.
             route.abort()
             return

--- a/Main/backend/tests/test_ssrf_guard.py
+++ b/Main/backend/tests/test_ssrf_guard.py
@@ -189,10 +189,11 @@ class RouteGuardTests(SimpleTestCase):
         "Host": "example.com",
     }
 
-    def _route(self, url, method="GET"):
+    def _route(self, url, method="GET", resource_type="document"):
         route = MagicMock()
         route.request.url = url
         route.request.method = method
+        route.request.resource_type = resource_type
         route.request.headers = dict(self._BROWSER_HEADERS)
         route.abort = AsyncMock()
         route.fulfill = AsyncMock()
@@ -209,8 +210,9 @@ class RouteGuardTests(SimpleTestCase):
 
         asyncio.run(run())
 
-    @patch("datascraper.ssrf_guard.safe_get")
-    def test_route_guard_aborts_blocked_request(self, m_get):
+    @patch("datascraper.ssrf_guard._PinnedSessionCache")
+    def test_route_guard_aborts_blocked_request(self, m_cache):
+        m_get = m_cache.return_value.fetch
         m_get.side_effect = UnsafeURLError("blocked")
         route = self._route("http://evil.example.test/x")
         self._drive(route)
@@ -219,8 +221,9 @@ class RouteGuardTests(SimpleTestCase):
         # Never delegate the fetch back to Chromium (would re-resolve DNS).
         route.continue_.assert_not_awaited()
 
-    @patch("datascraper.ssrf_guard.safe_get")
-    def test_route_guard_fulfills_public_request_from_pinned_fetch(self, m_get):
+    @patch("datascraper.ssrf_guard._PinnedSessionCache")
+    def test_route_guard_fulfills_public_request_from_pinned_fetch(self, m_cache):
+        m_get = m_cache.return_value.fetch
         resp = _FakeResp(
             status_code=200,
             headers={"Content-Type": "text/html", "Content-Encoding": "gzip"},
@@ -243,8 +246,9 @@ class RouteGuardTests(SimpleTestCase):
         m_get.assert_called_once()
         self.assertEqual(m_get.call_args.args[0], "http://example.com/x")
 
-    @patch("datascraper.ssrf_guard.safe_get")
-    def test_route_guard_forwards_browser_headers_to_pinned_fetch(self, m_get):
+    @patch("datascraper.ssrf_guard._PinnedSessionCache")
+    def test_route_guard_forwards_browser_headers_to_pinned_fetch(self, m_cache):
+        m_get = m_cache.return_value.fetch
         # The pinned fetch must present the browser's own User-Agent (the
         # context deliberately sets a Chrome UA to avoid bot-gating); SSRF
         # safety comes from IP-pinning, not from hiding the UA. Framing/encoding
@@ -264,14 +268,25 @@ class RouteGuardTests(SimpleTestCase):
         self.assertNotIn("host", lowered)
         self.assertNotIn("accept-encoding", lowered)
 
-    @patch("datascraper.ssrf_guard.safe_get")
-    def test_route_guard_aborts_non_get(self, m_get):
-        # safe_get is GET-only; non-GET in-browser requests fail closed.
+    @patch("datascraper.ssrf_guard._PinnedSessionCache")
+    def test_route_guard_aborts_non_get(self, m_cache):
+        m_get = m_cache.return_value.fetch
+        # cache.fetch is GET-only; non-GET in-browser requests fail closed.
         route = self._route("http://example.com/api", method="POST")
         self._drive(route)
         route.abort.assert_awaited_once()
         route.fulfill.assert_not_awaited()
         m_get.assert_not_called()
+
+    @patch("datascraper.ssrf_guard._PinnedSessionCache")
+    def test_route_guard_aborts_skipped_resource(self, m_cache):
+        # image/media/font are aborted before any fetch — they don't feed
+        # inner_text, so we never spend DNS+TLS or egress on them.
+        route = self._route("http://example.com/logo.png", resource_type="image")
+        self._drive(route)
+        route.abort.assert_awaited_once()
+        route.fulfill.assert_not_awaited()
+        m_cache.return_value.fetch.assert_not_called()
 
 
 class SyncRouteGuardTests(SimpleTestCase):
@@ -287,10 +302,11 @@ class SyncRouteGuardTests(SimpleTestCase):
         page.route = route
         return page
 
-    def _route(self, url, method="GET"):
+    def _route(self, url, method="GET", resource_type="document"):
         route = MagicMock()
         route.request.url = url
         route.request.method = method
+        route.request.resource_type = resource_type
         route.request.headers = {
             "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) Chrome/120.0.0.0",
             "Accept-Encoding": "gzip, deflate, br",
@@ -304,16 +320,18 @@ class SyncRouteGuardTests(SimpleTestCase):
         ssrf_guard.install_route_guard_sync(page)
         captured["handler"](route)
 
-    @patch("datascraper.ssrf_guard.safe_get")
-    def test_sync_guard_aborts_blocked_request(self, m_get):
+    @patch("datascraper.ssrf_guard._PinnedSessionCache")
+    def test_sync_guard_aborts_blocked_request(self, m_cache):
+        m_get = m_cache.return_value.fetch
         m_get.side_effect = UnsafeURLError("blocked")
         route = self._route("http://evil.example.test/x")
         self._drive(route)
         route.abort.assert_called_once()
         route.fulfill.assert_not_called()
 
-    @patch("datascraper.ssrf_guard.safe_get")
-    def test_sync_guard_fulfills_public_request(self, m_get):
+    @patch("datascraper.ssrf_guard._PinnedSessionCache")
+    def test_sync_guard_fulfills_public_request(self, m_cache):
+        m_get = m_cache.return_value.fetch
         resp = _FakeResp(status_code=200, headers={"Content-Type": "text/html"})
         resp._content = b"hi"
         m_get.return_value = resp
@@ -323,8 +341,9 @@ class SyncRouteGuardTests(SimpleTestCase):
         self.assertEqual(route.fulfill.call_args.kwargs["body"], b"hi")
         route.abort.assert_not_called()
 
-    @patch("datascraper.ssrf_guard.safe_get")
-    def test_sync_guard_forwards_browser_user_agent(self, m_get):
+    @patch("datascraper.ssrf_guard._PinnedSessionCache")
+    def test_sync_guard_forwards_browser_user_agent(self, m_cache):
+        m_get = m_cache.return_value.fetch
         resp = _FakeResp(status_code=200, headers={"Content-Type": "text/html"})
         resp._content = b"hi"
         m_get.return_value = resp
@@ -337,12 +356,21 @@ class SyncRouteGuardTests(SimpleTestCase):
         self.assertNotIn("host", lowered)
         self.assertNotIn("accept-encoding", lowered)
 
-    @patch("datascraper.ssrf_guard.safe_get")
-    def test_sync_guard_aborts_non_get(self, m_get):
+    @patch("datascraper.ssrf_guard._PinnedSessionCache")
+    def test_sync_guard_aborts_non_get(self, m_cache):
+        m_get = m_cache.return_value.fetch
         route = self._route("http://example.com/api", method="POST")
         self._drive(route)
         route.abort.assert_called_once()
         m_get.assert_not_called()
+
+    @patch("datascraper.ssrf_guard._PinnedSessionCache")
+    def test_sync_guard_aborts_skipped_resource(self, m_cache):
+        route = self._route("http://example.com/font.woff2", resource_type="font")
+        self._drive(route)
+        route.abort.assert_called_once()
+        route.fulfill.assert_not_called()
+        m_cache.return_value.fetch.assert_not_called()
 
 
 class PinnedSessionCacheTests(SimpleTestCase):

--- a/Main/backend/tests/test_ssrf_guard.py
+++ b/Main/backend/tests/test_ssrf_guard.py
@@ -288,6 +288,24 @@ class RouteGuardTests(SimpleTestCase):
         route.fulfill.assert_not_awaited()
         m_cache.return_value.fetch.assert_not_called()
 
+    @patch("datascraper.ssrf_guard._PinnedSessionCache")
+    def test_route_guard_closes_cache_on_page_close(self, m_cache):
+        # The guard must wire page.on("close", ...) -> cache.close() so the
+        # per-page sessions (including TTL-displaced ones held in _stale) are
+        # torn down when the page closes.
+        handlers = {}
+        page = MagicMock()
+
+        async def fake_route(pattern, handler):
+            pass
+
+        page.route = fake_route
+        page.on = lambda event, cb: handlers.__setitem__(event, cb)
+        asyncio.run(ssrf_guard.install_route_guard(page))
+        self.assertIn("close", handlers)
+        handlers["close"]("evt")  # simulate Playwright firing the close event
+        m_cache.return_value.close.assert_called_once()
+
 
 class SyncRouteGuardTests(SimpleTestCase):
     """install_route_guard_sync mirrors the async guard for the sync
@@ -456,6 +474,34 @@ class PinnedSessionCacheTests(SimpleTestCase):
         cache.close()
         fake.close.assert_called_once()
         self.assertEqual(cache._entries, {})
+
+    def test_ttl_reresolve_defers_closing_displaced_session(self):
+        # A session displaced by a TTL re-resolve must NOT be closed inline: a
+        # concurrent same-host fetch may still be mid-get on it (it is returned
+        # under the lock but used outside it). It is closed at page close instead.
+        cache = ssrf_guard._PinnedSessionCache(ttl=30)
+        clock = {"t": 100.0}
+        built = []
+
+        def fake_build(ip, host):
+            s = MagicMock()
+            built.append(s)
+            return s
+
+        with patch("datascraper.ssrf_guard.time.monotonic",
+                   side_effect=lambda: clock["t"]), \
+             patch.object(ssrf_guard._PinnedSessionCache, "_build_session",
+                          side_effect=fake_build), \
+             patch("datascraper.ssrf_guard._resolve_ips",
+                   side_effect=[["93.184.216.34"], ["93.184.216.34"]]):
+            cache._session_for("example.com")   # builds S0, expiry = 130
+            clock["t"] = 200.0                  # past the 30s TTL
+            cache._session_for("example.com")   # re-resolve -> builds S1, S0 displaced
+            built[0].close.assert_not_called()  # S0 NOT torn down inline
+        cache.close()
+        built[0].close.assert_called_once()     # both closed at page teardown
+        built[1].close.assert_called_once()
+        self.assertEqual(cache._stale, [])
 
 
 class AssertSafePageUrlTests(SimpleTestCase):

--- a/Main/backend/tests/test_ssrf_guard.py
+++ b/Main/backend/tests/test_ssrf_guard.py
@@ -1,6 +1,8 @@
 """Tests for datascraper.ssrf_guard (P0 Root B.1 SSRF guard)."""
 import asyncio
 import socket
+import threading
+import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from django.test import SimpleTestCase
@@ -341,6 +343,91 @@ class SyncRouteGuardTests(SimpleTestCase):
         self._drive(route)
         route.abort.assert_called_once()
         m_get.assert_not_called()
+
+
+class PinnedSessionCacheTests(SimpleTestCase):
+    """The per-page cache reuses validated DNS + keep-alive sessions per host,
+    re-validates after TTL, and never reaches a private address."""
+
+    def test_resolves_once_and_reuses_session_within_ttl(self):
+        cache = ssrf_guard._PinnedSessionCache(ttl=1000)
+        with patch("datascraper.ssrf_guard._resolve_ips",
+                   return_value=["93.184.216.34"]) as m_res:
+            s1 = cache._session_for("example.com")
+            s2 = cache._session_for("example.com")
+        self.assertIs(s1, s2)
+        m_res.assert_called_once()
+        cache.close()
+
+    def test_reresolves_and_reblocks_after_ttl(self):
+        cache = ssrf_guard._PinnedSessionCache(ttl=30)
+        clock = {"t": 100.0}
+        with patch("datascraper.ssrf_guard.time.monotonic",
+                   side_effect=lambda: clock["t"]), \
+             patch("datascraper.ssrf_guard._resolve_ips",
+                   side_effect=[["93.184.216.34"], ["127.0.0.1"]]) as m_res:
+            cache._session_for("rebind.test")     # caches; expiry = 130
+            clock["t"] = 200.0                     # past the 30s TTL
+            with self.assertRaises(UnsafeURLError):
+                cache._session_for("rebind.test")  # re-resolve -> now private -> blocked
+        self.assertEqual(m_res.call_count, 2)
+        cache.close()
+
+    def test_blocked_ip_on_miss_caches_nothing(self):
+        cache = ssrf_guard._PinnedSessionCache()
+        with patch("datascraper.ssrf_guard._resolve_ips",
+                   return_value=["169.254.169.254"]):
+            with self.assertRaises(UnsafeURLError):
+                cache._session_for("evil.test")
+        self.assertEqual(cache._entries, {})
+
+    def test_fetch_revalidates_each_redirect_host(self):
+        cache = ssrf_guard._PinnedSessionCache()
+        redirect = _FakeResp(status_code=302, location="http://h2.test/final")
+        final = _FakeResp(status_code=200, chunks=[b"ok"])
+        seen = []
+
+        def fake_session_for(host):
+            seen.append(host)
+            s = MagicMock()
+            s.get.return_value = redirect if host == "h1.test" else final
+            return s
+
+        with patch.object(cache, "_session_for", side_effect=fake_session_for):
+            resp = cache.fetch("http://h1.test/start")
+        self.assertEqual(seen, ["h1.test", "h2.test"])
+        self.assertEqual(resp._content, b"ok")
+        self.assertTrue(redirect.closed)
+
+    def test_concurrent_same_host_resolves_once(self):
+        cache = ssrf_guard._PinnedSessionCache(ttl=1000)
+
+        def slow_resolve(host):
+            time.sleep(0.02)
+            return ["93.184.216.34"]
+
+        with patch("datascraper.ssrf_guard._resolve_ips",
+                   side_effect=slow_resolve) as m_res:
+            threads = [threading.Thread(target=cache._session_for,
+                                        args=("example.com",)) for _ in range(8)]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join()
+        m_res.assert_called_once()
+        cache.close()
+
+    def test_close_closes_all_sessions(self):
+        cache = ssrf_guard._PinnedSessionCache(ttl=1000)
+        fake = MagicMock()
+        with patch.object(ssrf_guard._PinnedSessionCache, "_build_session",
+                          return_value=fake), \
+             patch("datascraper.ssrf_guard._resolve_ips",
+                   return_value=["93.184.216.34"]):
+            cache._session_for("example.com")
+        cache.close()
+        fake.close.assert_called_once()
+        self.assertEqual(cache._entries, {})
 
 
 class AssertSafePageUrlTests(SimpleTestCase):


### PR DESCRIPTION
## Summary
Item 1 of the two SSRF fetch-path follow-ups deferred from PR #314 (design: `Docs/superpowers/specs/2026-06-30-ssrf-fetch-efficiency-design.md`; plan: `Docs/superpowers/plans/2026-06-30-ssrf-fetch-efficiency.md`). Follows PR #324 (Item 2).

Makes in-browser (Playwright route-guard) fetches cheaper **without weakening the IP-pinning that closes DNS rebinding**:

1. **Resource-type filter** — the route guards `route.abort()` `image/media/font` subresources (env `SCRAPE_SKIP_RESOURCE_TYPES`) before any fetch. They never feed `page.inner_text`, so this is strictly *less* egress (no SSRF downside). CSS/JS/XHR/document deliberately kept.
2. **Per-page `_PinnedSessionCache`** — caches `{host -> (validated_ip, keep-alive session)}` with a short TTL (`SCRAPE_DNS_CACHE_TTL`, 30s), so same-host subresources reuse one DNS resolution + TCP/TLS instead of a fresh `requests.Session` per asset.

### Security invariants preserved
- **Per-hop re-validation:** every redirect `Location` resolves + block-checks its own host fresh (shared `_follow_redirects` helper, used by both `safe_get` and `cache.fetch`).
- **Validated-IP pinning:** a cache entry stores only an already-block-checked IP and stays pinned to it; a mid-scrape rebind public→private is refused on the next re-resolve after TTL.
- **Cache is per-page, never global.** Cookie jar disabled on cached sessions (cookies flow through Chromium) → thread-safe under the async guard's `asyncio.to_thread` dispatch.
- `safe_get`'s public signature is **unchanged** (stateless one-shot preserved for the requests-first path).

## Test plan
- [x] `PinnedSessionCacheTests` (6): resolve-once-within-TTL, re-resolve+re-block after TTL, blocked-on-miss caches nothing, per-hop redirect re-validation, concurrent-same-host-resolves-once, close-all — RED→GREEN
- [x] `RouteGuardTests`/`SyncRouteGuardTests` migrated to the cache seam + new skip tests (10) — RED→GREEN
- [x] `SafeGetTests`/`ValidateFetchUrlTests` unchanged (refactor is behavior-preserving)
- [x] Full backend suite: **552 passed, 1 skipped** (544 baseline + 8 new), no regressions
- [x] All edited modules import clean under Django settings