### PR TITLE
feat(security): WS/WebRTC SSRF egress firewall

### DIFF
--- a/.github/workflows/backend-deploy.yml
+++ b/.github/workflows/backend-deploy.yml
@@ -196,23 +196,20 @@ jobs:
               podman start fingpt-redis >/dev/null 2>&1 || true
             fi
 
-            # Pre-cutover firewall validation: prove the NEW image can generate + load the
-            # SSRF egress ruleset and pass its self-test on fingpt-net BEFORE the systemctl
-            # restart's --replace kills the currently-serving container. On failure, abort
+            # Pre-cutover firewall validation: run the NEW image's REAL entrypoint in
+            # check-only mode on fingpt-net BEFORE the systemctl restart's --replace kills
+            # the currently-serving container. --egress-check-only exercises the byte-
+            # identical root-init PID1 runs at cutover (generate + sentinel checks + nft
+            # load + transition-proof self-test + setpriv drop), then exits before the app
+            # phase; an inline re-copy of that sequence (this step's previous shape) can
+            # silently drift from the boot path it is supposed to prove. On failure, abort
             # so the OLD container keeps serving (there is no auto-rollback). This closes
             # the CI-invisible gap: the test job is pytest-only and never touches nft/netns.
             echo "Validating egress firewall on the new image (pre-cutover)..."
             podman run --rm --cap-add=NET_ADMIN --network fingpt-net \
               --env REDIS_URL=redis://fingpt-redis:6379/0 \
-              --entrypoint sh "$REMOTE_IMAGE" -c '
-                set -eu
-                RULES=$(mktemp)
-                python -m ops.egress_firewall > "$RULES"
-                if python -m ops.egress_firewall --metadata-reachable; then MB=1; else MB=0; fi
-                nft -f "$RULES"
-                nft list table inet ssrf_egress >/dev/null
-                METADATA_WAS_REACHABLE=$MB python -m ops.egress_firewall --self-test
-              ' || { echo "ERROR: egress firewall pre-cutover validation FAILED; aborting deploy (old container left serving)"; exit 1; }
+              "$REMOTE_IMAGE" --egress-check-only \
+              || { echo "ERROR: egress firewall pre-cutover validation FAILED; aborting deploy (old container left serving)"; exit 1; }
             echo "Egress firewall pre-cutover validation passed."
 
             # Record the currently-deployed image for manual rollback (no auto-rollback).

--- a/.github/workflows/backend-deploy.yml
+++ b/.github/workflows/backend-deploy.yml
@@ -181,6 +181,12 @@ jobs:
             # --replace) BEFORE the pre-cutover gate so (a) the firewall self-test has redis
             # up on fingpt-net, and (b) an ABORTED deploy does not bounce the live redis /
             # wipe counters for the still-serving old container.
+            # TRADE-OFF of start-if-absent: the running container stays FROZEN on whatever
+            # redis:7-alpine image it was created from -- deploys never pick up redis image
+            # updates (security patches included). To upgrade redis, run on the droplet:
+            #   podman pull docker.io/library/redis:7-alpine && podman rm -f fingpt-redis
+            # then let the next deploy (or a re-run of this one) recreate it. Counters are
+            # ephemeral by design, so the wipe is acceptable when done deliberately.
             if ! podman container exists fingpt-redis; then
               podman run -d --name fingpt-redis --restart=always \
                 --network fingpt-net \

--- a/.github/workflows/backend-deploy.yml
+++ b/.github/workflows/backend-deploy.yml
@@ -178,27 +178,58 @@ jobs:
 
             # Redis counter store (atomic incr/decr for agent budget + ratelimit).
             # Ephemeral cache: no persistence. --replace keeps redeploys idempotent.
+            # Started BEFORE the pre-cutover validation so the firewall self-test (which
+            # asserts redis + DNS are reachable) has redis up on fingpt-net.
             podman run -d --name fingpt-redis --replace --restart=always \
               --network fingpt-net \
               --health-cmd 'redis-cli ping' --health-interval 10s --health-retries 5 \
               docker.io/library/redis:7-alpine redis-server --save '' --appendonly no
 
+            # Pre-cutover firewall validation: prove the NEW image can generate + load the
+            # SSRF egress ruleset and pass its self-test on fingpt-net BEFORE the systemctl
+            # restart's --replace kills the currently-serving container. On failure, abort
+            # so the OLD container keeps serving (there is no auto-rollback). This closes
+            # the CI-invisible gap: the test job is pytest-only and never touches nft/netns.
+            echo "Validating egress firewall on the new image (pre-cutover)..."
+            podman run --rm --cap-add=NET_ADMIN --network fingpt-net \
+              --env REDIS_URL=redis://fingpt-redis:6379/0 \
+              --entrypoint sh "$REMOTE_IMAGE" -c '
+                set -eu
+                RULES=$(mktemp)
+                python -m ops.egress_firewall > "$RULES"
+                nft -f "$RULES"
+                nft list table inet ssrf_egress >/dev/null
+                python -m ops.egress_firewall --self-test
+              ' || { echo "ERROR: egress firewall pre-cutover validation FAILED; aborting deploy (old container left serving)"; exit 1; }
+            echo "Egress firewall pre-cutover validation passed."
+
+            # Record the currently-deployed image for manual rollback (no auto-rollback).
+            PREV_IMAGE=$(podman inspect --format '{{.ImageName}}' "$SYSTEMD_UNIT" 2>/dev/null || echo "unknown")
+            echo "Previous image (manual rollback target): $PREV_IMAGE"
+
             # Update systemd override to run the image we just pulled.
-            # The image now runs as non-root uid 1001 (Dockerfile USER fingpt), so the
-            # runtime bind mount below needs BOTH relabel suffixes for the non-root process
-            # to write it on this SELinux-enforcing Fedora host:
+            # PID1 is now root-in-userns (no Dockerfile USER line); it loads the egress
+            # firewall, chowns /app/runtime to fingpt, then setpriv-drops to uid1001 for
+            # the app. The runtime bind mount still needs BOTH relabel suffixes on this
+            # SELinux-enforcing Fedora host:
             #   :U  rootless podman recursively chowns the host dir to the in-container uid
-            #       (DAC/ownership); without it the write is EACCES.
+            #       (now root/0, since PID1 is root); entrypoint then re-chowns it to fingpt
+            #       so the dropped app user can write it (validated: spec Appendix A probe 3).
             #   :Z  relabels the (private) host dir to container_file_t (MAC/SELinux);
-            #       without it container_t is denied and the write is *also* EACCES -- which
+            #       without it container_t is denied and the write is EACCES -- which
             #       crash-looped the truth-layer store build the first time a deploy actually
             #       wrote this mount (#322). Ownership alone is not enough; both are required.
+            # --cap-add=NET_ADMIN is SECURITY/FUNCTIONALLY LOAD-BEARING: rootless podman's
+            # default cap set excludes NET_ADMIN, so without it the root-in-userns init
+            # cannot load the SSRF egress firewall (nft EPERM) -> entrypoint fail-closes ->
+            # the container never serves. Do NOT drop it. (The app itself runs as uid1001
+            # with NET_ADMIN removed from its bounding set; see Main/backend/entrypoint.sh.)
             OVERRIDE_DIR="$HOME/.config/systemd/user/${SYSTEMD_UNIT}.service.d"
             mkdir -p "$OVERRIDE_DIR"
             cat > "$OVERRIDE_DIR/override.conf" <<EOF
             [Service]
             ExecStart=
-            ExecStart=/usr/bin/podman run --name ${SYSTEMD_UNIT} --replace --rm --cgroups=split --sdnotify=conmon -d --memory=1.7g --memory-swap=2g --network fingpt-net -v /home/deploy/fingpt/runtime:/app/runtime:U,Z --publish 127.0.0.1:8000:8000 --env-file /home/deploy/fingpt/envs/.env.production --env REDIS_URL=redis://fingpt-redis:6379/0 ${REMOTE_IMAGE}
+            ExecStart=/usr/bin/podman run --name ${SYSTEMD_UNIT} --replace --rm --cap-add=NET_ADMIN --cgroups=split --sdnotify=conmon -d --memory=1.7g --memory-swap=2g --network fingpt-net -v /home/deploy/fingpt/runtime:/app/runtime:U,Z --publish 127.0.0.1:8000:8000 --env-file /home/deploy/fingpt/envs/.env.production --env REDIS_URL=redis://fingpt-redis:6379/0 ${REMOTE_IMAGE}
             EOF
 
             systemctl --user daemon-reload

--- a/.github/workflows/backend-deploy.yml
+++ b/.github/workflows/backend-deploy.yml
@@ -177,13 +177,18 @@ jobs:
             podman network exists fingpt-net || podman network create fingpt-net
 
             # Redis counter store (atomic incr/decr for agent budget + ratelimit).
-            # Ephemeral cache: no persistence. --replace keeps redeploys idempotent.
-            # Started BEFORE the pre-cutover validation so the firewall self-test (which
-            # asserts redis + DNS are reachable) has redis up on fingpt-net.
-            podman run -d --name fingpt-redis --replace --restart=always \
-              --network fingpt-net \
-              --health-cmd 'redis-cli ping' --health-interval 10s --health-retries 5 \
-              docker.io/library/redis:7-alpine redis-server --save '' --appendonly no
+            # Ephemeral cache: no persistence. Started idempotently (start-if-absent, not
+            # --replace) BEFORE the pre-cutover gate so (a) the firewall self-test has redis
+            # up on fingpt-net, and (b) an ABORTED deploy does not bounce the live redis /
+            # wipe counters for the still-serving old container.
+            if ! podman container exists fingpt-redis; then
+              podman run -d --name fingpt-redis --restart=always \
+                --network fingpt-net \
+                --health-cmd 'redis-cli ping' --health-interval 10s --health-retries 5 \
+                docker.io/library/redis:7-alpine redis-server --save '' --appendonly no
+            else
+              podman start fingpt-redis >/dev/null 2>&1 || true
+            fi
 
             # Pre-cutover firewall validation: prove the NEW image can generate + load the
             # SSRF egress ruleset and pass its self-test on fingpt-net BEFORE the systemctl
@@ -197,9 +202,10 @@ jobs:
                 set -eu
                 RULES=$(mktemp)
                 python -m ops.egress_firewall > "$RULES"
+                if python -m ops.egress_firewall --metadata-reachable; then MB=1; else MB=0; fi
                 nft -f "$RULES"
                 nft list table inet ssrf_egress >/dev/null
-                python -m ops.egress_firewall --self-test
+                METADATA_WAS_REACHABLE=$MB python -m ops.egress_firewall --self-test
               ' || { echo "ERROR: egress firewall pre-cutover validation FAILED; aborting deploy (old container left serving)"; exit 1; }
             echo "Egress firewall pre-cutover validation passed."
 

--- a/.github/workflows/uptime.yml
+++ b/.github/workflows/uptime.yml
@@ -20,13 +20,17 @@ jobs:
       - name: Curl public health endpoint
         run: |
           set -euo pipefail
-          for i in 1 2 3; do
-            if curl -fsS -m 15 https://agenticfinsearch.org/health/ >/dev/null; then
+          # ~180s budget: comfortably past the documented ~130s deploy cold start (the
+          # entrypoint builds the XBRL store before gunicorn listens, behind a --replace
+          # swap), so a tick landing in a deploy window catches recovery instead of crying
+          # wolf. A genuinely dead endpoint (>180s) still alerts.
+          for i in $(seq 1 9); do
+            if curl -fsS -m 10 https://agenticfinsearch.org/health/ >/dev/null; then
               echo "healthy (attempt $i)"
               exit 0
             fi
-            echo "attempt $i failed; retrying in 20s..."
+            echo "attempt $i/9 failed; retrying in 20s..."
             sleep 20
           done
-          echo "::error::agenticfinsearch.org/health/ is DOWN after 3 attempts"
+          echo "::error::agenticfinsearch.org/health/ is DOWN after 9 attempts (~180s)"
           exit 1

--- a/.github/workflows/uptime.yml
+++ b/.github/workflows/uptime.yml
@@ -1,0 +1,32 @@
+name: Uptime Monitor
+
+# Deploy-independent liveness: the backend fail-closes on a bad egress-firewall load,
+# and a load can fail on a reboot/OOM/kernel update WITHOUT a deploy (which re-runs the
+# entrypoint). This cron curls the PUBLIC endpoint so such an outage is caught within
+# minutes instead of by a user. Zero-infra fallback; GitHub may delay scheduled runs and
+# disables schedules after 60 days of repo inactivity.
+on:
+  schedule:
+    - cron: "*/10 * * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  probe:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Curl public health endpoint
+        run: |
+          set -euo pipefail
+          for i in 1 2 3; do
+            if curl -fsS -m 15 https://agenticfinsearch.org/health/ >/dev/null; then
+              echo "healthy (attempt $i)"
+              exit 0
+            fi
+            echo "attempt $i failed; retrying in 20s..."
+            sleep 20
+          done
+          echo "::error::agenticfinsearch.org/health/ is DOWN after 3 attempts"
+          exit 1

--- a/Docs/superpowers/specs/2026-07-02-websocket-webrtc-ssrf-egress-firewall-design.md
+++ b/Docs/superpowers/specs/2026-07-02-websocket-webrtc-ssrf-egress-firewall-design.md
@@ -172,6 +172,10 @@ Deliberate choices, each from the design review:
     resolver) → else non-zero.
   - `fingpt-redis:6379` TCP connect **must succeed** within a short retry window (~5×1s, tolerating
     redis's own cold start) → else non-zero.
+  - **AMENDED at implementation:** the DNS + redis legs shipped as **advisory (WARN, exit 0)**, not
+    fatal — the prior entrypoint had zero redis/DNS boot dependency, so a fatal leg would let a
+    redis blip at reboot fail-close a correct firewall (see `_self_test`'s docstring for the full
+    rationale). Only the metadata leg is fatal.
 - `ops/__init__.py` (new, empty) so `python -m ops.egress_firewall` resolves from WORKDIR `/app`.
 
 ### Dockerfile changes

--- a/Docs/superpowers/specs/2026-07-02-websocket-webrtc-ssrf-egress-firewall-design.md
+++ b/Docs/superpowers/specs/2026-07-02-websocket-webrtc-ssrf-egress-firewall-design.md
@@ -199,6 +199,12 @@ Deliberate choices, each from the design review:
   ssrf_egress >/dev/null && python -m ops.egress_firewall --self-test'`. **Abort the deploy on
   failure** so the old container keeps serving. This converts a catastrophic mid-swap fail-closed
   into a safe no-op abort and closes the CI-invisible gap.
+  **AMENDED at implementation (simplify pass):** the gate no longer inlines that sequence — it runs
+  the image's REAL entrypoint via `podman run … "$REMOTE_IMAGE" --egress-check-only` (a flag
+  entrypoint.sh handles after the setpriv drop, exiting before the app phase). An inline copy can
+  silently drift from the boot path it is supposed to prove (and had: it lacked the `[ -s ]` and
+  grep-sentinel guards); the flag form exercises the byte-identical root-init PID1 runs at cutover.
+  Wiring pinned by `test_dockerfile_nonroot.test_precutover_gate_runs_real_entrypoint_check_only`.
 - Record/echo the previously-deployed image digest before restart, and add a one-line manual
   rollback note to the deploy log for the no-auto-rollback case.
 

--- a/Main/backend/Dockerfile
+++ b/Main/backend/Dockerfile
@@ -11,6 +11,9 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
     python3.12-venv \
     python3.12-dev \
     nodejs \
+    nftables \
+    iproute2 \
+    util-linux \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh
@@ -52,21 +55,23 @@ RUN echo "Verifying Playwright browsers..." && \
     test -d /ms-playwright/chromium_headless_shell-* && \
     echo "✓ Chromium browser found at /ms-playwright"
 
-# Create a non-root runtime user and own ONLY the writable runtime dirs.
-# The application source under /app stays root-owned so a compromised
-# process cannot rewrite code at runtime (P0 Root A.3: no-write-under-/app).
+# Create the non-root runtime user and own ONLY the writable runtime dirs.
+# The application source under /app stays root-owned so a compromised process cannot
+# rewrite code at runtime (P0 Root A.3: no-write-under-/app). PID1 (entrypoint.sh) runs
+# as root-IN-USERNS -- rootless podman keeps that host-unprivileged -- solely to load the
+# SSRF egress firewall (needs CAP_NET_ADMIN) and chown the runtime mount, then
+# setpriv-drops to fingpt (uid1001, NET_ADMIN removed from the bounding set, no_new_privs)
+# so the long-running app is non-root and cannot flush its own firewall. The
+# no-write-under-/app intent holds: the app process is uid1001 and /app is root-owned;
+# only the brief pre-app init is root and it writes nothing under /app except chowning the
+# designated writable runtime mount (see entrypoint.sh; there is deliberately no USER line).
 # /app/runtime is the writable runtime-data volume mountpoint: entrypoint.sh builds the
-# regenerable DuckDB truth-layer store there (from the root-owned, still-read-only
-# vendored companyfacts JSON in the truthlayer/data package dir) BEFORE gunicorn forks, and in
-# production it is a persistent bind mount (podman -v ...:/app/runtime:U) so the store
-# survives restarts. Owning it in the image keeps it writable even with no mount
-# (compose/CI/bare docker run). Only this regenerable artifact dir is fingpt-writable;
-# no application code (.py) becomes writable, so the no-write-under-/app intent holds.
+# regenerable DuckDB truth-layer store there BEFORE gunicorn forks; in production it is a
+# persistent bind mount (podman -v ...:/app/runtime:U,Z) so the store survives restarts.
+# Owning these dirs in the image keeps them writable with no mount (compose/CI/bare run).
 RUN groupadd --system --gid 1001 fingpt \
     && useradd --system --uid 1001 --gid fingpt --no-create-home fingpt \
     && chown -R fingpt:fingpt /app/staticfiles /app/media /app/logs /tmp/fingpt_cache /app/runtime
-
-USER fingpt
 
 ENTRYPOINT ["/app/entrypoint.sh"]
 

--- a/Main/backend/datascraper/playwright_tools.py
+++ b/Main/backend/datascraper/playwright_tools.py
@@ -14,11 +14,12 @@ from datascraper import ssrf_guard
 
 logger = logging.getLogger(__name__)
 
-# Defense-in-depth for the SSRF egress firewall: a text scraper needs neither WebRTC
-# nor QUIC. Removing the RTCPeerConnection constructors in every frame prevents page JS
-# from opening WebRTC (ICE/STUN over UDP) at all; --disable-quic (a launch arg) drops
-# QUIC/HTTP3. The netns egress firewall remains the actual boundary; this only shrinks
-# the surface for the documented public-egress residual. See ops/egress_firewall.py.
+# Best-effort surface reduction for the SSRF egress firewall (NOT a boundary): a text
+# scraper needs neither WebRTC nor QUIC. Deleting the RTCPeerConnection constructors before
+# page scripts run stops the common WebRTC path (ICE/STUN over UDP); --disable-quic (a
+# launch arg) drops QUIC/HTTP3. The netns egress firewall remains the actual boundary
+# (a fresh realm could re-obtain the constructor); this only shrinks the surface for the
+# documented public-egress residual. See ops/egress_firewall.py.
 _DISABLE_WEBRTC_JS = (
     "delete window.RTCPeerConnection;"
     "delete window.webkitRTCPeerConnection;"
@@ -63,10 +64,9 @@ async def PlaywrightBrowser(timeout: int = 30000):
         # async entrypoints (and any future one) are pinned without each having
         # to remember the call. See datascraper.ssrf_guard.install_route_guard.
         await ssrf_guard.install_route_guard(page)
-        # WebRTC hardening: remove RTCPeerConnection in every frame before page
-        # scripts run, so a scraped page cannot open WebRTC on Chromium's own socket
-        # (which page.route/route guard cannot intercept). Defense-in-depth alongside
-        # the netns egress firewall + --disable-quic launch arg.
+        # WebRTC hardening (best-effort, not a boundary): remove RTCPeerConnection before
+        # page scripts run to curb WebRTC egress on Chromium's own socket (which the route
+        # guard cannot intercept). The netns egress firewall is the real boundary.
         await page.add_init_script(_DISABLE_WEBRTC_JS)
 
         yield page

--- a/Main/backend/datascraper/playwright_tools.py
+++ b/Main/backend/datascraper/playwright_tools.py
@@ -14,6 +14,18 @@ from datascraper import ssrf_guard
 
 logger = logging.getLogger(__name__)
 
+# Defense-in-depth for the SSRF egress firewall: a text scraper needs neither WebRTC
+# nor QUIC. Removing the RTCPeerConnection constructors in every frame prevents page JS
+# from opening WebRTC (ICE/STUN over UDP) at all; --disable-quic (a launch arg) drops
+# QUIC/HTTP3. The netns egress firewall remains the actual boundary; this only shrinks
+# the surface for the documented public-egress residual. See ops/egress_firewall.py.
+_DISABLE_WEBRTC_JS = (
+    "delete window.RTCPeerConnection;"
+    "delete window.webkitRTCPeerConnection;"
+    "delete window.RTCDataChannel;"
+)
+
+
 @asynccontextmanager
 async def PlaywrightBrowser(timeout: int = 30000):
     """
@@ -36,7 +48,8 @@ async def PlaywrightBrowser(timeout: int = 30000):
         playwright = await async_playwright().start()
         browser = await playwright.chromium.launch(
             headless=True,
-            args=['--no-sandbox', '--disable-setuid-sandbox', '--disable-dev-shm-usage']
+            args=['--no-sandbox', '--disable-setuid-sandbox', '--disable-dev-shm-usage',
+                  '--disable-quic']
         )
 
         context = await browser.new_context(
@@ -50,6 +63,11 @@ async def PlaywrightBrowser(timeout: int = 30000):
         # async entrypoints (and any future one) are pinned without each having
         # to remember the call. See datascraper.ssrf_guard.install_route_guard.
         await ssrf_guard.install_route_guard(page)
+        # WebRTC hardening: remove RTCPeerConnection in every frame before page
+        # scripts run, so a scraped page cannot open WebRTC on Chromium's own socket
+        # (which page.route/route guard cannot intercept). Defense-in-depth alongside
+        # the netns egress firewall + --disable-quic launch arg.
+        await page.add_init_script(_DISABLE_WEBRTC_JS)
 
         yield page
 

--- a/Main/backend/datascraper/playwright_tools.py
+++ b/Main/backend/datascraper/playwright_tools.py
@@ -38,7 +38,7 @@ async def PlaywrightBrowser(timeout: int = 30000):
         browser = await playwright.chromium.launch(
             headless=True,
             args=['--no-sandbox', '--disable-setuid-sandbox', '--disable-dev-shm-usage',
-                  '--disable-quic']
+                  *ssrf_guard.CHROMIUM_HARDENING_ARGS]
         )
 
         context = await browser.new_context(

--- a/Main/backend/datascraper/playwright_tools.py
+++ b/Main/backend/datascraper/playwright_tools.py
@@ -14,18 +14,6 @@ from datascraper import ssrf_guard
 
 logger = logging.getLogger(__name__)
 
-# Best-effort surface reduction for the SSRF egress firewall (NOT a boundary): a text
-# scraper needs neither WebRTC nor QUIC. Deleting the RTCPeerConnection constructors before
-# page scripts run stops the common WebRTC path (ICE/STUN over UDP); --disable-quic (a
-# launch arg) drops QUIC/HTTP3. The netns egress firewall remains the actual boundary
-# (a fresh realm could re-obtain the constructor); this only shrinks the surface for the
-# documented public-egress residual. See ops/egress_firewall.py.
-_DISABLE_WEBRTC_JS = (
-    "delete window.RTCPeerConnection;"
-    "delete window.webkitRTCPeerConnection;"
-    "delete window.RTCDataChannel;"
-)
-
 
 @asynccontextmanager
 async def PlaywrightBrowser(timeout: int = 30000):
@@ -67,7 +55,7 @@ async def PlaywrightBrowser(timeout: int = 30000):
         # WebRTC hardening (best-effort, not a boundary): remove RTCPeerConnection before
         # page scripts run to curb WebRTC egress on Chromium's own socket (which the route
         # guard cannot intercept). The netns egress firewall is the real boundary.
-        await page.add_init_script(_DISABLE_WEBRTC_JS)
+        await page.add_init_script(ssrf_guard.DISABLE_WEBRTC_JS)
 
         yield page
 

--- a/Main/backend/datascraper/ssrf_guard.py
+++ b/Main/backend/datascraper/ssrf_guard.py
@@ -29,6 +29,7 @@ Public contract (do not rename):
     install_route_guard_sync(page) (sync, Playwright)
     assert_safe_page_url(page)     (async, Playwright)
     DISABLE_WEBRTC_JS              (init-script string, Playwright)
+    CHROMIUM_HARDENING_ARGS        (launch-args tuple, Playwright)
 """
 import asyncio
 import ipaddress
@@ -76,14 +77,20 @@ _POOL_MAXSIZE = int(os.getenv("SCRAPE_POOL_MAXSIZE", "20"))
 # and page.route cannot intercept it (Chromium egresses it on its own socket). Installed
 # as a pre-navigation init script by BOTH scraper paths (the playwright_tools async
 # factory and the url_tools sync fallback) — defined once HERE so the two paths cannot
-# drift. Paired with --disable-quic on the launch args. A fresh realm could re-obtain
-# the deleted constructor, so the netns egress firewall (ops/egress_firewall.py) remains
-# the actual boundary; this only shrinks the surface for the public-egress residual.
+# drift. Paired with CHROMIUM_HARDENING_ARGS on the launch args. A fresh realm could
+# re-obtain the deleted constructor, so the netns egress firewall (ops/egress_firewall.py)
+# remains the actual boundary; this only shrinks the surface for the public-egress residual.
 DISABLE_WEBRTC_JS = (
     "delete window.RTCPeerConnection;"
     "delete window.webkitRTCPeerConnection;"
     "delete window.RTCDataChannel;"
 )
+
+# The launch-args half of the same surface reduction, consumed by BOTH launch sites
+# (playwright_tools async factory + url_tools sync fallback) so a hardening flag can
+# never be added to one path only. QUIC would otherwise carry HTTP/3 on Chromium's own
+# UDP socket, past page.route exactly like WebRTC.
+CHROMIUM_HARDENING_ARGS = ("--disable-quic",)
 
 # Response headers that must NOT be forwarded when fulfilling a Playwright route
 # from a safe_get response: requests has already decoded the body (so a stale

--- a/Main/backend/datascraper/ssrf_guard.py
+++ b/Main/backend/datascraper/ssrf_guard.py
@@ -14,8 +14,11 @@ request through ``safe_get`` (IP-pinned, byte-capped) and ``route.fulfill`` the
 buffered response, so Chromium never opens its own connection for the HTTP(S)
 requests ``page.route`` intercepts. Non-GET and non-http(s) in-browser requests
 fail closed (aborted), as ``safe_get`` only serves pinned GETs. (WebSocket /
-WebRTC are NOT intercepted by ``page.route`` and remain a separate, pre-existing
-gap — out of scope here.)
+WebRTC are NOT intercepted by ``page.route``; that gap is closed for
+private/link-local/metadata destinations at the netns layer by the egress
+firewall — see ops/egress_firewall.py, which deliberately still accepts
+own-subnet + public egress — with ``DISABLE_WEBRTC_JS`` below as best-effort
+surface reduction on top.)
 
 Public contract (do not rename):
     UnsafeURLError
@@ -25,6 +28,7 @@ Public contract (do not rename):
     install_route_guard(page)      (async, Playwright)
     install_route_guard_sync(page) (sync, Playwright)
     assert_safe_page_url(page)     (async, Playwright)
+    DISABLE_WEBRTC_JS              (init-script string, Playwright)
 """
 import asyncio
 import ipaddress
@@ -67,6 +71,19 @@ _DNS_CACHE_TTL = float(os.getenv("SCRAPE_DNS_CACHE_TTL", "30"))
 # Keep-alive pool size for each cached per-host pinned session, so a same-host
 # subresource burst reuses connections instead of serializing on one.
 _POOL_MAXSIZE = int(os.getenv("SCRAPE_POOL_MAXSIZE", "20"))
+
+# Best-effort WebRTC surface reduction (NOT a boundary): a text scraper needs no WebRTC,
+# and page.route cannot intercept it (Chromium egresses it on its own socket). Installed
+# as a pre-navigation init script by BOTH scraper paths (the playwright_tools async
+# factory and the url_tools sync fallback) — defined once HERE so the two paths cannot
+# drift. Paired with --disable-quic on the launch args. A fresh realm could re-obtain
+# the deleted constructor, so the netns egress firewall (ops/egress_firewall.py) remains
+# the actual boundary; this only shrinks the surface for the public-egress residual.
+DISABLE_WEBRTC_JS = (
+    "delete window.RTCPeerConnection;"
+    "delete window.webkitRTCPeerConnection;"
+    "delete window.RTCDataChannel;"
+)
 
 # Response headers that must NOT be forwarded when fulfilling a Playwright route
 # from a safe_get response: requests has already decoded the body (so a stale

--- a/Main/backend/datascraper/url_tools.py
+++ b/Main/backend/datascraper/url_tools.py
@@ -20,9 +20,10 @@ from datascraper import ssrf_guard
 
 logger = logging.getLogger(__name__)
 
-# Defense-in-depth for the SSRF egress firewall (matches datascraper.playwright_tools):
-# remove RTCPeerConnection in every frame so a scraped page cannot open WebRTC on
+# Best-effort surface reduction for the SSRF egress firewall (NOT a boundary; matches
+# datascraper.playwright_tools): delete RTCPeerConnection to curb WebRTC egress on
 # Chromium's own socket, which page.route cannot intercept. Paired with --disable-quic.
+# The netns egress firewall is the real boundary.
 _DISABLE_WEBRTC_JS = (
     "delete window.RTCPeerConnection;"
     "delete window.webkitRTCPeerConnection;"

--- a/Main/backend/datascraper/url_tools.py
+++ b/Main/backend/datascraper/url_tools.py
@@ -20,6 +20,15 @@ from datascraper import ssrf_guard
 
 logger = logging.getLogger(__name__)
 
+# Defense-in-depth for the SSRF egress firewall (matches datascraper.playwright_tools):
+# remove RTCPeerConnection in every frame so a scraped page cannot open WebRTC on
+# Chromium's own socket, which page.route cannot intercept. Paired with --disable-quic.
+_DISABLE_WEBRTC_JS = (
+    "delete window.RTCPeerConnection;"
+    "delete window.webkitRTCPeerConnection;"
+    "delete window.RTCDataChannel;"
+)
+
 backend_dir = Path(__file__).resolve().parent.parent
 load_dotenv(backend_dir / '.env')
 
@@ -202,7 +211,7 @@ def scrape_with_playwright(url: str) -> str:
 
     try:
         with sync_playwright() as p:
-            browser = p.chromium.launch(headless=True, args=['--no-sandbox', '--disable-setuid-sandbox'])
+            browser = p.chromium.launch(headless=True, args=['--no-sandbox', '--disable-setuid-sandbox', '--disable-quic'])
             try:
                 context = browser.new_context(
                     user_agent=HEADERS['User-Agent'],
@@ -215,6 +224,10 @@ def scrape_with_playwright(url: str) -> str:
                 # seed-only validate_fetch_url checks leave open. Must precede
                 # the first navigation.
                 ssrf_guard.install_route_guard_sync(page)
+                # WebRTC hardening (see _DISABLE_WEBRTC_JS): remove RTCPeerConnection in
+                # every frame so a scraped page cannot open WebRTC on Chromium's own
+                # socket. Must precede the first navigation.
+                page.add_init_script(_DISABLE_WEBRTC_JS)
 
                 logger.info(f"Playwright scraping: {url}")
                 page.goto(url, timeout=30000, wait_until="domcontentloaded")

--- a/Main/backend/datascraper/url_tools.py
+++ b/Main/backend/datascraper/url_tools.py
@@ -20,16 +20,6 @@ from datascraper import ssrf_guard
 
 logger = logging.getLogger(__name__)
 
-# Best-effort surface reduction for the SSRF egress firewall (NOT a boundary; matches
-# datascraper.playwright_tools): delete RTCPeerConnection to curb WebRTC egress on
-# Chromium's own socket, which page.route cannot intercept. Paired with --disable-quic.
-# The netns egress firewall is the real boundary.
-_DISABLE_WEBRTC_JS = (
-    "delete window.RTCPeerConnection;"
-    "delete window.webkitRTCPeerConnection;"
-    "delete window.RTCDataChannel;"
-)
-
 backend_dir = Path(__file__).resolve().parent.parent
 load_dotenv(backend_dir / '.env')
 
@@ -225,10 +215,10 @@ def scrape_with_playwright(url: str) -> str:
                 # seed-only validate_fetch_url checks leave open. Must precede
                 # the first navigation.
                 ssrf_guard.install_route_guard_sync(page)
-                # WebRTC hardening (see _DISABLE_WEBRTC_JS): remove RTCPeerConnection in
-                # every frame so a scraped page cannot open WebRTC on Chromium's own
-                # socket. Must precede the first navigation.
-                page.add_init_script(_DISABLE_WEBRTC_JS)
+                # WebRTC hardening (see ssrf_guard.DISABLE_WEBRTC_JS): remove
+                # RTCPeerConnection in every frame so a scraped page cannot open WebRTC
+                # on Chromium's own socket. Must precede the first navigation.
+                page.add_init_script(ssrf_guard.DISABLE_WEBRTC_JS)
 
                 logger.info(f"Playwright scraping: {url}")
                 page.goto(url, timeout=30000, wait_until="domcontentloaded")

--- a/Main/backend/datascraper/url_tools.py
+++ b/Main/backend/datascraper/url_tools.py
@@ -202,7 +202,7 @@ def scrape_with_playwright(url: str) -> str:
 
     try:
         with sync_playwright() as p:
-            browser = p.chromium.launch(headless=True, args=['--no-sandbox', '--disable-setuid-sandbox', '--disable-quic'])
+            browser = p.chromium.launch(headless=True, args=['--no-sandbox', '--disable-setuid-sandbox', *ssrf_guard.CHROMIUM_HARDENING_ARGS])
             try:
                 context = browser.new_context(
                     user_agent=HEADERS['User-Agent'],

--- a/Main/backend/entrypoint.sh
+++ b/Main/backend/entrypoint.sh
@@ -17,23 +17,35 @@ if [ "$(id -u)" = "0" ]; then
         || { echo "FATAL: egress ruleset missing metadata drop sentinel" >&2; exit 1; }
     grep -qE 'ip6? daddr [0-9a-fA-F].* accept' "$RULES" \
         || { echo "FATAL: egress ruleset missing own-subnet accept" >&2; exit 1; }
+    # Record metadata reachability BEFORE load so the self-test's "unreachable" result is
+    # a true reachable->blocked transition on cloud, not a vacuous pass off-cloud.
+    if python -m ops.egress_firewall --metadata-reachable; then META_BEFORE=1; else META_BEFORE=0; fi
     nft -f "$RULES" \
         || { echo "FATAL: nft failed to load egress ruleset" >&2; exit 1; }
     rm -f "$RULES"
     nft list table inet ssrf_egress >/dev/null 2>&1 \
         || { echo "FATAL: ssrf_egress table absent after load" >&2; exit 1; }
-    # Active proof the DROP bites AND the own-subnet accept did not strand redis/DNS.
-    python -m ops.egress_firewall --self-test \
+    # Active proof the DROP bites (fatal); redis/DNS reachability is advisory (non-fatal)
+    # so a redis blip at reboot cannot fail-close a correct firewall.
+    METADATA_WAS_REACHABLE="$META_BEFORE" python -m ops.egress_firewall --self-test \
         || { echo "FATAL: egress firewall self-test failed" >&2; exit 1; }
     echo "SSRF egress firewall loaded and self-tested."
     # :U chowned the runtime mount to root (PID1 is root); hand it to the app user.
     chown -R fingpt:fingpt /app/runtime
+    # Marker (env survives setpriv) so the app phase can refuse to serve if it was ever
+    # reached WITHOUT this root-init firewall load (e.g. a mistaken non-root PID1 start).
+    export EGRESS_FW_LOADED=1
     # Drop to uid1001, remove NET_ADMIN from the BOUNDING set (so a compromised app
     # cannot re-arm/flush the firewall), set no_new_privs, and re-exec self as fingpt.
     exec setpriv --reuid=1001 --regid=1001 --init-groups \
          --bounding-set=-net_admin --no-new-privs -- "$0" "$@"
 fi
 # ---- app phase (uid 1001) continues below, unchanged ----
+
+# Fail closed if the app phase is ever reached without the root-init firewall load
+# (defends Decision 2: never serve with the SSRF egress firewall absent).
+[ "${EGRESS_FW_LOADED:-}" = "1" ] \
+    || { echo "FATAL: app phase reached without egress firewall (non-root PID1?)" >&2; exit 1; }
 
 REQUIRE_OPENAI_API_KEY="${REQUIRE_OPENAI_API_KEY:-1}"
 

--- a/Main/backend/entrypoint.sh
+++ b/Main/backend/entrypoint.sh
@@ -34,6 +34,8 @@ if [ "$(id -u)" = "0" ]; then
     chown -R fingpt:fingpt /app/runtime
     # Marker (env survives setpriv) so the app phase can refuse to serve if it was ever
     # reached WITHOUT this root-init firewall load (e.g. a mistaken non-root PID1 start).
+    # A MISTAKE-GUARD ONLY, not a security boundary: trivially spoofable via -e/--env-file,
+    # and uid1001 cannot verify the table for real (nft list itself needs NET_ADMIN).
     export EGRESS_FW_LOADED=1
     # Drop to uid1001, remove NET_ADMIN from the BOUNDING set (so a compromised app
     # cannot re-arm/flush the firewall), set no_new_privs, and re-exec self as fingpt.

--- a/Main/backend/entrypoint.sh
+++ b/Main/backend/entrypoint.sh
@@ -49,6 +49,18 @@ fi
 [ "${EGRESS_FW_LOADED:-}" = "1" ] \
     || { echo "FATAL: app phase reached without egress firewall (non-root PID1?)" >&2; exit 1; }
 
+# Deploy pre-cutover gate mode (see backend-deploy.yml): everything the gate needs has
+# already run above -- the FULL root-init (generate + sentinel checks + nft load +
+# transition-proof self-test) plus the setpriv drop and the marker guard. Exit before
+# the app phase's heavy work (store build, collectstatic). Running the gate through
+# THIS script means it can never drift from what PID1 actually runs at boot.
+# Placement is load-bearing (pinned by test_dockerfile_nonroot): above the root-init
+# block this flag would exit 0 with NO firewall loaded -- a vacuous gate.
+if [ "${1:-}" = "--egress-check-only" ]; then
+    echo "Egress firewall check-only: root-init completed; skipping app phase."
+    exit 0
+fi
+
 REQUIRE_OPENAI_API_KEY="${REQUIRE_OPENAI_API_KEY:-1}"
 
 if [ "$REQUIRE_OPENAI_API_KEY" = "1" ] && [ -z "${OPENAI_API_KEY:-}" ]; then

--- a/Main/backend/entrypoint.sh
+++ b/Main/backend/entrypoint.sh
@@ -1,6 +1,40 @@
 #!/usr/bin/env sh
 set -eu
 
+# ---- root init phase: load + PROVE the SSRF egress firewall, then drop privilege ----
+# Runs only on the first (root-in-userns) invocation; re-execs self as uid1001.
+# See ops/egress_firewall.py and Docs/superpowers/specs/2026-07-02-*egress-firewall*.
+if [ "$(id -u)" = "0" ]; then
+    RULES="$(mktemp)"
+    # Temp-file, NOT a pipe: `python ... | nft -f -` fails OPEN under dash (a generator
+    # crash yields empty stdin, nft exits 0, set -e never fires -> we serve with NO
+    # firewall). Each guard below is fail-closed-and-loud, matching this file's idiom.
+    python -m ops.egress_firewall > "$RULES" \
+        || { echo "FATAL: egress ruleset generation failed" >&2; exit 1; }
+    [ -s "$RULES" ] \
+        || { echo "FATAL: egress ruleset empty" >&2; exit 1; }
+    grep -q '169.254.0.0/16' "$RULES" \
+        || { echo "FATAL: egress ruleset missing metadata drop sentinel" >&2; exit 1; }
+    grep -qE 'ip6? daddr [0-9a-fA-F].* accept' "$RULES" \
+        || { echo "FATAL: egress ruleset missing own-subnet accept" >&2; exit 1; }
+    nft -f "$RULES" \
+        || { echo "FATAL: nft failed to load egress ruleset" >&2; exit 1; }
+    rm -f "$RULES"
+    nft list table inet ssrf_egress >/dev/null 2>&1 \
+        || { echo "FATAL: ssrf_egress table absent after load" >&2; exit 1; }
+    # Active proof the DROP bites AND the own-subnet accept did not strand redis/DNS.
+    python -m ops.egress_firewall --self-test \
+        || { echo "FATAL: egress firewall self-test failed" >&2; exit 1; }
+    echo "SSRF egress firewall loaded and self-tested."
+    # :U chowned the runtime mount to root (PID1 is root); hand it to the app user.
+    chown -R fingpt:fingpt /app/runtime
+    # Drop to uid1001, remove NET_ADMIN from the BOUNDING set (so a compromised app
+    # cannot re-arm/flush the firewall), set no_new_privs, and re-exec self as fingpt.
+    exec setpriv --reuid=1001 --regid=1001 --init-groups \
+         --bounding-set=-net_admin --no-new-privs -- "$0" "$@"
+fi
+# ---- app phase (uid 1001) continues below, unchanged ----
+
 REQUIRE_OPENAI_API_KEY="${REQUIRE_OPENAI_API_KEY:-1}"
 
 if [ "$REQUIRE_OPENAI_API_KEY" = "1" ] && [ -z "${OPENAI_API_KEY:-}" ]; then

--- a/Main/backend/ops/egress_firewall.py
+++ b/Main/backend/ops/egress_firewall.py
@@ -85,32 +85,42 @@ def build_egress_ruleset(own_v4_cidrs, own_v6_cidrs=()):
     return "\n".join(lines) + "\n"
 
 
-def _valid_own(cidrs):
-    """Keep only CIDRs that are a private IPv4 container subnet nested in a broad
-    RFC1918 range (so a special/metadata range can never be accepted)."""
+def _nets_within(cidrs, version, broads):
+    """Parse ``cidrs`` and keep only ``version`` networks nested inside one of
+    ``broads``. The ONE shared implementation of the security-load-bearing nesting
+    guard (v4: broad RFC1918; v6: real ULA/GUA), so a fix to it can never land in
+    one address family only."""
     good = []
     for c in cidrs:
         try:
             net = ipaddress.ip_network(c, strict=False)
         except ValueError:
             continue
-        if net.version == 4 and net.is_private and any(net.subnet_of(b) for b in _BROAD_RFC1918):
+        if net.version == version and any(net.subnet_of(b) for b in broads):
             good.append(net)
     return good
 
 
+def _valid_own(cidrs):
+    """Private IPv4 container subnets only (so a special/metadata range can never be
+    accepted). RFC1918 nesting already implies ``is_private``; the extra check is
+    belt-and-braces at zero cost."""
+    return [n for n in _nets_within(cidrs, 4, _BROAD_RFC1918) if n.is_private]
+
+
 def _ip_addr_cidrs(family):
-    """Global-scope CIDRs from ``ip -o <family> addr show scope global``."""
+    """Global-scope CIDRs from ``ip -o <family> addr show scope global``. ``family``
+    is ``-4`` or ``-6``, so exactly one address key can appear in the output."""
     out = subprocess.run(
         ["ip", "-o", family, "addr", "show", "scope", "global"],
         capture_output=True, text=True, check=True,
     ).stdout
+    key = "inet6" if family == "-6" else "inet"
     cidrs = []
     for line in out.splitlines():
         parts = line.split()
-        for key in ("inet", "inet6"):
-            if key in parts:
-                cidrs.append(parts[parts.index(key) + 1])
+        if key in parts:
+            cidrs.append(parts[parts.index(key) + 1])
     return cidrs
 
 
@@ -125,16 +135,13 @@ def discover_own_v6():
     """Global-scope IPv6 subnets the container owns (empty on a v4-only network like
     fingpt-net). Constrained to real ULA/GUA the container owns (symmetric with the v4
     nesting check) so same-net v6 peers stay reachable; the v6 drop block still covers
-    every OTHER v6 range."""
-    good = []
-    for c in _ip_addr_cidrs("-6"):
-        try:
-            net = ipaddress.ip_network(c, strict=False)
-        except ValueError:
-            continue
-        if net.version == 6 and any(net.subnet_of(b) for b in _BROAD_V6):
-            good.append(net)
-    return good
+    every OTHER v6 range. An EGRESS_OWN_SUBNET override is the COMPLETE own-subnet
+    spec: it suppresses discovery here too, keeping the override path fully hermetic
+    (no ``ip`` subprocess on hosts without iproute2); omitting the v6 accepts under
+    override can only fail closed."""
+    if os.getenv("EGRESS_OWN_SUBNET"):
+        return []
+    return _nets_within(_ip_addr_cidrs("-6"), 6, _BROAD_V6)
 
 
 def _redis_host_port():

--- a/Main/backend/ops/egress_firewall.py
+++ b/Main/backend/ops/egress_firewall.py
@@ -45,6 +45,11 @@ _V4_DROP = (
 # destinations egress as real IPv4 packets caught by _V4_DROP.
 _V6_DROP = ("::1/128", "::/128", "fc00::/7", "fe80::/10", "ff00::/8", "64:ff9b::/96")
 
+# A discovered own-v6 subnet must be a real ULA (fc00::/7) or GUA (2000::/3) the container
+# owns -- symmetric with _valid_own's v4 nesting check. (Cross-version subnet_of raises, so
+# v6 cannot reuse the v4 broad-RFC1918 list.)
+_BROAD_V6 = (ipaddress.ip_network("fc00::/7"), ipaddress.ip_network("2000::/3"))
+
 _METADATA = ("169.254.169.254", 80)
 
 
@@ -110,15 +115,16 @@ def discover_own_v4():
 
 def discover_own_v6():
     """Global-scope IPv6 subnets the container owns (empty on a v4-only network like
-    fingpt-net). Accepted as-is so same-net v6 peers stay reachable; the v6 drop block
-    still covers every OTHER v6 range."""
+    fingpt-net). Constrained to real ULA/GUA the container owns (symmetric with the v4
+    nesting check) so same-net v6 peers stay reachable; the v6 drop block still covers
+    every OTHER v6 range."""
     good = []
     for c in _ip_addr_cidrs("-6"):
         try:
             net = ipaddress.ip_network(c, strict=False)
         except ValueError:
             continue
-        if net.version == 6:
+        if net.version == 6 and any(net.subnet_of(b) for b in _BROAD_V6):
             good.append(net)
     return good
 
@@ -137,25 +143,46 @@ def _tcp_ok(host, port, timeout=3):
 
 
 def _self_test():
-    """Prove the firewall is actually enforcing before the app serves. A syntactically
-    valid but wrong ruleset loads fine (nft exit 0) and passes the static /health/ gate,
-    so nft's exit code alone is NOT fail-closed -- this active check is."""
+    """Prove the firewall's DROP is enforcing before the app serves.
+
+    SECURITY-CRITICAL leg (fatal): the metadata IP must be UNREACHABLE after load. This
+    is a sound "the drop bites" proof only where the target is otherwise routable (the
+    prod droplet + the deploy pre-cutover gate). The caller passes METADATA_WAS_REACHABLE
+    so an unreachable result is treated as a true reachable->blocked transition on cloud,
+    and flagged INCONCLUSIVE (warn, not proof) off-cloud (e.g. `docker compose up`), where
+    169.254.169.254 is not served.
+
+    AVAILABILITY legs (WARN, non-fatal): DNS + redis reachability. The prior entrypoint
+    had NO redis/DNS boot dependency (redis is a request-time soft dependency), so making
+    them fatal would regress resilience -- a redis blip at reboot could fail-close a
+    correct firewall. The own-subnet accept's PRESENCE is already guarded upstream (main()
+    fails loud on empty discovery; entrypoint greps for the accept line), so these legs
+    are observability, not a boot gate."""
     if _tcp_ok(*_METADATA):
         sys.stderr.write("FATAL self-test: 169.254.169.254 reachable; egress firewall not enforcing\n")
         return 1
+    if os.getenv("METADATA_WAS_REACHABLE") == "0":
+        sys.stderr.write(
+            "WARN self-test: metadata target was not routable pre-load; the drop-bites "
+            "proof is INCONCLUSIVE on this host (expected off-cloud, e.g. dev compose)\n"
+        )
     host, port = _redis_host_port()
     try:
         socket.gethostbyname(host)
+        dns_ok = True
     except OSError:
-        sys.stderr.write(f"FATAL self-test: cannot resolve {host!r}; DNS egress blocked\n")
-        return 1
-    for _ in range(6):  # tolerate redis cold start (~5s window)
-        if _tcp_ok(host, port):
-            break
-        time.sleep(1)
-    else:
-        sys.stderr.write(f"FATAL self-test: {host}:{port} unreachable; own-subnet accept broken\n")
-        return 1
+        dns_ok = False
+    redis_ok = False
+    if dns_ok:
+        for _ in range(6):  # tolerate redis cold start (~5s window)
+            if _tcp_ok(host, port):
+                redis_ok = True
+                break
+            time.sleep(1)
+    if not dns_ok:
+        sys.stderr.write(f"WARN self-test: cannot resolve {host!r} (DNS/redis may be down); continuing\n")
+    elif not redis_ok:
+        sys.stderr.write(f"WARN self-test: {host}:{port} unreachable (redis may be down); continuing\n")
     return 0
 
 
@@ -170,6 +197,10 @@ def _emit():
 
 def main(argv=None):
     argv = sys.argv[1:] if argv is None else argv
+    if "--metadata-reachable" in argv:
+        # For the caller's before/after transition proof: exit 0 iff the metadata IP is
+        # reachable right now (run this BEFORE loading the ruleset).
+        return 0 if _tcp_ok(*_METADATA) else 1
     if "--self-test" in argv:
         return _self_test()
     return _emit()

--- a/Main/backend/ops/egress_firewall.py
+++ b/Main/backend/ops/egress_firewall.py
@@ -1,0 +1,179 @@
+"""Container network-namespace egress firewall for the SSRF boundary.
+
+Chromium (Playwright) runs in-process and egresses WebSocket/WebRTC/QUIC on its own
+socket, which page.route (and thus ssrf_guard's HTTP route guard) cannot intercept.
+This module generates an nftables ``inet`` ruleset -- loaded into the container's own
+netns at startup by entrypoint.sh, as root, before dropping to uid1001 -- that DROPs
+egress to every private / link-local / metadata / special range for ALL protocols and
+ports, while ACCEPTing the container's own subnet (redis + the podman DNS resolver +
+gateway) and public destinations. One boundary, all protocols.
+
+``build_egress_ruleset`` is pure + stdlib-only so the security-critical ruleset is
+hermetically unit-testable. Discovery + validation live in ``main()``; the active
+runtime self-test lives behind ``--self-test``.
+"""
+from __future__ import annotations
+
+import ipaddress
+import os
+import socket
+import subprocess
+import sys
+import time
+from urllib.parse import urlparse
+
+TABLE = "ssrf_egress"
+
+# A legitimate container subnet must nest inside one of these broad RFC1918 ranges.
+# A discovered own-subnet is accepted ONLY if it does, so a rogue link-scoped route
+# into a special/metadata range can never become an ``accept``.
+_BROAD_RFC1918 = tuple(
+    ipaddress.ip_network(c) for c in ("10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16")
+)
+
+# IPv4 destinations that must never be reachable. Mirrors ssrf_guard._is_blocked_ip
+# categories (private, loopback, link-local incl. 169.254.169.254 metadata, CGNAT,
+# multicast, reserved, unspecified, broadcast). Kept explicit (NOT shared with
+# ssrf_guard) so a parity test pins the two without either regressing.
+_V4_DROP = (
+    "10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16", "169.254.0.0/16",
+    "127.0.0.0/8", "100.64.0.0/10", "192.0.0.0/24", "198.18.0.0/15",
+    "224.0.0.0/4", "240.0.0.0/4", "0.0.0.0/8", "255.255.255.255/32",
+)
+# IPv6 destinations (constant, emitted unconditionally: the netns always has ::1 and a
+# fe80:: on the veth). ::ffff:0.0.0.0/96 is intentionally omitted -- v4-mapped
+# destinations egress as real IPv4 packets caught by _V4_DROP.
+_V6_DROP = ("::1/128", "::/128", "fc00::/7", "fe80::/10", "ff00::/8", "64:ff9b::/96")
+
+_METADATA = ("169.254.169.254", 80)
+
+
+def build_egress_ruleset(own_v4_cidrs, own_v6_cidrs=()):
+    """Return the nftables ruleset string. Pure. Emits own-subnet accepts ONE rule per
+    element (never an anonymous ``{}`` set -- an empty set is a parse error ->
+    fail-closed). Raises ValueError on empty ``own_v4_cidrs``: the own-subnet accept is
+    the only rule keeping redis + the DNS resolver reachable, so an empty list must fail
+    loud rather than silently strand internal infra."""
+    own_v4 = [str(c) for c in own_v4_cidrs]
+    own_v6 = [str(c) for c in own_v6_cidrs]
+    if not own_v4:
+        raise ValueError("build_egress_ruleset: own_v4_cidrs is empty")
+    lines = [
+        f"table inet {TABLE} {{",
+        "  chain output {",
+        "    type filter hook output priority 0; policy accept;",
+        '    oif "lo" accept',
+    ]
+    lines += [f"    ip daddr {c} accept" for c in own_v4]
+    lines += [f"    ip6 daddr {c} accept" for c in own_v6]
+    lines.append("    ip daddr { %s } drop" % ", ".join(_V4_DROP))
+    lines.append("    ip6 daddr { %s } drop" % ", ".join(_V6_DROP))
+    lines += ["  }", "}"]
+    return "\n".join(lines) + "\n"
+
+
+def _valid_own(cidrs):
+    """Keep only CIDRs that are a private IPv4 container subnet nested in a broad
+    RFC1918 range (so a special/metadata range can never be accepted)."""
+    good = []
+    for c in cidrs:
+        try:
+            net = ipaddress.ip_network(c, strict=False)
+        except ValueError:
+            continue
+        if net.version == 4 and net.is_private and any(net.subnet_of(b) for b in _BROAD_RFC1918):
+            good.append(net)
+    return good
+
+
+def _ip_addr_cidrs(family):
+    """Global-scope CIDRs from ``ip -o <family> addr show scope global``."""
+    out = subprocess.run(
+        ["ip", "-o", family, "addr", "show", "scope", "global"],
+        capture_output=True, text=True, check=True,
+    ).stdout
+    cidrs = []
+    for line in out.splitlines():
+        parts = line.split()
+        for key in ("inet", "inet6"):
+            if key in parts:
+                cidrs.append(parts[parts.index(key) + 1])
+    return cidrs
+
+
+def discover_own_v4():
+    override = os.getenv("EGRESS_OWN_SUBNET")
+    if override:
+        return _valid_own([override])
+    return _valid_own(_ip_addr_cidrs("-4"))
+
+
+def discover_own_v6():
+    """Global-scope IPv6 subnets the container owns (empty on a v4-only network like
+    fingpt-net). Accepted as-is so same-net v6 peers stay reachable; the v6 drop block
+    still covers every OTHER v6 range."""
+    good = []
+    for c in _ip_addr_cidrs("-6"):
+        try:
+            net = ipaddress.ip_network(c, strict=False)
+        except ValueError:
+            continue
+        if net.version == 6:
+            good.append(net)
+    return good
+
+
+def _redis_host_port():
+    p = urlparse(os.getenv("REDIS_URL", "redis://fingpt-redis:6379/0"))
+    return (p.hostname or "fingpt-redis", p.port or 6379)
+
+
+def _tcp_ok(host, port, timeout=3):
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            return True
+    except OSError:
+        return False
+
+
+def _self_test():
+    """Prove the firewall is actually enforcing before the app serves. A syntactically
+    valid but wrong ruleset loads fine (nft exit 0) and passes the static /health/ gate,
+    so nft's exit code alone is NOT fail-closed -- this active check is."""
+    if _tcp_ok(*_METADATA):
+        sys.stderr.write("FATAL self-test: 169.254.169.254 reachable; egress firewall not enforcing\n")
+        return 1
+    host, port = _redis_host_port()
+    try:
+        socket.gethostbyname(host)
+    except OSError:
+        sys.stderr.write(f"FATAL self-test: cannot resolve {host!r}; DNS egress blocked\n")
+        return 1
+    for _ in range(6):  # tolerate redis cold start (~5s window)
+        if _tcp_ok(host, port):
+            break
+        time.sleep(1)
+    else:
+        sys.stderr.write(f"FATAL self-test: {host}:{port} unreachable; own-subnet accept broken\n")
+        return 1
+    return 0
+
+
+def _emit():
+    v4 = discover_own_v4()
+    if not v4:
+        sys.stderr.write("FATAL: egress firewall could not determine a valid own IPv4 subnet\n")
+        return 3
+    sys.stdout.write(build_egress_ruleset(v4, discover_own_v6()))
+    return 0
+
+
+def main(argv=None):
+    argv = sys.argv[1:] if argv is None else argv
+    if "--self-test" in argv:
+        return _self_test()
+    return _emit()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/Main/backend/ops/egress_firewall.py
+++ b/Main/backend/ops/egress_firewall.py
@@ -43,6 +43,14 @@ _V4_DROP = (
 # IPv6 destinations (constant, emitted unconditionally: the netns always has ::1 and a
 # fe80:: on the veth). ::ffff:0.0.0.0/96 is intentionally omitted -- v4-mapped
 # destinations egress as real IPv4 packets caught by _V4_DROP.
+# FUTURE-IPv6 FOOTGUN: ff00::/8 (all multicast) + fe80::/10 in an OUTPUT-hook drop also
+# swallow NDP (solicits egress to ff02:: solicited-node multicast; adverts unicast back
+# to the solicitor's fe80::), so if fingpt-net ever gains IPv6, neighbor resolution
+# fails and v6 silently dies -- the own-v6 accept alone cannot save it. When enabling v6, add an
+# icmpv6 carve-out BEFORE these drops, scoped to NDP (roughly:
+# ``meta l4proto icmpv6 icmpv6 type { nd-router-solicit, nd-router-advert,
+# nd-neighbor-solicit, nd-neighbor-advert } accept``). Harmless today: fingpt-net is
+# v4-only, so no v6 traffic exists to break.
 _V6_DROP = ("::1/128", "::/128", "fc00::/7", "fe80::/10", "ff00::/8", "64:ff9b::/96")
 
 # A discovered own-v6 subnet must be a real ULA (fc00::/7) or GUA (2000::/3) the container
@@ -174,8 +182,14 @@ def _self_test():
         dns_ok = False
     redis_ok = False
     if dns_ok:
+        # timeout=1 (not _tcp_ok's default 3): redis is same-subnet, so a live connect
+        # answers in ms and a dead-but-routable one RSTs instantly; only silent packet
+        # loss burns the full timeout. Bounds this ADVISORY leg's worst case to
+        # 6*(1+1)=12s of boot (vs 24s at timeout=3) inside the ~130s deploy health
+        # window. Rarely even reached: a stopped redis container usually fails DNS
+        # above (aardvark-dns only answers for running containers), skipping the loop.
         for _ in range(6):  # tolerate redis cold start (~5s window)
-            if _tcp_ok(host, port):
+            if _tcp_ok(host, port, timeout=1):
                 redis_ok = True
                 break
             time.sleep(1)

--- a/Main/backend/tests/test_dockerfile_nonroot.py
+++ b/Main/backend/tests/test_dockerfile_nonroot.py
@@ -7,6 +7,7 @@ These lock the Dockerfile / deploy invariants so a later edit cannot
 silently re-root the container or widen the chown back to the whole tree.
 """
 import os
+import re
 
 from django.test import SimpleTestCase
 
@@ -47,16 +48,11 @@ class DockerfileNonRootTests(SimpleTestCase):
     def test_app_drops_to_nonroot_via_entrypoint_root_init_drop(self):
         # Root-init-drop: PID1 must be root-in-userns to load the SSRF egress firewall
         # (nft needs CAP_NET_ADMIN), so the Dockerfile deliberately has NO `USER` line;
-        # entrypoint.sh drops to the non-root uid1001 (fingpt) via setpriv, removing
-        # NET_ADMIN from the bounding set + setting no_new_privs, BEFORE running the app.
-        # The no-write-under-/app posture holds: the long-running app is uid1001.
+        # entrypoint.sh drops to the non-root uid1001 (fingpt) via setpriv BEFORE running
+        # the app. The setpriv statement itself (full flag set + last-statement position)
+        # is pinned by test_privilege_drop_is_last_statement_of_root_init_block.
         self.assertNotIn("\nUSER ", self.text, "Dockerfile must NOT set a USER (root-init-drop)")
-        entry = _read(ENTRYPOINT_SH)
-        self.assertIn("setpriv", entry)
-        self.assertIn("--reuid=1001", entry)
-        self.assertIn("--regid=1001", entry)
-        self.assertIn("--bounding-set=-net_admin", entry)
-        self.assertIn("--no-new-privs", entry)
+        self.assertIn("setpriv", _read(ENTRYPOINT_SH))
 
     def test_privilege_drop_is_last_statement_of_root_init_block(self):
         # Structural: the root-init `if [ id -u == 0 ]` block must END with the setpriv
@@ -66,19 +62,17 @@ class DockerfileNonRootTests(SimpleTestCase):
         lines = _read(ENTRYPOINT_SH).splitlines()
         start = next(i for i, l in enumerate(lines) if "id -u" in l and "then" in l)
         end = next(i for i in range(start + 1, len(lines)) if lines[i].strip() == "fi")
-        logical, buf = [], ""
-        for l in lines[start + 1:end]:
-            s = l.strip()
-            if not s or s.startswith("#"):
-                continue
-            buf += ((" " if buf else "") + s.rstrip("\\").strip())
-            if not l.rstrip().endswith("\\"):
-                logical.append(buf)
-                buf = ""
-        self.assertTrue(logical[-1].startswith("exec setpriv"), logical[-1])
-        self.assertIn('-- "$0" "$@"', logical[-1])
-        self.assertIn("--bounding-set=-net_admin", logical[-1])
-        self.assertIn("--no-new-privs", logical[-1])
+        block = re.sub(r"\\\n\s*", " ", "\n".join(lines[start + 1:end]))
+        logical = [s.strip() for s in block.splitlines()
+                   if s.strip() and not s.strip().startswith("#")]
+        drop = logical[-1]
+        self.assertTrue(drop.startswith("exec setpriv"), drop)
+        self.assertIn('-- "$0" "$@"', drop)
+        # The full flag set is asserted HERE, on the actual exec statement -- a whole-file
+        # substring check would pass with the flags on any line of the script.
+        for flag in ("--reuid=1001", "--regid=1001", "--init-groups",
+                     "--bounding-set=-net_admin", "--no-new-privs"):
+            self.assertIn(flag, drop)
         joined = "\n".join(logical)
         for marker in ("gunicorn", "collectstatic", "truthlayer", "REQUIRE_OPENAI_API_KEY"):
             self.assertNotIn(marker, joined, f"app-phase marker {marker!r} inside root block")
@@ -154,6 +148,28 @@ class DeployUserNamespaceTests(SimpleTestCase):
             data = yaml.safe_load(fh)
         caps = data["services"]["api"].get("cap_add", [])
         self.assertIn("NET_ADMIN", caps)
+
+    def test_precutover_gate_runs_real_entrypoint_check_only(self):
+        # The deploy's pre-cutover gate must exercise the image's REAL entrypoint via
+        # --egress-check-only, not an inline re-copy of the root-init sequence: a
+        # hand-copied gate can silently drift from what PID1 actually runs at cutover
+        # (the previous inline copy had already dropped the [ -s ] and grep-sentinel
+        # guards). No --entrypoint override may bypass it anywhere in the deploy.
+        wf = _read(DEPLOY_WORKFLOW)
+        self.assertIn("--egress-check-only", wf)
+        self.assertNotIn("--entrypoint", wf)
+        # Placement in entrypoint.sh is load-bearing: the check-only exit must come
+        # AFTER the setpriv drop (above the root-init block it would exit 0 with NO
+        # firewall loaded -- a vacuous gate) and BEFORE the app phase's heavy store
+        # build (so the gate stays fast and dependency-free).
+        entry_lines = _read(ENTRYPOINT_SH).splitlines()
+        flag_idx = next(i for i, l in enumerate(entry_lines)
+                        if "--egress-check-only" in l and l.lstrip().startswith("if "))
+        setpriv_idx = next(i for i, l in enumerate(entry_lines)
+                           if l.lstrip().startswith("exec setpriv"))
+        store_idx = next(i for i, l in enumerate(entry_lines) if "_ensure_built" in l)
+        self.assertGreater(flag_idx, setpriv_idx)
+        self.assertLess(flag_idx, store_idx)
 
     def test_runtime_bind_mount_selinux_relabel_for_nonroot(self):
         text = _read(DEPLOY_WORKFLOW)

--- a/Main/backend/tests/test_dockerfile_nonroot.py
+++ b/Main/backend/tests/test_dockerfile_nonroot.py
@@ -16,6 +16,7 @@ ENTRYPOINT_SH = os.path.join(_HERE, "..", "entrypoint.sh")
 DEPLOY_WORKFLOW = os.path.join(
     _HERE, "..", "..", "..", ".github", "workflows", "backend-deploy.yml"
 )
+COMPOSE = os.path.join(_HERE, "..", "..", "..", "docker-compose.yml")
 
 RUNTIME_DIRS = ["/app/staticfiles", "/app/media", "/app/logs", "/tmp/fingpt_cache", "/app/runtime"]
 
@@ -56,6 +57,31 @@ class DockerfileNonRootTests(SimpleTestCase):
         self.assertIn("--regid=1001", entry)
         self.assertIn("--bounding-set=-net_admin", entry)
         self.assertIn("--no-new-privs", entry)
+
+    def test_privilege_drop_is_last_statement_of_root_init_block(self):
+        # Structural: the root-init `if [ id -u == 0 ]` block must END with the setpriv
+        # exec, and NO app-phase work (gunicorn/collectstatic/truthlayer/OPENAI gate) may
+        # run inside it -- else the app would run as root. Substring presence is not enough
+        # (dropping `exec` or hoisting an app line above setpriv keeps all substrings).
+        lines = _read(ENTRYPOINT_SH).splitlines()
+        start = next(i for i, l in enumerate(lines) if "id -u" in l and "then" in l)
+        end = next(i for i in range(start + 1, len(lines)) if lines[i].strip() == "fi")
+        logical, buf = [], ""
+        for l in lines[start + 1:end]:
+            s = l.strip()
+            if not s or s.startswith("#"):
+                continue
+            buf += ((" " if buf else "") + s.rstrip("\\").strip())
+            if not l.rstrip().endswith("\\"):
+                logical.append(buf)
+                buf = ""
+        self.assertTrue(logical[-1].startswith("exec setpriv"), logical[-1])
+        self.assertIn('-- "$0" "$@"', logical[-1])
+        self.assertIn("--bounding-set=-net_admin", logical[-1])
+        self.assertIn("--no-new-privs", logical[-1])
+        joined = "\n".join(logical)
+        for marker in ("gunicorn", "collectstatic", "truthlayer", "REQUIRE_OPENAI_API_KEY"):
+            self.assertNotIn(marker, joined, f"app-phase marker {marker!r} inside root block")
 
     def test_chown_only_runtime_dirs_not_whole_tree(self):
         # Count only actual chown COMMANDS, not prose in comments (the root-init-drop
@@ -111,6 +137,23 @@ class DeployUserNamespaceTests(SimpleTestCase):
         # uid (1001) so the non-root process can write it.
         self.assertIn("/home/deploy/fingpt/runtime:/app/runtime:U", text)
         self.assertNotIn("/home/deploy/fingpt/runtime:/app/runtime ", text)
+
+    def test_execstart_podman_run_has_net_admin_cap(self):
+        # --cap-add=NET_ADMIN is load-bearing (root-in-userns needs it to load nft) and
+        # must be on the ExecStart podman run line SPECIFICALLY -- a whole-file assertIn
+        # would pass if only the pre-cutover validation kept it while ExecStart dropped it.
+        text = _read(DEPLOY_WORKFLOW)
+        execstart = [l for l in text.splitlines() if "--name ${SYSTEMD_UNIT}" in l and "podman run" in l]
+        self.assertTrue(execstart, "ExecStart podman run line not found")
+        for l in execstart:
+            self.assertIn("--cap-add=NET_ADMIN", l)
+
+    def test_compose_api_service_has_net_admin_cap(self):
+        import yaml
+        with open(COMPOSE, "r", encoding="utf-8") as fh:
+            data = yaml.safe_load(fh)
+        caps = data["services"]["api"].get("cap_add", [])
+        self.assertIn("NET_ADMIN", caps)
 
     def test_runtime_bind_mount_selinux_relabel_for_nonroot(self):
         text = _read(DEPLOY_WORKFLOW)

--- a/Main/backend/tests/test_dockerfile_nonroot.py
+++ b/Main/backend/tests/test_dockerfile_nonroot.py
@@ -12,6 +12,7 @@ from django.test import SimpleTestCase
 
 _HERE = os.path.dirname(os.path.abspath(__file__))
 DOCKERFILE = os.path.join(_HERE, "..", "Dockerfile")
+ENTRYPOINT_SH = os.path.join(_HERE, "..", "entrypoint.sh")
 DEPLOY_WORKFLOW = os.path.join(
     _HERE, "..", "..", "..", ".github", "workflows", "backend-deploy.yml"
 )
@@ -42,11 +43,26 @@ class DockerfileNonRootTests(SimpleTestCase):
             self.text,
         )
 
-    def test_switches_to_nonroot_user(self):
-        self.assertIn("\nUSER fingpt\n", self.text)
+    def test_app_drops_to_nonroot_via_entrypoint_root_init_drop(self):
+        # Root-init-drop: PID1 must be root-in-userns to load the SSRF egress firewall
+        # (nft needs CAP_NET_ADMIN), so the Dockerfile deliberately has NO `USER` line;
+        # entrypoint.sh drops to the non-root uid1001 (fingpt) via setpriv, removing
+        # NET_ADMIN from the bounding set + setting no_new_privs, BEFORE running the app.
+        # The no-write-under-/app posture holds: the long-running app is uid1001.
+        self.assertNotIn("\nUSER ", self.text, "Dockerfile must NOT set a USER (root-init-drop)")
+        entry = _read(ENTRYPOINT_SH)
+        self.assertIn("setpriv", entry)
+        self.assertIn("--reuid=1001", entry)
+        self.assertIn("--regid=1001", entry)
+        self.assertIn("--bounding-set=-net_admin", entry)
+        self.assertIn("--no-new-privs", entry)
 
     def test_chown_only_runtime_dirs_not_whole_tree(self):
-        chown_lines = [l for l in self.lines if "chown" in l]
+        # Count only actual chown COMMANDS, not prose in comments (the root-init-drop
+        # comment block legitimately mentions chowning the runtime mount).
+        chown_lines = [
+            l for l in self.lines if "chown" in l and not l.strip().startswith("#")
+        ]
         self.assertEqual(
             len(chown_lines), 1, f"expected exactly one chown line, got {chown_lines}"
         )
@@ -62,18 +78,17 @@ class DockerfileNonRootTests(SimpleTestCase):
         # snapshots) stays root-owned and read-only, restoring no-write-under-/app.
         self.assertNotIn("/app/truthlayer/data", chown)
 
-    def test_user_switch_after_last_root_run_before_entrypoint(self):
+    def test_chown_after_last_root_run_before_entrypoint(self):
         ln_idx = self._index_of("ln -sf /ms-playwright")
         verify_idx = self._index_of("Chromium browser found")
         chown_idx = self._index_of("chown -R fingpt:fingpt")
-        user_idx = self._index_of("USER fingpt")
         entry_idx = self._index_of('ENTRYPOINT ["/app/entrypoint.sh"]')
-        # USER comes after the last root RUN (the /usr/bin symlink + browser verify)
-        # and after the chown, then immediately before ENTRYPOINT.
-        self.assertGreater(user_idx, ln_idx)
-        self.assertGreater(user_idx, verify_idx)
-        self.assertGreater(user_idx, chown_idx)
-        self.assertLess(user_idx, entry_idx)
+        # The chown comes after the last root RUN (the /usr/bin symlink + browser verify)
+        # and before ENTRYPOINT. There is no Dockerfile USER line (root-init-drop): the
+        # privilege drop to uid1001 happens at runtime in entrypoint.sh via setpriv.
+        self.assertGreater(chown_idx, ln_idx)
+        self.assertGreater(chown_idx, verify_idx)
+        self.assertLess(chown_idx, entry_idx)
 
     def test_store_persisted_on_runtime_volume(self):
         # The regenerable DuckDB store must build onto the /app/runtime volume

--- a/Main/backend/tests/test_egress_firewall.py
+++ b/Main/backend/tests/test_egress_firewall.py
@@ -24,6 +24,8 @@ from ops.egress_firewall import (
 )
 from datascraper import ssrf_guard
 
+_BACKEND = Path(__file__).resolve().parent.parent
+
 
 def test_v4_drop_ranges_all_present():
     rs = build_egress_ruleset(["10.89.0.0/24"])
@@ -76,6 +78,17 @@ def test_override_env(monkeypatch):
     assert [str(n) for n in discover_own_v4()] == ["10.89.0.0/24"]
 
 
+def test_override_env_suppresses_v6_discovery(monkeypatch):
+    # The override is the COMPLETE own-subnet spec: v6 discovery must not shell out
+    # either, keeping the override path hermetic on hosts without iproute2.
+    monkeypatch.setenv("EGRESS_OWN_SUBNET", "10.89.0.0/24")
+    monkeypatch.setattr(
+        ef.subprocess, "run",
+        lambda *a, **k: pytest.fail("override must suppress the ip subprocess"),
+    )
+    assert ef.discover_own_v6() == []
+
+
 # Parity vs ssrf_guard: the two "what is private" definitions must not silently diverge.
 # 100.64/10 (CGNAT) is deliberately EXCLUDED: the firewall drops it, but ssrf_guard's
 # ipaddress-based check does NOT block it on Python 3.12/3.13 (is_private=False) -- a
@@ -98,10 +111,9 @@ def test_parity_with_ssrf_guard_block_list():
 
 def test_subprocess_invocation_is_hermetic():
     env = dict(os.environ, EGRESS_OWN_SUBNET="10.89.0.0/24")
-    backend = Path(__file__).resolve().parent.parent
     r = subprocess.run(
         [sys.executable, "-m", "ops.egress_firewall"],
-        cwd=backend, env=env, capture_output=True, text=True,
+        cwd=_BACKEND, env=env, capture_output=True, text=True,
     )
     assert r.returncode == 0, r.stderr
     assert "table inet ssrf_egress" in r.stdout
@@ -161,9 +173,12 @@ def test_self_test_passes_when_blocked_and_infra_up(monkeypatch):
 
 def test_entrypoint_grep_sentinels_match_generated_ruleset():
     # The entrypoint's own-subnet-accept grep pattern must match what the generator emits.
-    entry = (Path(__file__).resolve().parent.parent / "entrypoint.sh").read_text()
+    entry = (_BACKEND / "entrypoint.sh").read_text()
     rs = build_egress_ruleset(["10.89.0.0/24"])
     assert "169.254.0.0/16" in entry and "169.254.0.0/16" in rs
     m = re.search(r"grep -qE '([^']+)'", entry)
     assert m, "own-subnet accept 'grep -qE' pattern not found in entrypoint.sh"
     assert re.search(m.group(1), rs), f"entrypoint grep {m.group(1)!r} does not match ruleset"
+    # The entrypoint's post-load table check must use the SAME table name the generator
+    # creates (the literal is spelled in both places; pin them together).
+    assert f"nft list table inet {ef.TABLE}" in entry

--- a/Main/backend/tests/test_egress_firewall.py
+++ b/Main/backend/tests/test_egress_firewall.py
@@ -6,12 +6,15 @@ depend on the runner's interfaces.
 """
 import ipaddress
 import os
+import re
 import subprocess
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
+import ops.egress_firewall as ef
 from ops.egress_firewall import (
     _V4_DROP,
     _V6_DROP,
@@ -103,3 +106,64 @@ def test_subprocess_invocation_is_hermetic():
     assert r.returncode == 0, r.stderr
     assert "table inet ssrf_egress" in r.stdout
     assert "169.254.0.0/16" in r.stdout
+
+
+# --- discovery parser (security-load-bearing; the override tests above bypass it) ---
+
+def _patch_ip(monkeypatch, stdout):
+    monkeypatch.setattr(ef.subprocess, "run", lambda *a, **k: SimpleNamespace(stdout=stdout))
+    monkeypatch.delenv("EGRESS_OWN_SUBNET", raising=False)
+
+
+def test_discover_own_v4_parses_real_ip_output(monkeypatch):
+    # brd token, secondary addr on a second interface — the parser must pick the CIDR
+    # right after each 'inet', not the brd address or the ifname column.
+    sample = (
+        "2: eth0    inet 10.89.0.26/24 brd 10.89.0.255 scope global eth0\\       valid_lft forever\n"
+        "3: eth1    inet 172.20.0.5/16 brd 172.20.255.255 scope global eth1\\       valid_lft forever\n"
+    )
+    _patch_ip(monkeypatch, sample)
+    assert [str(n) for n in discover_own_v4()] == ["10.89.0.0/24", "172.20.0.0/16"]
+
+
+def test_discover_own_v4_rejects_rogue_special_scope_global(monkeypatch):
+    # A rogue link-local/metadata route showing as scope global must NOT become an accept.
+    sample = (
+        "2: eth0 inet 10.89.0.26/24 brd 10.89.0.255 scope global eth0\n"
+        "3: eth1 inet 169.254.10.5/16 scope global eth1\n"
+    )
+    _patch_ip(monkeypatch, sample)
+    assert [str(n) for n in discover_own_v4()] == ["10.89.0.0/24"]
+
+
+def test_self_test_metadata_reachable_is_fatal(monkeypatch):
+    monkeypatch.setattr(ef, "_tcp_ok", lambda h, p, timeout=3: h == "169.254.169.254")
+    assert ef._self_test() == 1
+
+
+def test_self_test_redis_and_dns_down_is_nonfatal(monkeypatch):
+    # metadata blocked (good) but redis/DNS down -> WARN + continue (0), matching the
+    # prior entrypoint's zero redis-boot-dependency (no resilience regression).
+    monkeypatch.setattr(ef, "_tcp_ok", lambda h, p, timeout=3: False)
+
+    def _boom(_):
+        raise OSError("no dns")
+
+    monkeypatch.setattr(ef.socket, "gethostbyname", _boom)
+    assert ef._self_test() == 0
+
+
+def test_self_test_passes_when_blocked_and_infra_up(monkeypatch):
+    monkeypatch.setattr(ef, "_tcp_ok", lambda h, p, timeout=3: h != "169.254.169.254")
+    monkeypatch.setattr(ef.socket, "gethostbyname", lambda h: "10.89.0.5")
+    assert ef._self_test() == 0
+
+
+def test_entrypoint_grep_sentinels_match_generated_ruleset():
+    # The entrypoint's own-subnet-accept grep pattern must match what the generator emits.
+    entry = (Path(__file__).resolve().parent.parent / "entrypoint.sh").read_text()
+    rs = build_egress_ruleset(["10.89.0.0/24"])
+    assert "169.254.0.0/16" in entry and "169.254.0.0/16" in rs
+    m = re.search(r"grep -qE '([^']+)'", entry)
+    assert m, "own-subnet accept 'grep -qE' pattern not found in entrypoint.sh"
+    assert re.search(m.group(1), rs), f"entrypoint grep {m.group(1)!r} does not match ruleset"

--- a/Main/backend/tests/test_egress_firewall.py
+++ b/Main/backend/tests/test_egress_firewall.py
@@ -1,0 +1,105 @@
+"""Egress firewall ruleset-generator tests (WS/WebRTC SSRF).
+
+Pure/hermetic: build_egress_ruleset takes CIDRs and returns a string; no network,
+no nft, no container. The one subprocess test uses EGRESS_OWN_SUBNET so it does not
+depend on the runner's interfaces.
+"""
+import ipaddress
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from ops.egress_firewall import (
+    _V4_DROP,
+    _V6_DROP,
+    _valid_own,
+    build_egress_ruleset,
+    discover_own_v4,
+)
+from datascraper import ssrf_guard
+
+
+def test_v4_drop_ranges_all_present():
+    rs = build_egress_ruleset(["10.89.0.0/24"])
+    for cidr in _V4_DROP:
+        assert cidr in rs
+
+
+def test_v6_drop_block_present_even_on_v4_only_network():
+    rs = build_egress_ruleset(["10.89.0.0/24"], [])
+    for cidr in _V6_DROP:
+        assert cidr in rs
+
+
+def test_metadata_range_is_dropped():
+    assert "169.254.0.0/16" in build_egress_ruleset(["10.89.0.0/24"])
+
+
+def test_own_subnet_accept_precedes_broad_drop():
+    rs = build_egress_ruleset(["10.89.0.0/24"])
+    assert rs.index("ip daddr 10.89.0.0/24 accept") < rs.index("10.0.0.0/8")
+
+
+def test_never_emits_empty_anonymous_set():
+    rs = build_egress_ruleset(["10.89.0.0/24"], [])
+    assert "{}" not in rs
+    assert "{ }" not in rs
+
+
+def test_v6_own_subnet_emitted_per_element_only_when_present():
+    before_drop = build_egress_ruleset(["10.89.0.0/24"], []).split("ip6 daddr {")[0]
+    assert "ip6 daddr" not in before_drop
+    rs = build_egress_ruleset(["10.89.0.0/24"], ["fd00:89::/64"])
+    assert "ip6 daddr fd00:89::/64 accept" in rs
+
+
+def test_empty_own_v4_raises():
+    with pytest.raises(ValueError):
+        build_egress_ruleset([])
+
+
+def test_valid_own_rejects_special_and_public_ranges():
+    assert _valid_own(["169.254.0.0/16"]) == []      # metadata / link-local
+    assert _valid_own(["100.64.0.0/10"]) == []       # CGNAT (not nested in broad RFC1918)
+    assert _valid_own(["8.8.8.0/24"]) == []          # public
+    assert [str(n) for n in _valid_own(["10.89.0.26/24"])] == ["10.89.0.0/24"]
+
+
+def test_override_env(monkeypatch):
+    monkeypatch.setenv("EGRESS_OWN_SUBNET", "10.89.0.0/24")
+    assert [str(n) for n in discover_own_v4()] == ["10.89.0.0/24"]
+
+
+# Parity vs ssrf_guard: the two "what is private" definitions must not silently diverge.
+# 100.64/10 (CGNAT) is deliberately EXCLUDED: the firewall drops it, but ssrf_guard's
+# ipaddress-based check does NOT block it on Python 3.12/3.13 (is_private=False) -- a
+# real HTTP-side gap tracked separately, NOT fixed in this egress-firewall PR.
+_DANGEROUS = [
+    "169.254.169.254", "10.1.2.3", "172.16.5.5", "192.168.1.1", "127.0.0.1",
+    "0.0.0.0", "255.255.255.255", "198.18.0.1", "192.0.0.170", "240.0.0.1",
+    "::1", "fc00::1", "fe80::1",
+]
+
+
+def test_parity_with_ssrf_guard_block_list():
+    rs = build_egress_ruleset(["10.89.0.0/24"])
+    for ip in _DANGEROUS:
+        assert ssrf_guard._is_blocked_ip(ip), f"ssrf_guard should block {ip}"
+        addr = ipaddress.ip_address(ip)
+        drops = _V4_DROP if addr.version == 4 else _V6_DROP
+        assert any(addr in ipaddress.ip_network(c) for c in drops), f"firewall should drop {ip}"
+
+
+def test_subprocess_invocation_is_hermetic():
+    env = dict(os.environ, EGRESS_OWN_SUBNET="10.89.0.0/24")
+    backend = Path(__file__).resolve().parent.parent
+    r = subprocess.run(
+        [sys.executable, "-m", "ops.egress_firewall"],
+        cwd=backend, env=env, capture_output=True, text=True,
+    )
+    assert r.returncode == 0, r.stderr
+    assert "table inet ssrf_egress" in r.stdout
+    assert "169.254.0.0/16" in r.stdout

--- a/Main/backend/tests/test_ssrf_wire.py
+++ b/Main/backend/tests/test_ssrf_wire.py
@@ -25,6 +25,56 @@ def _fake_html_response(text: str) -> MagicMock:
     return resp
 
 
+def _async_pw_mocks():
+    """Mock chain for pt.PlaywrightBrowser: async_playwright().start() -> playwright
+    .chromium.launch(**kw) -> browser.new_context() -> context.new_page() -> page.
+    Returns (ap, page, launch_kwargs); launch kwargs are captured so hardening tests
+    can assert on them. ONE scaffold shared by the factory-guard and Chromium-hardening
+    tests, so a change to the factory's call chain is fixed in one place."""
+    page = MagicMock(name="page")
+    page.add_init_script = AsyncMock()
+    context = MagicMock(name="context")
+    context.new_page = AsyncMock(return_value=page)
+    browser = MagicMock(name="browser")
+    browser.new_context = AsyncMock(return_value=context)
+    browser.close = AsyncMock()
+    launch_kwargs = {}
+
+    async def _launch(**kwargs):
+        launch_kwargs.update(kwargs)
+        return browser
+
+    playwright = MagicMock(name="playwright")
+    playwright.chromium.launch = AsyncMock(side_effect=_launch)
+    playwright.stop = AsyncMock()
+    ap = MagicMock()
+    ap.start = AsyncMock(return_value=playwright)
+    return ap, page, launch_kwargs
+
+
+def _sync_pw_mocks():
+    """Sync-fallback twin of _async_pw_mocks for url_tools.scrape_with_playwright:
+    sync_playwright() (context manager) -> p.chromium.launch(**kw) -> browser
+    .new_context() -> context.new_page() -> page. Returns (sp_cm, page, launch_kwargs)."""
+    page = MagicMock()
+    page.url = "http://example.com/x"
+    ctx = MagicMock()
+    ctx.new_page.return_value = page
+    browser = MagicMock()
+    browser.new_context.return_value = ctx
+    launch_kwargs = {}
+
+    def _launch(**kwargs):
+        launch_kwargs.update(kwargs)
+        return browser
+
+    p = MagicMock()
+    p.chromium.launch.side_effect = _launch
+    sp_cm = MagicMock()
+    sp_cm.__enter__.return_value = p
+    return sp_cm, page, launch_kwargs
+
+
 class ScrapeUrlSinkTests(SimpleTestCase):
     """_scrape_url_impl must fetch only via ssrf_guard.safe_get."""
 
@@ -87,16 +137,7 @@ class PlaywrightFallbackRouteGuardTests(SimpleTestCase):
     Chromium subresources are pinned, not only the seed + post-nav URL."""
 
     def test_scrape_with_playwright_installs_sync_route_guard(self):
-        page = MagicMock()
-        page.url = "http://example.com/x"
-        ctx = MagicMock()
-        ctx.new_page.return_value = page
-        browser = MagicMock()
-        browser.new_context.return_value = ctx
-        p = MagicMock()
-        p.chromium.launch.return_value = browser
-        sp_cm = MagicMock()
-        sp_cm.__enter__.return_value = p
+        sp_cm, page, _ = _sync_pw_mocks()
 
         # Record whether the navigation had already happened at the instant the
         # guard is installed. The guard MUST precede page.goto, else the seed
@@ -174,18 +215,7 @@ class PlaywrightFactoryGuardTests(SimpleTestCase):
     def test_factory_installs_route_guard_on_yielded_page(self):
         import datascraper.playwright_tools as pt
 
-        page = MagicMock(name="page")
-        page.add_init_script = AsyncMock()
-        context = MagicMock(name="context")
-        context.new_page = AsyncMock(return_value=page)
-        browser = MagicMock(name="browser")
-        browser.new_context = AsyncMock(return_value=context)
-        browser.close = AsyncMock()
-        playwright = MagicMock(name="playwright")
-        playwright.chromium.launch = AsyncMock(return_value=browser)
-        playwright.stop = AsyncMock()
-        ap = MagicMock()
-        ap.start = AsyncMock(return_value=playwright)
+        ap, page, _ = _async_pw_mocks()
 
         async def run():
             with patch("playwright.async_api.async_playwright", return_value=ap), \
@@ -209,24 +239,7 @@ class ChromiumEgressHardeningTests(SimpleTestCase):
     def test_async_factory_disables_webrtc_and_quic(self):
         import datascraper.playwright_tools as pt
 
-        page = MagicMock(name="page")
-        page.add_init_script = AsyncMock()
-        context = MagicMock(name="context")
-        context.new_page = AsyncMock(return_value=page)
-        browser = MagicMock(name="browser")
-        browser.new_context = AsyncMock(return_value=context)
-        browser.close = AsyncMock()
-        launch_kwargs = {}
-
-        async def _launch(**kwargs):
-            launch_kwargs.update(kwargs)
-            return browser
-
-        playwright = MagicMock(name="playwright")
-        playwright.chromium.launch = AsyncMock(side_effect=_launch)
-        playwright.stop = AsyncMock()
-        ap = MagicMock()
-        ap.start = AsyncMock(return_value=playwright)
+        ap, page, launch_kwargs = _async_pw_mocks()
 
         async def run():
             with patch("playwright.async_api.async_playwright", return_value=ap), \
@@ -247,22 +260,7 @@ class ChromiumEgressHardeningTests(SimpleTestCase):
     def test_sync_path_disables_webrtc_and_quic(self):
         import datascraper.url_tools as ut
 
-        page = MagicMock()
-        page.url = "http://example.com/x"
-        ctx = MagicMock()
-        ctx.new_page.return_value = page
-        browser = MagicMock()
-        browser.new_context.return_value = ctx
-        launch_kwargs = {}
-
-        def _launch(**kwargs):
-            launch_kwargs.update(kwargs)
-            return browser
-
-        p = MagicMock()
-        p.chromium.launch.side_effect = _launch
-        sp_cm = MagicMock()
-        sp_cm.__enter__.return_value = p
+        sp_cm, page, launch_kwargs = _sync_pw_mocks()
 
         # Record whether goto had already run at the instant the init script is installed;
         # it MUST precede navigation or it is inert on the seed page.

--- a/Main/backend/tests/test_ssrf_wire.py
+++ b/Main/backend/tests/test_ssrf_wire.py
@@ -175,6 +175,7 @@ class PlaywrightFactoryGuardTests(SimpleTestCase):
         import datascraper.playwright_tools as pt
 
         page = MagicMock(name="page")
+        page.add_init_script = AsyncMock()
         context = MagicMock(name="context")
         context.new_page = AsyncMock(return_value=page)
         browser = MagicMock(name="browser")
@@ -197,3 +198,52 @@ class PlaywrightFactoryGuardTests(SimpleTestCase):
                     self.assertIs(yielded, page)
 
         asyncio.run(run())
+
+
+class ChromiumEgressHardeningTests(SimpleTestCase):
+    """WebRTC/QUIC are disabled at the Chromium layer (defense-in-depth for the netns
+    egress firewall) in BOTH the async factory and the sync fallback: --disable-quic on
+    the launch args, and an init script that removes RTCPeerConnection so page JS cannot
+    open WebRTC at all."""
+
+    def test_async_factory_disables_webrtc_and_quic(self):
+        import datascraper.playwright_tools as pt
+
+        page = MagicMock(name="page")
+        page.add_init_script = AsyncMock()
+        context = MagicMock(name="context")
+        context.new_page = AsyncMock(return_value=page)
+        browser = MagicMock(name="browser")
+        browser.new_context = AsyncMock(return_value=context)
+        browser.close = AsyncMock()
+        launch_kwargs = {}
+
+        async def _launch(**kwargs):
+            launch_kwargs.update(kwargs)
+            return browser
+
+        playwright = MagicMock(name="playwright")
+        playwright.chromium.launch = AsyncMock(side_effect=_launch)
+        playwright.stop = AsyncMock()
+        ap = MagicMock()
+        ap.start = AsyncMock(return_value=playwright)
+
+        async def run():
+            with patch("playwright.async_api.async_playwright", return_value=ap), \
+                 patch("datascraper.ssrf_guard.install_route_guard", new=AsyncMock()):
+                async with pt.PlaywrightBrowser():
+                    pass
+
+        asyncio.run(run())
+        args = launch_kwargs.get("args", [])
+        self.assertIn("--disable-quic", args)
+        page.add_init_script.assert_awaited()
+        script = page.add_init_script.await_args.args[0]
+        self.assertIn("RTCPeerConnection", script)
+
+    def test_sync_path_disables_webrtc_and_quic(self):
+        import datascraper.url_tools as ut
+        text = open(ut.__file__, "r", encoding="utf-8").read()
+        self.assertIn("--disable-quic", text)
+        self.assertIn("add_init_script", text)
+        self.assertIn("RTCPeerConnection", text)

--- a/Main/backend/tests/test_ssrf_wire.py
+++ b/Main/backend/tests/test_ssrf_wire.py
@@ -239,6 +239,9 @@ class ChromiumEgressHardeningTests(SimpleTestCase):
         self.assertIn("--disable-quic", args)
         page.add_init_script.assert_awaited()
         script = page.add_init_script.await_args.args[0]
+        # Exact equality with the SHARED constant (single-sourced in ssrf_guard), not
+        # just a substring: pins that this path cannot drift onto a local copy.
+        self.assertEqual(script, ssrf_guard.DISABLE_WEBRTC_JS)
         self.assertIn("RTCPeerConnection", script)
 
     def test_sync_path_disables_webrtc_and_quic(self):
@@ -280,6 +283,9 @@ class ChromiumEgressHardeningTests(SimpleTestCase):
         self.assertIn("--disable-quic", launch_kwargs.get("args", []))
         page.add_init_script.assert_called_once()
         script = page.add_init_script.call_args.args[0]
+        # Same shared-constant pin as the async path: both scrapers must install THE
+        # ssrf_guard.DISABLE_WEBRTC_JS object, not a reintroduced local copy.
+        self.assertEqual(script, ssrf_guard.DISABLE_WEBRTC_JS)
         self.assertIn("RTCPeerConnection", script)
         self.assertIn("goto_at_init", order)
         self.assertFalse(order["goto_at_init"], "add_init_script must precede page.goto")

--- a/Main/backend/tests/test_ssrf_wire.py
+++ b/Main/backend/tests/test_ssrf_wire.py
@@ -243,7 +243,43 @@ class ChromiumEgressHardeningTests(SimpleTestCase):
 
     def test_sync_path_disables_webrtc_and_quic(self):
         import datascraper.url_tools as ut
-        text = open(ut.__file__, "r", encoding="utf-8").read()
-        self.assertIn("--disable-quic", text)
-        self.assertIn("add_init_script", text)
-        self.assertIn("RTCPeerConnection", text)
+
+        page = MagicMock()
+        page.url = "http://example.com/x"
+        ctx = MagicMock()
+        ctx.new_page.return_value = page
+        browser = MagicMock()
+        browser.new_context.return_value = ctx
+        launch_kwargs = {}
+
+        def _launch(**kwargs):
+            launch_kwargs.update(kwargs)
+            return browser
+
+        p = MagicMock()
+        p.chromium.launch.side_effect = _launch
+        sp_cm = MagicMock()
+        sp_cm.__enter__.return_value = p
+
+        # Record whether goto had already run at the instant the init script is installed;
+        # it MUST precede navigation or it is inert on the seed page.
+        order = {}
+
+        def _record_init(script):
+            order["goto_at_init"] = page.goto.called
+
+        page.add_init_script.side_effect = _record_init
+
+        with patch("datascraper.ssrf_guard.validate_fetch_url", side_effect=lambda u: u), \
+             patch("datascraper.ssrf_guard.install_route_guard_sync"), \
+             patch("datascraper.url_tools._extract_article_text", return_value="hello world"), \
+             patch("datascraper.url_tools._dismiss_cookie_consent"), \
+             patch("playwright.sync_api.sync_playwright", return_value=sp_cm):
+            ut.scrape_with_playwright("http://example.com/x")
+
+        self.assertIn("--disable-quic", launch_kwargs.get("args", []))
+        page.add_init_script.assert_called_once()
+        script = page.add_init_script.call_args.args[0]
+        self.assertIn("RTCPeerConnection", script)
+        self.assertIn("goto_at_init", order)
+        self.assertFalse(order["goto_at_init"], "add_init_script must precede page.goto")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,12 @@ services:
   api:
     build: ./Main/backend
 
+    # Required: entrypoint.sh loads the SSRF egress firewall (nft) into the container
+    # netns at startup, which needs CAP_NET_ADMIN. Without it the fail-closed entrypoint
+    # aborts and the container never serves. Mirrors --cap-add=NET_ADMIN in prod.
+    cap_add:
+      - NET_ADMIN
+
     ports:
       # P0 Root C.1: publish only to loopback; the host reverse proxy (Caddy)
       # is the sole public entrypoint and sets X-Real-IP.


### PR DESCRIPTION
## Summary
Closes the WebSocket/WebRTC/QUIC SSRF gap `page.route` cannot intercept (Chromium egresses those on its own socket, bypassing the HTTP route guard) with a **container-netns nftables egress firewall** — one boundary, all protocols. Loaded fail-closed at startup by a **root-init-drop** entrypoint that then drops to uid1001.

Design: `Docs/superpowers/specs/2026-07-02-websocket-webrtc-ssrf-egress-firewall-design.md`
Plan: `Docs/superpowers/plans/2026-07-02-websocket-webrtc-ssrf-egress-firewall.md`

## What it does
- **`ops/egress_firewall.py`** — pure ruleset generator (`inet` family, default-accept + destination DROPs for every private/link-local/metadata/special range; own-subnet `/24` accept for redis + podman DNS) + validated fail-loud discovery + an active `--self-test`.
- **`entrypoint.sh` root-init-drop** — PID1 runs as root-in-userns (rootless podman keeps it host-unprivileged), loads the firewall (guarded temp-file load, NOT a pipe — a pipe fails *open* under dash), runs the self-test, chowns the runtime mount, then `exec setpriv --bounding-set=-net_admin --no-new-privs` to uid1001. A compromised app **cannot flush its own firewall** (NET_ADMIN removed from the bounding set). No setcap → no capability-xattr-survival risk.
- **Dockerfile** — install nftables/iproute2/util-linux; remove `USER fingpt` (init drops instead).
- **Deploy** — `--cap-add=NET_ADMIN` (load-bearing) + a **pre-cutover validation gate** that loads+self-tests the new image on `fingpt-net` *before* the `--replace` swap and aborts on failure (old container keeps serving; no auto-rollback exists). Records the previous image for manual rollback. `docker-compose.yml` gets `cap_add: [NET_ADMIN]`.
- **Chromium hardening** (defense-in-depth, both scraper paths) — `--disable-quic` + delete `RTCPeerConnection` before page scripts.
- **`uptime.yml`** — off-box cron catching a fail-closed outage that happens *without* a deploy (reboot/OOM/update).

## Security invariants (all droplet-validated)
- Metadata + all private ranges DROPped for every protocol (WS/WebRTC/QUIC/TCP/UDP): `169.254.169.254` REACHABLE → **UNREACHABLE** with the ruleset applied.
- Non-self-disarmable: uid1001 `nft flush`/`nft delete` **BLOCKED** (CapBnd NET_ADMIN cleared, `no_new_privs=1`).
- Genuinely fail-closed: guarded load + post-load table assertion + active self-test; metadata proof is a reachable→blocked **transition** (honest/inconclusive off-cloud).
- `:U,Z` runtime mount handled by an explicit root chown (uid1001 writes it) — mount suffixes unchanged.

## Test plan
- [x] Full backend suite green: **561 passed, 1 skipped, 0 failures**
- [x] Django `manage.py check` + `verify_deployment.py` pass
- [x] Real shipped `ops` module on prod `fingpt-net` (SELinux enforcing): correct ruleset, `NFT_LOAD_OK`, `TABLE_PRESENT`, `SELFTEST_PASS`
- [x] Droplet probes: setpriv self-disarm blocked; `:U,Z`+chown lets uid1001 write runtime; empty `ip6 daddr {}` is a parse error; no-cap → nft EPERM
- [x] Adversarial design + implementation review (multi-agent) — confirmed findings fixed in-branch

## Documented residuals (nft cannot close — Chromium shares netns+uid)
- browser→`redis:6379`/DNS (mitigated: 6379 is a Chromium-blocked port; future redis AUTH / Chromium-netns isolation)
- `wss://public:443` exfil (indistinguishable from HTTPS at L3/L4; WebRTC/QUIC disabled at Chromium reduces surface)

## Tracked follow-ups (NOT in this PR)
- `ssrf_guard` CGNAT gap: `100.64.0.0/10` is firewall-dropped but not blocked by `_is_blocked_ip` (`is_private=False` on Py3.12/3.13) — separate HTTP-side PR.
- Deferred hardening: `EGRESS_OWN_SUBNET` prefixlen floor, `RULES` mktemp trap, writable `$HOME` for the dropped user.

⚠️ Merging `main` auto-deploys to prod (no auto-rollback). The pre-cutover gate makes a bad firewall abort safely, but please review before merge.