### PR TITLE
fix(security): close CGNAT + 192.0.0.0/24 HTTP-side SSRF gaps; drop dead RUN_TESTS scaffolding

### DIFF
--- a/.github/workflows/backend-deploy.yml
+++ b/.github/workflows/backend-deploy.yml
@@ -23,7 +23,6 @@ env:
   DROPLET_HOST: ${{ vars.DROPLET_HOST }}
   DROPLET_USER: ${{ vars.DROPLET_USER }}
   SYSTEMD_UNIT: fingpt-api
-  RUN_TESTS: "true" # Backend TDD suite gates deploy (P0 F-gate)
 
 jobs:
   build:
@@ -109,25 +108,17 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
-      - name: Tests temporarily disabled
-        if: ${{ env.RUN_TESTS != 'true' }}
-        run: echo "::warning::Backend test suite is currently skipped. Set RUN_TESTS to true when ready to re-enable it."
-
       - name: Set up uv
-        if: ${{ env.RUN_TESTS == 'true' }}
         uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39  # v3.2.4
 
       - name: Install Python ${{ env.PYTHON_VERSION }}
-        if: ${{ env.RUN_TESTS == 'true' }}
         run: uv python install ${{ env.PYTHON_VERSION }}
 
       - name: Sync backend dependencies
-        if: ${{ env.RUN_TESTS == 'true' }}
         working-directory: ${{ env.BACKEND_DIR }}
         run: uv sync --frozen --python ${{ env.PYTHON_VERSION }}
 
       - name: Run backend tests
-        if: ${{ env.RUN_TESTS == 'true' }}
         working-directory: ${{ env.BACKEND_DIR }}
         run: uv run pytest tests -q
 

--- a/Main/backend/datascraper/ssrf_guard.py
+++ b/Main/backend/datascraper/ssrf_guard.py
@@ -125,8 +125,9 @@ class UnsafeURLError(ValueError):
 #     CPython added in the post-CVE-2024-4032 IANA alignment: 192.0.0.9 (PCP,
 #     RFC 7723) and 192.0.0.10 (TURN anycast, RFC 8155). A scraper has no
 #     business at either, and the firewall drops the whole /24, so block it whole.
-# Full-range parity with the firewall (exhaustive for small ranges) is pinned by
-# tests/test_egress_firewall.py::test_every_firewall_drop_range_blocked_http_side.
+# Both directions of parity with the firewall (drop-implies-blocked, exhaustively
+# for small ranges; and each entry here nests inside a drop range) are pinned by
+# the structural tests in tests/test_egress_firewall.py.
 _EXTRA_BLOCKED_NETS = (
     ipaddress.ip_network("100.64.0.0/10"),
     ipaddress.ip_network("192.0.0.0/24"),

--- a/Main/backend/datascraper/ssrf_guard.py
+++ b/Main/backend/datascraper/ssrf_guard.py
@@ -123,7 +123,7 @@ class UnsafeURLError(ValueError):
 #     nor globally reachable, so is_private and is_reserved are both False.
 #   192.0.0.0/24  -- is_private EXCEPT the two globally-reachable anycast carve-outs
 #     CPython added in the post-CVE-2024-4032 IANA alignment: 192.0.0.9 (PCP,
-#     RFC 7723) and 192.0.0.10 (NAT64/DNS64 discovery, RFC 8155). A scraper has no
+#     RFC 7723) and 192.0.0.10 (TURN anycast, RFC 8155). A scraper has no
 #     business at either, and the firewall drops the whole /24, so block it whole.
 # Full-range parity with the firewall (exhaustive for small ranges) is pinned by
 # tests/test_egress_firewall.py::test_every_firewall_drop_range_blocked_http_side.

--- a/Main/backend/datascraper/ssrf_guard.py
+++ b/Main/backend/datascraper/ssrf_guard.py
@@ -117,6 +117,22 @@ class UnsafeURLError(ValueError):
     """Raised when a URL, host, or resolved IP is rejected by the SSRF guard."""
 
 
+# Firewall-dropped space (see ops/egress_firewall._V4_DROP) that CPython's address
+# properties do NOT flag, so _is_blocked_ip needs explicit membership checks:
+#   100.64.0.0/10 -- CGNAT / RFC 6598 shared space, IANA-listed as neither private
+#     nor globally reachable, so is_private and is_reserved are both False.
+#   192.0.0.0/24  -- is_private EXCEPT the two globally-reachable anycast carve-outs
+#     CPython added in the post-CVE-2024-4032 IANA alignment: 192.0.0.9 (PCP,
+#     RFC 7723) and 192.0.0.10 (NAT64/DNS64 discovery, RFC 8155). A scraper has no
+#     business at either, and the firewall drops the whole /24, so block it whole.
+# Full-range parity with the firewall (exhaustive for small ranges) is pinned by
+# tests/test_egress_firewall.py::test_every_firewall_drop_range_blocked_http_side.
+_EXTRA_BLOCKED_NETS = (
+    ipaddress.ip_network("100.64.0.0/10"),
+    ipaddress.ip_network("192.0.0.0/24"),
+)
+
+
 def _normalize_ip(ip_str: str) -> str:
     """Collapse an IPv4-mapped IPv6 address (``::ffff:a.b.c.d``) to its bare IPv4
     form before classification, so a private IPv4 cannot be smuggled past the
@@ -131,8 +147,10 @@ def _normalize_ip(ip_str: str) -> str:
 def _is_blocked_ip(ip_str: str) -> bool:
     """True if ``ip_str`` (after :func:`_normalize_ip`) is in a range that must
     never be reachable from a user-driven fetch: private, loopback, link-local
-    (incl. 169.254.169.254 cloud metadata), multicast, reserved, or the
-    unspecified address. An unparseable value is treated as blocked."""
+    (incl. 169.254.169.254 cloud metadata), multicast, reserved, the
+    unspecified address, or the ranges the ipaddress properties don't cover
+    (``_EXTRA_BLOCKED_NETS``: CGNAT + the 192.0.0.0/24 anycast carve-outs).
+    An unparseable value is treated as blocked."""
     try:
         ip = ipaddress.ip_address(_normalize_ip(ip_str))
     except ValueError:
@@ -144,6 +162,7 @@ def _is_blocked_ip(ip_str: str) -> bool:
         or ip.is_multicast
         or ip.is_reserved
         or ip.is_unspecified
+        or any(ip in net for net in _EXTRA_BLOCKED_NETS)
     )
 
 

--- a/Main/backend/tests/test_egress_firewall.py
+++ b/Main/backend/tests/test_egress_firewall.py
@@ -92,9 +92,9 @@ def test_override_env_suppresses_v6_discovery(monkeypatch):
 # Parity vs ssrf_guard: the two "what is private" definitions must not silently diverge.
 # CPython's address properties miss two kinds of firewall-dropped space: all of
 # 100.64/10 (CGNAT: neither private nor global to IANA) and the two globally-reachable
-# anycast carve-outs inside 192.0.0.0/24 (192.0.0.9 PCP, 192.0.0.10 NAT64/DNS64
-# discovery, per the post-CVE-2024-4032 registry alignment); ssrf_guard blocks both
-# ranges explicitly (_EXTRA_BLOCKED_NETS).
+# anycast carve-outs inside 192.0.0.0/24 (192.0.0.9 PCP, 192.0.0.10 TURN, per the
+# post-CVE-2024-4032 registry alignment); ssrf_guard blocks both ranges explicitly
+# (_EXTRA_BLOCKED_NETS).
 _DANGEROUS = [
     "169.254.169.254", "10.1.2.3", "172.16.5.5", "192.168.1.1", "127.0.0.1",
     "0.0.0.0", "255.255.255.255", "198.18.0.1", "192.0.0.170", "240.0.0.1",
@@ -115,14 +115,17 @@ def test_every_firewall_drop_range_blocked_http_side():
     # Structural parity, the reverse direction of the sample list above: EVERY
     # range the netns firewall drops must also be blocked by ssrf_guard in-process,
     # so a range added to _V4_DROP/_V6_DROP can never silently stay fetchable at
-    # the HTTP layer. Ranges up to /16 are enumerated EXHAUSTIVELY (~0.6s total):
+    # the HTTP layer. Ranges up to /15 are enumerated EXHAUSTIVELY (~1.4s total):
     # IANA carve-outs are single addresses inside small special-purpose blocks
     # (192.0.0.9/.10 hid from first/middle/last sampling exactly this way), so
-    # sampling a small range proves nothing. Larger ranges get first/middle/last;
-    # their known carve-outs are none, and full enumeration is infeasible.
+    # sampling a small range proves nothing. The /15 threshold covers every
+    # special-purpose block in the drop lists (198.18.0.0/15 is the largest);
+    # what remains -- RFC1918 /12 and /8s, the /4s, the huge v6 blocks -- gets
+    # first/middle/last: no registry carve-outs exist there, and enumeration
+    # genuinely is infeasible (the /12 alone costs ~6s, a /8 ~90s).
     for cidr in _V4_DROP + _V6_DROP:
         net = ipaddress.ip_network(cidr)
-        if net.num_addresses <= 65536:
+        if net.num_addresses <= 131072:
             addrs = iter(net)
         else:
             addrs = iter({net.network_address, net.broadcast_address,

--- a/Main/backend/tests/test_egress_firewall.py
+++ b/Main/backend/tests/test_egress_firewall.py
@@ -90,11 +90,9 @@ def test_override_env_suppresses_v6_discovery(monkeypatch):
 
 
 # Parity vs ssrf_guard: the two "what is private" definitions must not silently diverge.
-# CPython's address properties miss two kinds of firewall-dropped space: all of
-# 100.64/10 (CGNAT: neither private nor global to IANA) and the two globally-reachable
-# anycast carve-outs inside 192.0.0.0/24 (192.0.0.9 PCP, 192.0.0.10 TURN, per the
-# post-CVE-2024-4032 registry alignment); ssrf_guard blocks both ranges explicitly
-# (_EXTRA_BLOCKED_NETS).
+# 100.64.0.1 / 192.0.0.9 / 192.0.0.10 pin the space CPython's address properties miss;
+# the registry rationale lives at ssrf_guard._EXTRA_BLOCKED_NETS (single source --
+# don't restate it here).
 _DANGEROUS = [
     "169.254.169.254", "10.1.2.3", "172.16.5.5", "192.168.1.1", "127.0.0.1",
     "0.0.0.0", "255.255.255.255", "198.18.0.1", "192.0.0.170", "240.0.0.1",
@@ -111,29 +109,54 @@ def test_parity_with_ssrf_guard_block_list():
         assert any(addr in ipaddress.ip_network(c) for c in drops), f"firewall should drop {ip}"
 
 
+# Drop ranges too large to enumerate (> /15) that are wholly covered by ONE
+# ipaddress property with no registry carve-outs, so 3-point sampling is acceptable
+# for them. A new too-large drop range does NOT get sampling by default: the parity
+# test fails until it is consciously listed here.
+_SAMPLING_OK = frozenset({
+    "10.0.0.0/8", "172.16.0.0/12", "127.0.0.0/8", "0.0.0.0/8", "100.64.0.0/10",
+    "224.0.0.0/4", "240.0.0.0/4",
+    "fc00::/7", "fe80::/10", "ff00::/8", "64:ff9b::/96",
+})
+
+
 def test_every_firewall_drop_range_blocked_http_side():
     # Structural parity, the reverse direction of the sample list above: EVERY
     # range the netns firewall drops must also be blocked by ssrf_guard in-process,
     # so a range added to _V4_DROP/_V6_DROP can never silently stay fetchable at
-    # the HTTP layer. Ranges up to /15 are enumerated EXHAUSTIVELY (~1.4s total):
-    # IANA carve-outs are single addresses inside small special-purpose blocks
-    # (192.0.0.9/.10 hid from first/middle/last sampling exactly this way), so
-    # sampling a small range proves nothing. The /15 threshold covers every
-    # special-purpose block in the drop lists (198.18.0.0/15 is the largest);
-    # what remains -- RFC1918 /12 and /8s, the /4s, the huge v6 blocks -- gets
-    # first/middle/last: no registry carve-outs exist there, and enumeration
-    # genuinely is infeasible (the /12 alone costs ~6s, a /8 ~90s).
+    # the HTTP layer. Ranges up to /15 (198.18.0.0/15 is the largest IANA
+    # special-purpose block in the drop lists) are enumerated EXHAUSTIVELY
+    # (~1.4s total): single-address carve-outs hide from point sampling
+    # (192.0.0.9/.10 did exactly that), so sampling a small block proves nothing.
+    # Only _SAMPLING_OK ranges -- where enumeration genuinely is infeasible (the
+    # /12 alone costs ~6s, a /8 ~90s) -- get first/middle/last.
     for cidr in _V4_DROP + _V6_DROP:
         net = ipaddress.ip_network(cidr)
         if net.num_addresses <= 131072:
-            addrs = iter(net)
+            addrs = net
+        elif cidr in _SAMPLING_OK:
+            addrs = (net.network_address, net.broadcast_address,
+                     net.network_address + net.num_addresses // 2)
         else:
-            addrs = iter({net.network_address, net.broadcast_address,
-                          net.network_address + net.num_addresses // 2})
+            pytest.fail(
+                f"{cidr} is too large to enumerate and not in _SAMPLING_OK -- "
+                "sampling proves nothing for special-purpose blocks; decide consciously"
+            )
         for addr in addrs:
             assert ssrf_guard._is_blocked_ip(str(addr)), (
                 f"{addr} is in firewall-dropped {cidr} but ssrf_guard does not block it"
             )
+
+
+def test_extra_blocked_nets_nest_in_firewall_drops():
+    # The remaining structural direction: every explicit ssrf_guard range must nest
+    # inside a firewall drop range, else a net added HTTP-side (the pattern invites
+    # future registry carve-outs) leaves WS/WebRTC/QUIC egress open to it.
+    for net in ssrf_guard._EXTRA_BLOCKED_NETS:
+        drops = _V4_DROP if net.version == 4 else _V6_DROP
+        assert any(net.subnet_of(ipaddress.ip_network(c)) for c in drops), (
+            f"{net} is in ssrf_guard._EXTRA_BLOCKED_NETS but not inside any firewall drop range"
+        )
 
 
 def test_subprocess_invocation_is_hermetic():

--- a/Main/backend/tests/test_egress_firewall.py
+++ b/Main/backend/tests/test_egress_firewall.py
@@ -90,13 +90,15 @@ def test_override_env_suppresses_v6_discovery(monkeypatch):
 
 
 # Parity vs ssrf_guard: the two "what is private" definitions must not silently diverge.
-# 100.64/10 (CGNAT) is deliberately EXCLUDED: the firewall drops it, but ssrf_guard's
-# ipaddress-based check does NOT block it on Python 3.12/3.13 (is_private=False) -- a
-# real HTTP-side gap tracked separately, NOT fixed in this egress-firewall PR.
+# CPython's address properties miss two kinds of firewall-dropped space: all of
+# 100.64/10 (CGNAT: neither private nor global to IANA) and the two globally-reachable
+# anycast carve-outs inside 192.0.0.0/24 (192.0.0.9 PCP, 192.0.0.10 NAT64/DNS64
+# discovery, per the post-CVE-2024-4032 registry alignment); ssrf_guard blocks both
+# ranges explicitly (_EXTRA_BLOCKED_NETS).
 _DANGEROUS = [
     "169.254.169.254", "10.1.2.3", "172.16.5.5", "192.168.1.1", "127.0.0.1",
     "0.0.0.0", "255.255.255.255", "198.18.0.1", "192.0.0.170", "240.0.0.1",
-    "::1", "fc00::1", "fe80::1",
+    "100.64.0.1", "192.0.0.9", "192.0.0.10", "::1", "fc00::1", "fe80::1",
 ]
 
 
@@ -107,6 +109,28 @@ def test_parity_with_ssrf_guard_block_list():
         addr = ipaddress.ip_address(ip)
         drops = _V4_DROP if addr.version == 4 else _V6_DROP
         assert any(addr in ipaddress.ip_network(c) for c in drops), f"firewall should drop {ip}"
+
+
+def test_every_firewall_drop_range_blocked_http_side():
+    # Structural parity, the reverse direction of the sample list above: EVERY
+    # range the netns firewall drops must also be blocked by ssrf_guard in-process,
+    # so a range added to _V4_DROP/_V6_DROP can never silently stay fetchable at
+    # the HTTP layer. Ranges up to /16 are enumerated EXHAUSTIVELY (~0.6s total):
+    # IANA carve-outs are single addresses inside small special-purpose blocks
+    # (192.0.0.9/.10 hid from first/middle/last sampling exactly this way), so
+    # sampling a small range proves nothing. Larger ranges get first/middle/last;
+    # their known carve-outs are none, and full enumeration is infeasible.
+    for cidr in _V4_DROP + _V6_DROP:
+        net = ipaddress.ip_network(cidr)
+        if net.num_addresses <= 65536:
+            addrs = iter(net)
+        else:
+            addrs = iter({net.network_address, net.broadcast_address,
+                          net.network_address + net.num_addresses // 2})
+        for addr in addrs:
+            assert ssrf_guard._is_blocked_ip(str(addr)), (
+                f"{addr} is in firewall-dropped {cidr} but ssrf_guard does not block it"
+            )
 
 
 def test_subprocess_invocation_is_hermetic():

--- a/Main/backend/tests/test_ssrf_guard.py
+++ b/Main/backend/tests/test_ssrf_guard.py
@@ -64,6 +64,22 @@ class NormalizeAndBlockTests(SimpleTestCase):
                    "::ffff:10.0.0.1", "fe80::1", "224.0.0.1"):
             self.assertTrue(ssrf_guard._is_blocked_ip(ip), ip)
 
+    def test_blocks_cgnat_shared_address_space(self):
+        # RFC 6598 100.64.0.0/10 is neither private nor reserved to CPython's
+        # ipaddress (IANA: neither private nor globally reachable), so the
+        # property checks alone let it through -- it needs the explicit range.
+        for ip in ("100.64.0.0", "100.64.0.1", "100.96.0.5",
+                   "100.127.255.255", "::ffff:100.64.0.1"):
+            self.assertTrue(ssrf_guard._is_blocked_ip(ip), ip)
+
+    def test_blocks_ietf_protocol_anycast_carveouts(self):
+        # CPython (post CVE-2024-4032 IANA alignment) carves 192.0.0.9 (PCP
+        # anycast) and 192.0.0.10 (NAT64/DNS64 discovery) out of the otherwise
+        # is_private 192.0.0.0/24, so the property checks alone let exactly
+        # those two through -- the explicit range must cover the whole /24.
+        for ip in ("192.0.0.9", "192.0.0.10", "::ffff:192.0.0.9"):
+            self.assertTrue(ssrf_guard._is_blocked_ip(ip), ip)
+
     def test_public_ips_allowed(self):
         for ip in ("8.8.8.8", "93.184.216.34", "1.1.1.1"):
             self.assertFalse(ssrf_guard._is_blocked_ip(ip), ip)

--- a/Main/backend/tests/test_ssrf_guard.py
+++ b/Main/backend/tests/test_ssrf_guard.py
@@ -74,7 +74,7 @@ class NormalizeAndBlockTests(SimpleTestCase):
 
     def test_blocks_ietf_protocol_anycast_carveouts(self):
         # CPython (post CVE-2024-4032 IANA alignment) carves 192.0.0.9 (PCP
-        # anycast) and 192.0.0.10 (NAT64/DNS64 discovery) out of the otherwise
+        # anycast) and 192.0.0.10 (TURN anycast) out of the otherwise
         # is_private 192.0.0.0/24, so the property checks alone let exactly
         # those two through -- the explicit range must cover the whole /24.
         for ip in ("192.0.0.9", "192.0.0.10", "::ffff:192.0.0.9"):

--- a/Main/backend/tests/test_ssrf_guard.py
+++ b/Main/backend/tests/test_ssrf_guard.py
@@ -65,18 +65,17 @@ class NormalizeAndBlockTests(SimpleTestCase):
             self.assertTrue(ssrf_guard._is_blocked_ip(ip), ip)
 
     def test_blocks_cgnat_shared_address_space(self):
-        # RFC 6598 100.64.0.0/10 is neither private nor reserved to CPython's
-        # ipaddress (IANA: neither private nor globally reachable), so the
-        # property checks alone let it through -- it needs the explicit range.
+        # is_private and is_reserved are both False for this whole range -- only
+        # the explicit _EXTRA_BLOCKED_NETS entry blocks it (rationale at its
+        # definition).
         for ip in ("100.64.0.0", "100.64.0.1", "100.96.0.5",
                    "100.127.255.255", "::ffff:100.64.0.1"):
             self.assertTrue(ssrf_guard._is_blocked_ip(ip), ip)
 
     def test_blocks_ietf_protocol_anycast_carveouts(self):
-        # CPython (post CVE-2024-4032 IANA alignment) carves 192.0.0.9 (PCP
-        # anycast) and 192.0.0.10 (TURN anycast) out of the otherwise
-        # is_private 192.0.0.0/24, so the property checks alone let exactly
-        # those two through -- the explicit range must cover the whole /24.
+        # CPython carves exactly these two globally-reachable anycast addresses
+        # out of the otherwise-is_private 192.0.0.0/24 -- only the explicit
+        # _EXTRA_BLOCKED_NETS entry blocks them (rationale at its definition).
         for ip in ("192.0.0.9", "192.0.0.10", "::ffff:192.0.0.9"):
             self.assertTrue(ssrf_guard._is_blocked_ip(ip), ip)
 


### PR DESCRIPTION
## Summary

Closes the HTTP-side SSRF parity gaps that PR #326 documented as tracked-separately, plus a dead-scaffolding CI cleanup.

**Security fix (`ssrf_guard.py`)** — CPython's `ipaddress` properties miss two kinds of space the netns egress firewall (`ops/egress_firewall._V4_DROP`) already drops, so a host resolving there passed `_is_blocked_ip` while the firewall dropped it:

- **`100.64.0.0/10` (CGNAT, RFC 6598)** — IANA lists it as *neither private nor globally reachable*, so `is_private` and `is_reserved` are both `False`. This was the known gap.
- **`192.0.0.9` / `192.0.0.10`** — found by adversarial review of this very fix: the post-CVE-2024-4032 registry alignment carves these two anycast addresses (PCP RFC 7723, TURN RFC 8155) out of the otherwise-`is_private` `192.0.0.0/24` as globally reachable.

Both ranges are now blocked via explicit `_EXTRA_BLOCKED_NETS` membership (the whole `/24`, matching what the firewall drops). IPv4-mapped IPv6 forms (`::ffff:100.64.0.1`) are covered via the existing `_normalize_ip` collapse.

**Test hardening** — the new structural parity test enumerates **every address** of each firewall-dropped range up to /15 (~1.4s; ~262k checks) instead of sampling first/middle/last — single-address IANA carve-outs like `.9`/`.10` hide from sampling exactly this way, and the /15 threshold covers every IANA special-purpose block in the drop lists (`198.18.0.0/15` is the largest). Genuinely infeasible ranges keep 3-point sampling. Sample-list parity (`_DANGEROUS`) extended with `100.64.0.1`, `192.0.0.9`, `192.0.0.10`.

**CI cleanup (`backend-deploy.yml`)** — `RUN_TESTS` has been hardcoded `"true"` since the P0 remediation; removed the toggle, the skipped "Tests temporarily disabled" step, and the four per-step conditionals. The test job now always runs and `deploy` still hard-requires it via `needs` — this also removes a one-line switch that could silently disable the deploy's test gate.

## Test plan

- [x] TDD red→green: new tests failed on unpatched `_is_blocked_ip` (exactly the CGNAT + anycast assertions), pass after
- [x] Full suite: 566 passed, 1 skipped; `manage.py check` clean
- [x] Exhaustive sweep of all 18 firewall-dropped ranges vs `_is_blocked_ip` on Python 3.12.13: zero remaining gaps
- [x] Workflow YAML parses; zero `RUN_TESTS` references remain; deploy gating (`needs: [build, test]`) unchanged
- [x] Post-review hardening (`8bc0d70`): 192.0.0.10 relabeled TURN anycast (was mislabeled NAT64/DNS64 discovery); parity-test threshold raised to enumerate `198.18.0.0/15` exhaustively

🤖 Generated with [Claude Code](https://claude.com/claude-code)
