### PR TITLE
fix(deploy): retire superseded digest-pulled images; serialize deploy jobs

### DIFF
--- a/.github/workflows/backend-deploy.yml
+++ b/.github/workflows/backend-deploy.yml
@@ -125,6 +125,13 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     if: ${{ github.ref == 'refs/heads/main' }}
+    # Serialize deploys so two merges in quick succession can't land out of order,
+    # leave the droplet on the older commit, or -- now that superseded images are
+    # retired below -- rmi an in-flight peer's freshly pulled, still container-less
+    # image mid-cutover (same stanza as the concierge/heartbeat deploy jobs).
+    concurrency:
+      group: backend-deploy
+      cancel-in-progress: false
     needs:
       - build
       - test
@@ -234,6 +241,47 @@ jobs:
 
             systemctl --user daemon-reload
             systemctl --user restart "$SYSTEMD_UNIT"
+
+            # Retire superseded backend images. The pull above is BY DIGEST, so every
+            # old image keeps a repo@sha256 name, is never "dangling", and the plain
+            # image prune below skips it forever (~3.3GB accumulated per deploy; 10
+            # deep when first cleaned by hand, 2026-07-03). Keep exactly two: the
+            # image just deployed and PREV_IMAGE (the manual rollback target recorded
+            # above). Do NOT swap this for pruning ALL unused images or a time-window
+            # filter: the first deletes the rollback target outright, the second ages
+            # it by BUILD time, so any deploy gap longer than the window deletes it
+            # too. Retirement runs ONLY when the keep set has two DISTINCT resolvable
+            # members: on a first deploy / absent container (PREV_IMAGE=unknown -- a
+            # crash-looped unit's --rm leaves no container), a same-digest job re-run
+            # (KEEP_NEW == KEEP_PREV), or a failed keep resolution, deleting
+            # "everything else" would take the last-known-good image precisely when a
+            # rollback is most likely needed -- those paths skip, loudly. Removals
+            # are unforced (force can remove RUNNING containers) and fail OPEN to
+            # accumulation: a refusal warns and continues, never failing a deploy
+            # that has already cut over (set -e is in force). reference= matching
+            # digest-named images, short-ID resolution, and multi-name rmi refusal
+            # were validated live on the droplet's podman 5.6.2 before this shipped.
+            REPO="${REMOTE_IMAGE%%@*}"
+            if [ "$PREV_IMAGE" = "unknown" ]; then
+              echo "No previous container recorded; skipping image retirement"
+            elif ! KEEP_NEW=$(podman image inspect --format '{{.Id}}' "$REMOTE_IMAGE"); then
+              echo "WARN: cannot resolve just-deployed image ${REMOTE_IMAGE}; skipping image retirement"
+            elif ! KEEP_PREV=$(podman image inspect --format '{{.Id}}' "$PREV_IMAGE"); then
+              echo "WARN: cannot resolve rollback target ${PREV_IMAGE}; skipping image retirement"
+            elif [ "$KEEP_NEW" = "$KEEP_PREV" ]; then
+              echo "Redeploy of the already-running image; skipping image retirement"
+            else
+              for short in $(podman images --filter "reference=${REPO}" --format '{{.ID}}' | sort -u); do
+                img=$(podman image inspect --format '{{.Id}}' "$short" 2>/dev/null) || continue
+                case "$img" in
+                  "$KEEP_NEW"|"$KEEP_PREV") ;;
+                  *)
+                    echo "Retiring superseded image ${short}"
+                    podman rmi "$short" || echo "WARN: could not remove ${short}; leaving in place"
+                    ;;
+                esac
+              done
+            fi
             podman image prune -f
 
       - name: Verify deployment health

--- a/Main/backend/tests/test_dockerfile_nonroot.py
+++ b/Main/backend/tests/test_dockerfile_nonroot.py
@@ -171,6 +171,80 @@ class DeployUserNamespaceTests(SimpleTestCase):
         self.assertGreater(flag_idx, setpriv_idx)
         self.assertLess(flag_idx, store_idx)
 
+    def test_image_retirement_keeps_new_and_rollback_target_only(self):
+        # Deploys pull by DIGEST, so superseded images keep a repo@sha256 name, are
+        # never "dangling", and plain `podman image prune -f` skips them forever
+        # (~3.3GB piled up per deploy; 10 deep when first cleaned by hand 2026-07-03).
+        # The deploy must retire them explicitly, keeping exactly the just-deployed
+        # image and PREV_IMAGE (the documented manual-rollback target).
+        wf = _read(DEPLOY_WORKFLOW)
+        script = wf[wf.index("Deploy to Fedora droplet"):wf.index("Verify deployment health")]
+        # Both keeps spelled on the case guard itself, not merely defined somewhere.
+        self.assertIn('"$KEEP_NEW"|"$KEEP_PREV")', script)
+        # Retirement is scoped to the backend repo -- it must never be able to touch
+        # redis or other infra images.
+        self.assertIn('REPO="${REMOTE_IMAGE%%@*}"', script)
+        self.assertIn('--filter "reference=${REPO}"', script)
+        # Degenerate keep sets must SKIP retirement, not delete "everything else":
+        # a same-digest job re-run (KEEP_NEW == KEEP_PREV), a deploy while the
+        # container is absent (PREV_IMAGE=unknown: first deploy, or a crash-looped
+        # unit whose --rm removed the container), or a failed keep resolution would
+        # otherwise collapse the keep set and delete the last-known-good image
+        # precisely when a rollback is most likely needed.
+        self.assertIn('if [ "$PREV_IMAGE" = "unknown" ]', script)
+        self.assertIn('elif [ "$KEEP_NEW" = "$KEEP_PREV" ]', script)
+        self.assertEqual(script.count("skipping image retirement"), 4)
+        # Keeps are compared in FULL-Id space: `podman images` emits SHORT 12-char
+        # ids, so each must be normalized via inspect before the case guard --
+        # casing on "$short" directly would match nothing and retire everything
+        # (the rollback target included) while the deploy stayed green.
+        self.assertIn(
+            """img=$(podman image inspect --format '{{.Id}}' "$short" 2>/dev/null) || continue""",
+            script,
+        )
+        self.assertIn('case "$img" in', script)
+        # Post-cutover fail-open: a refused removal must WARN and continue -- under
+        # the script's set -euo pipefail an unguarded refusal reds a deploy that has
+        # already cut over AND skips the Verify-deployment-health step.
+        self.assertIn('podman rmi "$short" || echo "WARN: could not remove', script)
+        # Fail-safe placement: keep-set derivation precedes any removal, PREV_IMAGE
+        # is recorded from the still-running container BEFORE cutover, and the whole
+        # block sits after the pull (hoisted above it, the inspect of a not-yet-
+        # present digest would abort every deploy) and after cutover.
+        self.assertLess(script.index("KEEP_NEW="), script.index("podman rmi"))
+        self.assertLess(script.index("KEEP_PREV="), script.index("podman rmi"))
+        self.assertLess(script.index("PREV_IMAGE="), script.index("systemctl --user restart"))
+        self.assertLess(script.index('podman pull "$REMOTE_IMAGE"'), script.index("KEEP_NEW="))
+        self.assertLess(script.index("systemctl --user restart"), script.index("podman rmi"))
+
+    def test_image_retirement_never_forces_and_never_prunes_all(self):
+        # Forced removal can take out RUNNING containers; pruning all unused images
+        # deletes the rollback target outright, and a time-window filter ages by
+        # BUILD time, so any deploy gap longer than the window deletes it too.
+        # Regexes over non-comment lines, not literal substrings: literals missed
+        # `--force`, `-f -a`, the double-quoted `--filter "until=...` (the script's
+        # own quoting style), and `--filter=until=...`.
+        wf = _read(DEPLOY_WORKFLOW)
+        code = "\n".join(
+            l for l in wf.splitlines() if not l.lstrip().startswith("#")
+        )
+        self.assertIsNone(re.search(r"\brmi\b[^\n]*(\s-\w*f\b|\s--force\b)", code))
+        self.assertIsNone(re.search(r"\bprune\b[^\n]*(\s-\w*a\b|\s--all\b)", code))
+        self.assertIsNone(re.search(r"""--filter[= ]["']?until""", code))
+
+    def test_deploy_job_serialized_by_concurrency_group(self):
+        # Without serialization, two quick-succession merges run overlapping deploy
+        # scripts against the same droplet: they can land out of order, and the
+        # retirement loop of one can rmi the other's freshly pulled (still
+        # container-less) image mid-cutover, forcing a multi-GB re-pull inside
+        # ExecStart against the health window. Same stanza the concierge and
+        # heartbeat deploy jobs already carry.
+        wf = _read(DEPLOY_WORKFLOW)
+        deploy_job = wf[wf.index("\n  deploy:"):wf.index("Deploy to Fedora droplet")]
+        self.assertIn("concurrency:", deploy_job)
+        self.assertIn("group: backend-deploy", deploy_job)
+        self.assertIn("cancel-in-progress: false", deploy_job)
+
     def test_runtime_bind_mount_selinux_relabel_for_nonroot(self):
         text = _read(DEPLOY_WORKFLOW)
         # The droplet is SELinux-enforcing Fedora. :U relabels OWNERSHIP (DAC) but leaves


### PR DESCRIPTION
## Problem

Deploys pull the backend image **by digest** (`REMOTE_IMAGE = needs.build.outputs.digest`). Digest-pulled images keep a `repo@sha256` name, so podman never classifies them as dangling and the deploy's `podman image prune -f` is a permanent no-op for them: **~3.3GB accumulated per deploy**. When first cleaned by hand (2026-07-03) the droplet held 10 superseded backend images — 17.5GB of image storage, 93% reclaimable.

## Fix

After cutover, the deploy retires every other image of the backend repo, keeping exactly two: the just-deployed image and `PREV_IMAGE` (the documented manual-rollback target — there is no auto-rollback).

Safety posture (shaped by an adversarial review that confirmed 12 findings against the naive version):

- **Degenerate keep sets skip, loudly.** Retirement runs only when the keep set has two *distinct, resolvable* members. A same-digest job re-run (`KEEP_NEW == KEEP_PREV`), a deploy while the container is absent (`PREV_IMAGE=unknown`: first deploy, or a crash-looped unit whose `--rm` left no container — the #322 incident profile), or a failed keep resolution would otherwise collapse the keep set and delete the last-known-good image precisely when a rollback is most likely needed.
- **Unforced, fail-open removals.** Never `rmi -f`/`--force` (can remove running containers). A refusal warns and continues — under the script's `set -euo pipefail`, an unguarded refusal would red a deploy that already cut over *and* skip the Verify-deployment-health step.
- **Deploy jobs serialized.** `concurrency: {group: backend-deploy, cancel-in-progress: false}` — the stanza the concierge/heartbeat deploy jobs already carry. Without it, overlapping deploys could `rmi` each other's freshly pulled, still container-less image mid-cutover, forcing a multi-GB re-pull inside ExecStart against the health window.
- **Never `prune -a` / `--filter until=`.** `-a` deletes the rollback target outright; `until=` ages by *build* time, so any deploy gap longer than the window deletes it too.

## Verification

- Podman semantics validated **live on the droplet** (podman 5.6.2) before writing the block: `--filter reference=` matches digest-named images; `{{.ID}}` is short-form and resolves via `image inspect`; unforced `rmi` refuses multi-named images; all four guard branches exercised verbatim under `set -euo pipefail` (normal → keeps exactly 2; re-run / absent-container / unresolvable-digest → skip cleanly).
- New pinning tests in `test_dockerfile_nonroot.py` (red→green) lock the keep-set guards, the short→full-Id normalization, the fail-open suffixes, block placement (after pull, after cutover), regex-hardened force/prune-all/until bans over non-comment lines, and the concurrency stanza.
- Full backend suite: **570 passed, 1 skipped**.
- Live proof lands with this PR's own deploy: its retirement pass should remove the image superseded by this build, leaving exactly two backend images on the droplet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
