### PR TITLE
feat(security): environment-gate the prod deploy secrets (SEC Root F, final item)

### DIFF
--- a/.github/workflows/backend-deploy.yml
+++ b/.github/workflows/backend-deploy.yml
@@ -125,6 +125,14 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     if: ${{ github.ref == 'refs/heads/main' }}
+    # DEPLOY_SSH_KEY / GHCR_READ_TOKEN are ENVIRONMENT secrets (Production has a
+    # deployment branch policy of main only), not repo-scoped: even a workflow
+    # edited or dispatched on a non-main ref cannot release the prod SSH key.
+    # This gates the secret itself, independently of the ref-gate above -- the
+    # two layers fail separately (same stanza as the heartbeat/concierge jobs).
+    environment:
+      name: Production
+      url: https://agenticfinsearch.org
     # Serialize deploys so two merges in quick succession can't land out of order,
     # leave the droplet on the older commit, or -- now that superseded images are
     # retired below -- rmi an in-flight peer's freshly pulled, still container-less

--- a/.github/workflows/concierge-tests.yml
+++ b/.github/workflows/concierge-tests.yml
@@ -49,6 +49,10 @@ jobs:
     if: ${{ github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     needs: test
+    # DEPLOY_SSH_KEY is an ENVIRONMENT secret (Production: deployment branch
+    # policy = main only) -- non-main refs cannot release the prod SSH key even
+    # if the ref-gate above is edited away (same stanza as backend/heartbeat).
+    environment: Production
     # Serialize deploys so two merges in quick succession can't land out of order and
     # leave the droplet on the older commit.
     concurrency:

--- a/.github/workflows/heartbeat-tests.yml
+++ b/.github/workflows/heartbeat-tests.yml
@@ -43,6 +43,10 @@ jobs:
     if: ${{ github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     needs: test
+    # DEPLOY_SSH_KEY is an ENVIRONMENT secret (Production: deployment branch
+    # policy = main only) -- non-main refs cannot release the prod SSH key even
+    # if the ref-gate above is edited away (same stanza as backend/concierge).
+    environment: Production
     # Serialize deploys so two merges in quick succession can't land
     # out of order and leave the droplet on the older commit.
     concurrency:

--- a/Main/backend/tests/test_dockerfile_nonroot.py
+++ b/Main/backend/tests/test_dockerfile_nonroot.py
@@ -232,6 +232,19 @@ class DeployUserNamespaceTests(SimpleTestCase):
         self.assertIsNone(re.search(r"\bprune\b[^\n]*(\s-\w*a\b|\s--all\b)", code))
         self.assertIsNone(re.search(r"""--filter[= ]["']?until""", code))
 
+    def test_deploy_job_bound_to_production_environment(self):
+        # DEPLOY_SSH_KEY (the prod SSH key) and GHCR_READ_TOKEN are ENVIRONMENT
+        # secrets on Production, whose deployment branch policy is main-only. The
+        # job must reference that environment or the secrets simply don't resolve
+        # -- and, critically, a workflow edited/dispatched on a non-main ref can
+        # never release them, independently of the ref-gate `if:`. Dropping this
+        # key would silently fall back to... nothing (the repo-scoped copies are
+        # deleted), so the deploy-gate step would skip deploys forever.
+        wf = _read(DEPLOY_WORKFLOW)
+        deploy_job = wf[wf.index("\n  deploy:"):wf.index("Deploy to Fedora droplet")]
+        self.assertIn("environment:", deploy_job)
+        self.assertIn("name: Production", deploy_job)
+
     def test_deploy_job_serialized_by_concurrency_group(self):
         # Without serialization, two quick-succession merges run overlapping deploy
         # scripts against the same droplet: they can land out of order, and the


### PR DESCRIPTION
## What

`DEPLOY_SSH_KEY` (the prod droplet SSH key) and `GHCR_READ_TOKEN` were **repo-scoped** Actions secrets — releasable by any workflow on any ref. This PR completes SEC Root F by environment-gating them:

- **GitHub side (already applied, admin API):** the `Production` environment now has a deployment branch policy allowing **`main` only**, and holds `DEPLOY_SSH_KEY` + `GHCR_READ_TOKEN` as environment secrets.
- **Workflow side (this PR):** all three deploy jobs (backend / heartbeat / concierge) declare `environment: Production`. Environment secrets shadow the repo-scoped copies, which will be **deleted after this deploys green**.
- **Key rotation:** the environment's `DEPLOY_SSH_KEY` is a freshly generated, CI-only ed25519 key (installed additively on the droplet). The old key doubled as a personal login key — it stays valid for interactive SSH but no longer lives in GitHub.
- **Sentinel pin:** new grep-sentinel test (`test_deploy_job_bound_to_production_environment`) pins the environment reference — once the repo-scoped secrets are gone, silently dropping `environment:` would make the deploy-gate skip all deploys.

## Why two layers

The existing `if: github.ref == 'refs/heads/main'` gate lives in the workflow file and can be edited away by anything that can push a workflow change. The environment branch policy is enforced by GitHub outside the repo tree — the ref-gate and the secret-gate now fail independently, matching the deploy pipeline's defense-in-depth pattern.

## Verification

- `uv run pytest tests/test_dockerfile_nonroot.py -q` → 15 passed (includes the new pin).
- New CI key live-verified: `ssh -i <ci-key> deploy@droplet` OK before the secret was set.
- All three workflows self-trigger on their own file edits, so merging this runs all three deploys against the environment secrets — that green run is the end-to-end verification, after which the repo-scoped secrets get deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)