### PR TITLE
feat(security): Root G hygiene batch (audit P2 — final security backlog item)

### DIFF
--- a/.github/workflows/backend-deploy.yml
+++ b/.github/workflows/backend-deploy.yml
@@ -211,8 +211,15 @@ jobs:
             # silently drift from the boot path it is supposed to prove. On failure, abort
             # so the OLD container keeps serving (there is no auto-rollback). This closes
             # the CI-invisible gap: the test job is pytest-only and never touches nft/netns.
+            # The gate runs under the IDENTICAL frozen cap/pids flags as the ExecStart
+            # below (cap-to-step map at the override; parity pinned in
+            # Main/backend/tests/test_dockerfile_nonroot.py). That parity IS the safety
+            # property: check-only mode exits right after the setpriv drop, so all five
+            # caps the root-init needs (nft + chown + setuid/setgid + bounding-set drop)
+            # are exercised HERE -- a too-narrow set aborts the deploy with the old
+            # container still serving, instead of crash-looping the new unit at cutover.
             echo "Validating egress firewall on the new image (pre-cutover)..."
-            podman run --rm --cap-add=NET_ADMIN --network fingpt-net \
+            podman run --rm --cap-drop=ALL --cap-add=NET_ADMIN --cap-add=CHOWN --cap-add=SETUID --cap-add=SETGID --cap-add=SETPCAP --pids-limit=1024 --network fingpt-net \
               --env REDIS_URL=redis://fingpt-redis:6379/0 \
               "$REMOTE_IMAGE" --egress-check-only \
               || { echo "ERROR: egress firewall pre-cutover validation FAILED; aborting deploy (old container left serving)"; exit 1; }
@@ -234,17 +241,34 @@ jobs:
             #       without it container_t is denied and the write is EACCES -- which
             #       crash-looped the truth-layer store build the first time a deploy actually
             #       wrote this mount (#322). Ownership alone is not enough; both are required.
-            # --cap-add=NET_ADMIN is SECURITY/FUNCTIONALLY LOAD-BEARING: rootless podman's
-            # default cap set excludes NET_ADMIN, so without it the root-in-userns init
-            # cannot load the SSRF egress firewall (nft EPERM) -> entrypoint fail-closes ->
-            # the container never serves. Do NOT drop it. (The app itself runs as uid1001
-            # with NET_ADMIN removed from its bounding set; see Main/backend/entrypoint.sh.)
+            # Frozen capability set: --cap-drop=ALL, then add back ONLY the five caps the
+            # root-init phase of Main/backend/entrypoint.sh actually uses. Each cap maps
+            # 1:1 to a root-init step, so nothing in the set is discretionary:
+            #   NET_ADMIN     nft loads the SSRF egress firewall -- rootless podman's
+            #                 default set excludes it; without it nft EPERMs, entrypoint
+            #                 fail-closes, and the container never serves;
+            #   CHOWN         the /app/runtime re-chown to fingpt after the :U mount chown;
+            #   SETUID/SETGID setpriv's drop to uid/gid 1001 (+ --init-groups);
+            #   SETPCAP       setpriv's --bounding-set=-net_admin drop for the app phase
+            #                 (the app runs as uid1001 with NET_ADMIN out of its bounding set).
+            # The pre-cutover gate above runs the IDENTICAL flags -- that is the safety
+            # property: all five caps get exercised end-to-end BEFORE cutover, so a
+            # too-narrow set aborts the deploy rather than crash-looping the unit. Set +
+            # gate/ExecStart parity are pinned by Main/backend/tests/test_dockerfile_nonroot.py;
+            # widen only by editing BOTH podman run invocations AND the sentinel, with the
+            # new cap's root-init step documented here.
+            # --pids-limit=1024 is the fork-bomb ceiling: worst case today is ~400-600
+            # tasks (gunicorn workers x threads + agent fan-out + Playwright/Chromium);
+            # revisit if AGENT_MAX_CONCURRENCY or GUNICORN_WORKERS is raised.
+            # A read-only rootfs is DELIBERATELY deferred: the gate exits before the app
+            # phase, so --read-only would ship unvalidated pre-cutover -- and collectstatic
+            # writes /app/staticfiles at boot, which needs a tmpfs/volume design first.
             OVERRIDE_DIR="$HOME/.config/systemd/user/${SYSTEMD_UNIT}.service.d"
             mkdir -p "$OVERRIDE_DIR"
             cat > "$OVERRIDE_DIR/override.conf" <<EOF
             [Service]
             ExecStart=
-            ExecStart=/usr/bin/podman run --name ${SYSTEMD_UNIT} --replace --rm --cap-add=NET_ADMIN --cgroups=split --sdnotify=conmon -d --memory=1.7g --memory-swap=2g --network fingpt-net -v /home/deploy/fingpt/runtime:/app/runtime:U,Z --publish 127.0.0.1:8000:8000 --env-file /home/deploy/fingpt/envs/.env.production --env REDIS_URL=redis://fingpt-redis:6379/0 ${REMOTE_IMAGE}
+            ExecStart=/usr/bin/podman run --name ${SYSTEMD_UNIT} --replace --rm --cap-drop=ALL --cap-add=NET_ADMIN --cap-add=CHOWN --cap-add=SETUID --cap-add=SETGID --cap-add=SETPCAP --pids-limit=1024 --cgroups=split --sdnotify=conmon -d --memory=1.7g --memory-swap=2g --network fingpt-net -v /home/deploy/fingpt/runtime:/app/runtime:U,Z --publish 127.0.0.1:8000:8000 --env-file /home/deploy/fingpt/envs/.env.production --env REDIS_URL=redis://fingpt-redis:6379/0 ${REMOTE_IMAGE}
             EOF
 
             systemctl --user daemon-reload

--- a/.github/workflows/uptime.yml
+++ b/.github/workflows/uptime.yml
@@ -34,3 +34,38 @@ jobs:
           done
           echo "::error::agenticfinsearch.org/health/ is DOWN after 9 attempts (~180s)"
           exit 1
+      - name: Verify edge security headers
+        # Converts the edge headers from CONFIGURED to POSITIVELY-VERIFIED: a
+        # non-deferred Caddy `header` block validates fine yet ships duplicate
+        # HSTS lines and a silently-losing Referrer-Policy (the silent-no-op
+        # lesson behind the deferred block in Deploy/podman/Caddyfile.example),
+        # so only probing the live response proves delivery. Runs only after
+        # the health probe above passed, so a failure here is a HEADER
+        # regression, not an outage. No `-f` on curl: an HTTP error status
+        # still carries the deferred edge headers we assert on.
+        # NOTE: red until the deferred header block ships on the live edge
+        # Caddyfile (a separate, post-review op).
+        run: |
+          set -euo pipefail
+          for i in 1 2 3; do
+            if hdrs=$(curl -sSI -m 10 https://agenticfinsearch.org/health/); then
+              break
+            fi
+            if [ "$i" = 3 ]; then
+              echo "::error::could not fetch response headers after 3 attempts"
+              exit 1
+            fi
+            sleep 10
+          done
+          printf '%s\n' "$hdrs"
+          csp=$(printf '%s\n' "$hdrs" | grep -ic '^content-security-policy:' || true)
+          hsts=$(printf '%s\n' "$hdrs" | grep -ic '^strict-transport-security:' || true)
+          if [ "$csp" -lt 1 ]; then
+            echo "::error::edge response lacks Content-Security-Policy (deferred header block missing at the proxy)"
+            exit 1
+          fi
+          if [ "$hsts" -gt 1 ]; then
+            echo "::error::$hsts Strict-Transport-Security lines in one response (defer lost: Caddy + Django copies both shipped)"
+            exit 1
+          fi
+          echo "edge headers verified (CSP present, single HSTS)"

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,14 @@
-# environment variables
-Main/backend/.env
-Main/backend/.env.production
-# older ver has env in here
-chat_interface/backend_modules/.env
+# environment variables — repo-wide guard. Real dotenvs (Concierge/.env.concierge,
+# Heartbeat/.env.heartbeat, droplet-written) sit NEXT TO tracked .example templates,
+# and the old path-specific list (Main/backend/.env, chat_interface/...) silently
+# rotted each time a service was added: a `git add -A` from the repo root would have
+# staged live Discord/OpenAI credentials. Ignore every dotenv shape everywhere; the
+# two negations re-include ONLY the committed onboarding templates. Sentinel:
+# Main/backend/tests/test_gitignore_env.py pins both directions.
+.env
+.env.*
+!.env.example
+!.env.*.example
 
 # google cookie
 Main/backend/.google-cookie

--- a/Deploy/podman/Caddyfile.example
+++ b/Deploy/podman/Caddyfile.example
@@ -35,12 +35,39 @@ fingpt.example.com {
         reverse_proxy fingpt-api:8000
     }
 
+    # Root G hygiene: browser-facing security headers, set once at the edge.
+    # `defer` is LOAD-BEARING: it runs these ops at response-write time, AFTER
+    # the upstream copies are merged in, so `set` REPLACES what Django's
+    # SecurityMiddleware already emits. Without defer the ops run pre-proxy and
+    # the proxy ADDs the upstream copies on top: the response ships two
+    # Strict-Transport-Security lines and Caddy's Referrer-Policy silently
+    # loses to Django's (last valid value wins per spec) -- "configured" here
+    # but never delivered, the silent no-op uptime.yml now positively probes.
     header {
+        defer
         Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
+        # API-only origin: no first-party HTML/JS is ever served, so CSP locks
+        # everything down (and frame-ancestors kills UI redressing). If a future
+        # HTML frontend is ever served from THIS origin, these directives must
+        # be relaxed deliberately -- default-src 'none' blocks all its
+        # subresources (scripts, styles, images, XHR).
+        Content-Security-Policy "default-src 'none'; frame-ancestors 'none'; base-uri 'none'; form-action 'none'"
+        Referrer-Policy "no-referrer"
+        Permissions-Policy "accelerometer=(), autoplay=(), camera=(), display-capture=(), encrypted-media=(), fullscreen=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), midi=(), payment=(), picture-in-picture=(), publickey-credentials-get=(), screen-wake-lock=(), usb=(), web-share=(), xr-spatial-tracking=()"
     }
 
     log {
         output stdout
-        format console
+        # Strip the query string from the logged URI: query strings carry PII
+        # (user questions, browsing URLs) and, before the backend dropped the
+        # ?token= auth path, credentials. The app-side gunicorn access log is
+        # redacted the same way (%(U)s, no %(q)s) -- both layers must agree or
+        # the redaction is a silent no-op at the edge.
+        format filter {
+            wrap console
+            fields {
+                request>uri regexp \?.* ""
+            }
+        }
     }
 }

--- a/Docs/production_setup.md
+++ b/Docs/production_setup.md
@@ -233,7 +233,18 @@ api.your-domain.com {
         header_up X-Forwarded-For {remote_host}
         header_up X-Forwarded-Proto {scheme}
     }
-    header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
+    # `defer` is load-bearing: the ops run AFTER Django's SecurityMiddleware
+    # copies are merged in, so `set` dedupes them. Non-deferred, the response
+    # ships two Strict-Transport-Security lines and Referrer-Policy silently
+    # loses. Full rationale in Deploy/podman/Caddyfile.example.
+    header {
+        defer
+        Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
+        # API-only origin -- relax deliberately if HTML is ever served here.
+        Content-Security-Policy "default-src 'none'; frame-ancestors 'none'; base-uri 'none'; form-action 'none'"
+        Referrer-Policy "no-referrer"
+        Permissions-Policy "accelerometer=(), autoplay=(), camera=(), display-capture=(), encrypted-media=(), fullscreen=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), midi=(), payment=(), picture-in-picture=(), publickey-credentials-get=(), screen-wake-lock=(), usb=(), web-share=(), xr-spatial-tracking=()"
+    }
 }
 ```
 

--- a/Main/backend/.env.example
+++ b/Main/backend/.env.example
@@ -95,7 +95,8 @@ MEMORY_LEAK_SLOPE_THRESHOLD=0.1
 MEMORY_LEAK_CHECK_INTERVAL=50
 # Soft limit: trigger graceful worker restart above this (MB)
 MEMORY_SOFT_LIMIT_MB=450
-# Token for /debug/memory/ endpoint (empty = disabled)
+# Token for /debug/memory/ endpoint (empty = disabled). The route itself is only registered
+# when DJANGO_DEBUG=True (django_config/urls.py) — in production the URL 404s regardless.
 DEBUG_MEMORY_TOKEN=
 # Stack frames stored per allocation in tracemalloc
 TRACEMALLOC_FRAMES=25

--- a/Main/backend/api/views.py
+++ b/Main/backend/api/views.py
@@ -251,7 +251,13 @@ def validate_claims(request: HttpRequest) -> JsonResponse:
 
  
 
+# Root-G Tier 2: the chat/agent surface is GET-by-contract (extension + SSE
+# clients read query params only), so pin the method on all five views. The
+# gate sits OUTSIDE @ratelimit (same stacking as validate_claims) so a
+# wrong-method probe is bounced with 405 without consuming the caller's
+# rate budget.
 @csrf_exempt
+@require_http_methods(['GET'])
 @ratelimit(key='api.identity.ratelimit_key', rate=settings.API_RATE_LIMIT, method=ALL, block=True)
 def chat_response(request: HttpRequest) -> JsonResponse:
     """
@@ -347,6 +353,7 @@ def chat_response(request: HttpRequest) -> JsonResponse:
 
 
 @csrf_exempt
+@require_http_methods(['GET'])
 @ratelimit(key='api.identity.ratelimit_key', rate=settings.API_RATE_LIMIT, method=ALL, block=True)
 def adv_response(request: HttpRequest) -> JsonResponse:
     """
@@ -471,6 +478,7 @@ def adv_response(request: HttpRequest) -> JsonResponse:
 
 
 @csrf_exempt
+@require_http_methods(['GET'])
 @ratelimit(key='api.identity.ratelimit_key', rate=settings.API_RATE_LIMIT, method=ALL, block=True)
 def agent_chat_response(request: HttpRequest) -> JsonResponse:
     """
@@ -563,6 +571,7 @@ def agent_chat_response(request: HttpRequest) -> JsonResponse:
 
 
 @csrf_exempt
+@require_http_methods(['GET'])
 @ratelimit(key='api.identity.ratelimit_key', rate=settings.API_RATE_LIMIT, method=ALL, block=True)
 def chat_response_stream(request: HttpRequest) -> StreamingHttpResponse:
     """
@@ -740,6 +749,7 @@ def chat_response_stream(request: HttpRequest) -> StreamingHttpResponse:
 
 
 @csrf_exempt
+@require_http_methods(['GET'])
 @ratelimit(key='api.identity.ratelimit_key', rate=settings.API_RATE_LIMIT, method=ALL, block=True)
 def adv_response_stream(request: HttpRequest) -> StreamingHttpResponse:
     """Process streaming advanced chat response from selected models using SSE"""
@@ -921,7 +931,16 @@ def adv_response_stream(request: HttpRequest) -> StreamingHttpResponse:
 
 
 
+# Root-G Tier 1: every routed sink shares the per-identity limiter. The
+# previously un-throttled ingest/store/log endpoints (auto_scrape through
+# get_available_models below) were a free amplification path — cache writes,
+# the disk-backed preferred-links file, unbounded log lines — even though they
+# never touch the LLM. Only health/ stays undecorated: django-ratelimit fails
+# CLOSED when the counter cache is unreachable (get_usage -> should_limit on a
+# None count), which would take the LB probe down together with Redis. Pinned
+# by tests/test_endpoint_protection.py.
 @csrf_exempt
+@ratelimit(key='api.identity.ratelimit_key', rate=settings.API_RATE_LIMIT, method=ALL, block=True)
 def auto_scrape(request: HttpRequest) -> JsonResponse:
     """
     Automatically scrape the current page if not already in context.
@@ -985,6 +1004,7 @@ def auto_scrape(request: HttpRequest) -> JsonResponse:
 
 
 @csrf_exempt
+@ratelimit(key='api.identity.ratelimit_key', rate=settings.API_RATE_LIMIT, method=ALL, block=True)
 def add_webtext(request: HttpRequest) -> JsonResponse:
     """
     Handle appending the site's text to the message list.
@@ -1037,7 +1057,13 @@ def add_webtext(request: HttpRequest) -> JsonResponse:
         return JsonResponse({'error': _safe_error_message(e, request.path)}, status=500)
 
 
+# POST-only: clear drops conversation state, and on a CSRF-exempt endpoint a
+# GET would leave it triggerable by any prefetch/img-tag. The shipped frontend
+# already sends POST (dist/main.js fetch {method:"POST"}), so only the
+# accidental-GET surface changes.
 @csrf_exempt
+@require_http_methods(['POST'])
+@ratelimit(key='api.identity.ratelimit_key', rate=settings.API_RATE_LIMIT, method=ALL, block=True)
 def clear(request: HttpRequest) -> JsonResponse:
     """
     Clear conversation messages and optionally preserve scraped web content.
@@ -1068,6 +1094,7 @@ def clear(request: HttpRequest) -> JsonResponse:
 
 
 @csrf_exempt
+@ratelimit(key='api.identity.ratelimit_key', rate=settings.API_RATE_LIMIT, method=ALL, block=True)
 def get_memory_stats(request: HttpRequest) -> JsonResponse:
     """
     Get context statistics for current session.
@@ -1101,6 +1128,10 @@ def get_memory_stats(request: HttpRequest) -> JsonResponse:
 
 
 
+# NEVER decorate health with @ratelimit: the limiter fails closed when the
+# counter cache is down (django-ratelimit get_usage returns should_limit for a
+# None count), so a Redis outage would 429/500 the probe and cascade into a
+# restart loop. Pinned by test_endpoint_protection HealthIndependenceTests.
 def health(request: HttpRequest) -> JsonResponse:
     """
     Health check endpoint for load balancers and monitoring.
@@ -1116,6 +1147,7 @@ def health(request: HttpRequest) -> JsonResponse:
 
 
 @csrf_exempt
+@ratelimit(key='api.identity.ratelimit_key', rate=settings.API_RATE_LIMIT, method=ALL, block=True)
 def get_sources(request: HttpRequest) -> JsonResponse:
     """Get sources for a query"""
     query = request.GET.get('query', '')
@@ -1129,6 +1161,7 @@ def get_sources(request: HttpRequest) -> JsonResponse:
     return JsonResponse({'resp': sources})
 
 
+@ratelimit(key='api.identity.ratelimit_key', rate=settings.API_RATE_LIMIT, method=ALL, block=True)
 def log_question(request: HttpRequest) -> JsonResponse:
     """Legacy question logging (redirects to enhanced logging)"""
     question = request.GET.get('question', '')
@@ -1136,11 +1169,15 @@ def log_question(request: HttpRequest) -> JsonResponse:
     current_url = request.GET.get('current_url', '')
 
     if question and button_clicked and current_url:
-        logger.info(f"Interaction [{button_clicked}]: URL={current_url}, Q='{question}'")
+        # [:50] like every other Interaction line: this sink logs verbatim
+        # caller input, so an untruncated question is a log-flooding /
+        # line-injection vector out of proportion to its telemetry value.
+        logger.info(f"Interaction [{button_clicked}]: URL={current_url}, Q='{question[:50]}...'")
 
     return JsonResponse({'status': 'success'})
 
 
+@ratelimit(key='api.identity.ratelimit_key', rate=settings.API_RATE_LIMIT, method=ALL, block=True)
 def get_preferred_urls(request: HttpRequest) -> JsonResponse:
     """Retrieve preferred URLs from storage"""
     manager = get_manager()
@@ -1149,6 +1186,7 @@ def get_preferred_urls(request: HttpRequest) -> JsonResponse:
 
 
 @csrf_exempt
+@ratelimit(key='api.identity.ratelimit_key', rate=settings.API_RATE_LIMIT, method=ALL, block=True)
 def add_preferred_url(request: HttpRequest) -> JsonResponse:
     """Add new preferred URL to storage"""
     if request.method == 'POST':
@@ -1175,6 +1213,7 @@ def add_preferred_url(request: HttpRequest) -> JsonResponse:
 
 
 @csrf_exempt
+@ratelimit(key='api.identity.ratelimit_key', rate=settings.API_RATE_LIMIT, method=ALL, block=True)
 def sync_preferred_urls(request: HttpRequest) -> JsonResponse:
     """Sync preferred URLs from frontend to backend storage"""
     if request.method == 'POST':
@@ -1193,6 +1232,7 @@ def sync_preferred_urls(request: HttpRequest) -> JsonResponse:
     return JsonResponse({'status': 'failed'}, status=400)
 
 
+@ratelimit(key='api.identity.ratelimit_key', rate=settings.API_RATE_LIMIT, method=ALL, block=True)
 def get_available_models(request: HttpRequest) -> JsonResponse:
     """Get list of available models with their configurations"""
     models = []

--- a/Main/backend/api/views_debug.py
+++ b/Main/backend/api/views_debug.py
@@ -18,14 +18,17 @@ _previous_snapshot = None
 
 
 def _check_token(request: HttpRequest) -> bool:
-    """Verify the debug token from query param or header."""
+    """Verify the debug token from the X-Debug-Token header.
+
+    Header only, deliberately: ?token= was dropped because query strings are
+    recorded verbatim by the Caddy edge access log (and gunicorn's, before its
+    format was redacted), so accepting the credential there turned every
+    authenticated call into a plaintext token write to the log pipeline.
+    """
     configured_token = os.environ.get('DEBUG_MEMORY_TOKEN', '')
     if not configured_token:
         return False
-    request_token = request.GET.get('token', '')
-    if not request_token:
-        request_token = request.headers.get('X-Debug-Token', '')
-    return request_token == configured_token
+    return request.headers.get('X-Debug-Token', '') == configured_token
 
 
 @csrf_exempt

--- a/Main/backend/django_config/settings_prod.py
+++ b/Main/backend/django_config/settings_prod.py
@@ -14,6 +14,11 @@ SECURE_HSTS_INCLUDE_SUBDOMAINS = os.getenv('SECURE_HSTS_INCLUDE_SUBDOMAINS', 'Tr
 SECURE_HSTS_PRELOAD = os.getenv('SECURE_HSTS_PRELOAD', 'True').strip().lower() in ('true', '1', 't')
 SECURE_CONTENT_TYPE_NOSNIFF = True
 X_FRAME_OPTIONS = 'DENY'
+# Referrer-Policy at the app layer too, not only the Caddy edge headers: the
+# edge copy protects proxied traffic, but a direct backend hit or an edge
+# header regression must still ship the same policy (two-layer principle —
+# same reason SecurityMiddleware repeats HSTS/nosniff behind the proxy).
+SECURE_REFERRER_POLICY = "no-referrer"
 
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 USE_X_FORWARDED_HOST = True

--- a/Main/backend/django_config/urls.py
+++ b/Main/backend/django_config/urls.py
@@ -1,4 +1,5 @@
 """URL configuration for chat_server."""
+from django.conf import settings
 from django.urls import path
 from api import views
 from api import openai_views
@@ -24,11 +25,19 @@ urlpatterns = [
     path('api/axioms/validate/', views.validate_claims, name='axioms_validate'),
     path('api/axioms/has_claims/', views.has_axiom_claims, name='axioms_has_claims'),
     path('api/axioms/xbrl/<str:filename>/', views.xbrl_filing_download, name='axioms_xbrl_filing'),
-    
-    # Debug/diagnostic endpoints
-    path('debug/memory/', views_debug.debug_memory, name='debug_memory'),
 
     # Standard OpenAI-compatible API
     path('v1/models', openai_views.models_list, name='openai_models_list'),
     path('v1/chat/completions', openai_views.chat_completions, name='openai_chat_completions'),
 ]
+
+# Root G hygiene: /debug/memory/ leaks allocator tracebacks (absolute paths + line numbers)
+# and lets a caller start tracemalloc (persistent RAM overhead — a DoS lever) behind a single
+# static shared token. Defense in depth on top of that token: the route only exists when
+# DEBUG=True, so production (DJANGO_DEBUG unset -> False) 404s before the view is reachable,
+# even if DEBUG_MEMORY_TOKEN leaks or gets set by mistake. Gating pinned by
+# tests/test_debug_route_gating.py — keep this registration inside `if settings.DEBUG:`.
+if settings.DEBUG:
+    urlpatterns += [
+        path('debug/memory/', views_debug.debug_memory, name='debug_memory'),
+    ]

--- a/Main/backend/gunicorn.conf.py
+++ b/Main/backend/gunicorn.conf.py
@@ -17,7 +17,12 @@ keepalive = 5
 accesslog = '-'
 errorlog = '-'
 loglevel = os.getenv('GUNICORN_LOG_LEVEL', 'info')
-access_log_format = '%(h)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s" %(D)s'
+# %(m)s %(U)s %(H)s instead of %(r)s: the raw request line embeds the query string, so
+# any credential passed there (the old /api/debug/memory/?token=... pattern, signed URLs,
+# etc.) would be written verbatim to stdout and shipped to log aggregation. Logging
+# method + path + protocol keeps the combined-log shape for downstream parsers while
+# dropping the query string entirely. Pinned by tests/test_gunicorn_conf.py.
+access_log_format = '%(h)s %(l)s %(u)s %(t)s "%(m)s %(U)s %(H)s" %(s)s %(b)s "%(f)s" "%(a)s" %(D)s'
 
 proc_name = 'fingpt-backend'
 

--- a/Main/backend/mcp_client/mcp_manager.py
+++ b/Main/backend/mcp_client/mcp_manager.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import Dict, List, Optional, Any, Callable
 
 from mcp import ClientSession, StdioServerParameters
-from mcp.client.stdio import stdio_client
+from mcp.client.stdio import get_default_environment, stdio_client
 from mcp.client.sse import sse_client
 from mcp.types import Tool as MCPTool, CallToolResult
 
@@ -135,7 +135,28 @@ class MCPClientManager:
 
             self._log(f"[MCP DEBUG] {server_name} using Stdio transport: {command} {args}")
 
-            full_env = os.environ.copy()
+            # Root G hygiene (2026-06-29 audit follow-up): never hand a child
+            # the full backend environment. os.environ here carries
+            # OPENAI_API_KEY / DJANGO_SECRET_KEY / Redis + Mem0 credentials,
+            # and stdio servers run third-party code (sec-edgar-mcp,
+            # npx-fetched packages) that needs none of them — a compromised or
+            # merely chatty dependency could exfiltrate every secret with one
+            # os.environ dump. Start from the MCP SDK's safe base
+            # (HOME/LOGNAME/PATH/SHELL/TERM/USER on posix, exported shell
+            # functions skipped) — exactly what stdio_client would use if we
+            # passed env=None — then layer on only what this server's config
+            # block declares. tests/test_mcp_child_env.py pins this.
+            full_env = get_default_environment()
+
+            # Opt-in passthrough for non-secret parent vars a server may need
+            # (e.g. proxy settings): "inheritEnv": ["NAME", ...]. Applied
+            # before the env block so explicit config values always win.
+            # Secret-shaped names are rejected by the config sentinel in
+            # tests/test_mcp_child_env.py; no shipped server uses this today.
+            for inherited_name in config.get("inheritEnv", []):
+                if inherited_name in os.environ:
+                    full_env[inherited_name] = os.environ[inherited_name]
+
             for key, value in env.items():
                 if isinstance(value, str):
                     import re

--- a/Main/backend/tests/test_caddyfile_headers.py
+++ b/Main/backend/tests/test_caddyfile_headers.py
@@ -1,0 +1,115 @@
+"""Static guards for the edge security-header block (Root G hygiene).
+
+Runs in the standard backend harness (SimpleTestCase, no DB):
+    uv run pytest tests/test_caddyfile_headers.py -q
+
+These pin Deploy/podman/Caddyfile.example so a later edit cannot silently
+drop `defer` (without which Django's SecurityMiddleware copies duplicate
+HSTS and out-win Referrer-Policy -- headers "configured" but never
+delivered), weaken the API-only CSP, or lose the P0 Root C.1 forwarding
+override. The LIVE edge is verified separately by uptime.yml's header probe;
+this suite keeps the repo's canonical example from drifting underneath it.
+"""
+import os
+
+from django.test import SimpleTestCase
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+CADDYFILE = os.path.join(
+    _HERE, "..", "..", "..", "Deploy", "podman", "Caddyfile.example"
+)
+
+
+def _read(path):
+    with open(path, "r", encoding="utf-8") as fh:
+        return fh.read()
+
+
+class CaddyfileHeaderBlockTests(SimpleTestCase):
+    def setUp(self):
+        self.text = _read(CADDYFILE)
+
+    def _header_block(self):
+        # Extract the site-level `header { ... }` block specifically -- a
+        # whole-file assertIn would pass with the directives moved into a
+        # comment or into some never-matched handler.
+        lines = self.text.splitlines()
+        starts = [i for i, l in enumerate(lines) if l.strip() == "header {"]
+        self.assertEqual(
+            len(starts), 1, f"expected exactly one `header {{` block, got {len(starts)}"
+        )
+        start = starts[0]
+        end = next(
+            i for i in range(start + 1, len(lines)) if lines[i].strip() == "}"
+        )
+        return lines[start + 1:end]
+
+    def _ops(self):
+        return [
+            l.strip() for l in self._header_block()
+            if l.strip() and not l.strip().startswith("#")
+        ]
+
+    def test_defer_is_an_op_of_the_header_block(self):
+        # `defer` is load-bearing: it makes `set` REPLACE the Django copies at
+        # response-write time. Non-deferred, the response ships two HSTS lines
+        # and Caddy's Referrer-Policy silently loses (last valid value wins).
+        self.assertIn("defer", self._ops())
+
+    def test_csp_locks_api_only_origin(self):
+        csp = [op for op in self._ops() if op.startswith("Content-Security-Policy")]
+        self.assertEqual(len(csp), 1, f"expected one CSP op, got {csp}")
+        # API-only origin: every fetch/embed/base/form vector closed. Any
+        # future first-party HTML frontend must relax these DELIBERATELY.
+        for directive in (
+            "default-src 'none'",
+            "frame-ancestors 'none'",
+            "base-uri 'none'",
+            "form-action 'none'",
+        ):
+            self.assertIn(directive, csp[0])
+
+    def test_referrer_policy_no_referrer(self):
+        self.assertIn('Referrer-Policy "no-referrer"', self._ops())
+
+    def test_permissions_policy_denies_powerful_features(self):
+        pp = [op for op in self._ops() if op.startswith("Permissions-Policy")]
+        self.assertEqual(len(pp), 1, f"expected one Permissions-Policy op, got {pp}")
+        for feature in (
+            "camera=()",
+            "microphone=()",
+            "geolocation=()",
+            "payment=()",
+            "usb=()",
+        ):
+            self.assertIn(feature, pp[0])
+
+    def test_hsts_kept_with_preload(self):
+        # The deferred block must not LOSE the pre-existing HSTS pin while
+        # gaining the new headers.
+        self.assertIn(
+            'Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"',
+            self._ops(),
+        )
+
+    def test_real_ip_override_survives(self):
+        # P0 Root C.1: the proxy derives the client IP from the real TCP peer
+        # and OVERRIDES client-supplied forwarding headers -- the header-block
+        # rework must not disturb it (rate limiting keys off X-Real-IP).
+        self.assertIn("header_up X-Real-IP {remote_host}", self.text)
+
+    def test_access_log_redacts_query_string(self):
+        # The edge access log must strip the URI query string: it carries PII
+        # (user questions, browsing URLs) and historically credentials (the
+        # removed ?token= path). This is the edge half of the same redaction
+        # gunicorn.conf.py applies app-side (%(U)s, no %(q)s) -- pinned in
+        # test_gunicorn_conf.py; both layers must agree or one log stream
+        # keeps leaking what the other redacts. Bare `format console` (the
+        # pre-hygiene shape) must not come back.
+        lines = [
+            l.strip() for l in self.text.splitlines()
+            if l.strip() and not l.strip().startswith("#")
+        ]
+        self.assertIn("format filter {", lines)
+        self.assertIn('request>uri regexp \\?.* ""', lines)
+        self.assertNotIn("format console", lines)

--- a/Main/backend/tests/test_debug_memory_endpoint.py
+++ b/Main/backend/tests/test_debug_memory_endpoint.py
@@ -21,7 +21,7 @@ def test_wrong_token_returns_403(monkeypatch):
     from api.views_debug import debug_memory
     from django.test import RequestFactory
     factory = RequestFactory()
-    request = factory.get('/debug/memory/?token=wrong')
+    request = factory.get('/debug/memory/', HTTP_X_DEBUG_TOKEN='wrong')
     response = debug_memory(request)
     assert response.status_code == 403
 
@@ -31,7 +31,7 @@ def test_correct_token_returns_200(monkeypatch):
     from api.views_debug import debug_memory
     from django.test import RequestFactory
     factory = RequestFactory()
-    request = factory.get('/debug/memory/?token=secret123&action=status')
+    request = factory.get('/debug/memory/?action=status', HTTP_X_DEBUG_TOKEN='secret123')
     response = debug_memory(request)
     assert response.status_code == 200
 
@@ -41,9 +41,40 @@ def test_empty_token_config_disables_endpoint(monkeypatch):
     from api.views_debug import debug_memory
     from django.test import RequestFactory
     factory = RequestFactory()
-    request = factory.get('/debug/memory/?token=anything&action=status')
+    request = factory.get('/debug/memory/?action=status', HTTP_X_DEBUG_TOKEN='anything')
     response = debug_memory(request)
     assert response.status_code == 403
+
+
+# ── Token transport: header only, never the query string ─────────
+
+def test_correct_token_in_query_param_is_rejected(monkeypatch):
+    # ?token= acceptance was removed deliberately: the query string is written verbatim
+    # into the Caddy edge access log (and gunicorn's, before its format was redacted), so
+    # that transport turned every authenticated call into a plaintext credential write.
+    # Even the CORRECT token must be refused when it arrives in the URL.
+    monkeypatch.setenv('DEBUG_MEMORY_TOKEN', 'secret123')
+    from api.views_debug import debug_memory
+    from django.test import RequestFactory
+    factory = RequestFactory()
+    request = factory.get('/debug/memory/?token=secret123&action=status')
+    response = debug_memory(request)
+    assert response.status_code == 403
+
+
+def test_header_token_accepted_and_query_param_ignored(monkeypatch):
+    # The header path must keep working, and a stale/garbage ?token= alongside it must be
+    # inert — auth decisions read only X-Debug-Token, never the (logged) query string.
+    monkeypatch.setenv('DEBUG_MEMORY_TOKEN', 'secret123')
+    from api.views_debug import debug_memory
+    from django.test import RequestFactory
+    factory = RequestFactory()
+    request = factory.get(
+        '/debug/memory/?token=wrong-and-ignored&action=status',
+        HTTP_X_DEBUG_TOKEN='secret123',
+    )
+    response = debug_memory(request)
+    assert response.status_code == 200
 
 
 # ── Action: status ────────────────────────────────────────────────
@@ -54,7 +85,7 @@ def test_status_action_returns_snapshot(monkeypatch):
     from api.views_debug import debug_memory
     from django.test import RequestFactory
     factory = RequestFactory()
-    request = factory.get('/debug/memory/?token=secret123&action=status')
+    request = factory.get('/debug/memory/?action=status', HTTP_X_DEBUG_TOKEN='secret123')
     response = debug_memory(request)
     data = json.loads(response.content)
     assert 'snapshot' in data
@@ -74,7 +105,7 @@ def test_snapshot_action_starts_tracemalloc(monkeypatch):
     from api.views_debug import debug_memory
     from django.test import RequestFactory
     factory = RequestFactory()
-    request = factory.get('/debug/memory/?token=secret123&action=snapshot')
+    request = factory.get('/debug/memory/?action=snapshot', HTTP_X_DEBUG_TOKEN='secret123')
     response = debug_memory(request)
     data = json.loads(response.content)
     assert 'top_allocations' in data
@@ -91,7 +122,7 @@ def test_stop_action_stops_tracemalloc(monkeypatch):
     from api.views_debug import debug_memory
     from django.test import RequestFactory
     factory = RequestFactory()
-    request = factory.get('/debug/memory/?token=secret123&action=stop')
+    request = factory.get('/debug/memory/?action=stop', HTTP_X_DEBUG_TOKEN='secret123')
     response = debug_memory(request)
     assert response.status_code == 200
     assert not tracemalloc.is_tracing()

--- a/Main/backend/tests/test_debug_route_gating.py
+++ b/Main/backend/tests/test_debug_route_gating.py
@@ -1,0 +1,141 @@
+"""Route-level gating for /debug/memory/ (Root G hygiene).
+
+api.views_debug discloses allocator tracebacks (absolute file paths + line numbers) and lets
+a caller start tracemalloc — persistent RAM overhead, a DoS lever — behind one static shared
+token. Token auth itself is covered in tests/test_debug_memory_endpoint.py; this file pins
+the OUTER layer: django_config/urls.py registers the route only under `if settings.DEBUG:`,
+so production (DJANGO_DEBUG unset -> False) 404s before the view is reachable, even if
+DEBUG_MEMORY_TOKEN leaks or gets set by mistake.
+
+Hermeticity: CI runs with no .env (DEBUG=False), but a local backend/.env sets
+DJANGO_DEBUG=True, so these tests never trust the ambient flag — they re-evaluate the
+URLconf's import-time `if settings.DEBUG:` by reloading django_config.urls under an explicit
+override_settings(DEBUG=...) and restore the ambient URLconf in tearDown.
+"""
+import ast
+import importlib
+from pathlib import Path
+
+from django.test import SimpleTestCase, override_settings
+from django.urls import NoReverseMatch, clear_url_caches, reverse
+
+import django_config.urls as project_urls
+
+URLS_PATH = Path(project_urls.__file__).resolve()
+
+# Shared knobs for driving a REAL request through the middleware stack under bare pytest
+# (no Django test runner, so setup_test_environment() never adds 'testserver' to
+# ALLOWED_HOSTS). SECURE_SSL_REDIRECT must be pinned off: with DEBUG=False the settings
+# default it True, and SecurityMiddleware would 301 the plain-HTTP test request BEFORE URL
+# resolution (the 301-trap, PR #313) — we'd assert on the redirect, not on routing.
+_REQUEST_KNOBS = {
+    "ALLOWED_HOSTS": ["testserver"],
+    "SECURE_SSL_REDIRECT": False,
+}
+
+
+def _reload_urlconf():
+    """Re-run django_config.urls' module body so its `if settings.DEBUG:` re-evaluates
+    against the CURRENTLY ACTIVE settings, then drop Django's cached resolver."""
+    importlib.reload(project_urls)
+    clear_url_caches()
+
+
+class DebugRouteGatingTests(SimpleTestCase):
+    def tearDown(self):
+        # Rebuild the URLconf from ambient settings so the reload never bleeds into other
+        # test modules that resolve against the default ROOT_URLCONF.
+        _reload_urlconf()
+
+    def test_route_absent_when_debug_false(self):
+        """Production posture (DEBUG=False): no reverse() name, and the URL 404s."""
+        with override_settings(DEBUG=False, **_REQUEST_KNOBS):
+            _reload_urlconf()
+            with self.assertRaises(NoReverseMatch):
+                reverse("debug_memory")
+            response = self.client.get("/debug/memory/")
+            self.assertEqual(
+                response.status_code, 404,
+                "/debug/memory/ must not be routed at all when DEBUG=False — a 403 here "
+                "would mean the view is reachable and only the token stands in the way",
+            )
+
+    def test_route_present_when_debug_true(self):
+        """The gate is conditional registration, not deletion: under DEBUG=True the route
+        resolves and hits the view's token check (403 without a token — NOT 404)."""
+        with override_settings(DEBUG=True, **_REQUEST_KNOBS):
+            _reload_urlconf()
+            self.assertEqual(reverse("debug_memory"), "/debug/memory/")
+            response = self.client.get("/debug/memory/")
+            self.assertEqual(response.status_code, 403)
+
+
+# ── Structural pin on the source (grep-sentinel style) ────────────────────────────────────
+# The runtime tests above prove behavior for the current module body; this pins the SHAPE of
+# urls.py so a refactor that hoists the registration out of the `if settings.DEBUG:` block
+# (or adds a second, unguarded copy) fails loudly even if it keeps the tests' env happy.
+
+class _DebugRouteVisitor(ast.NodeVisitor):
+    """Collect every `path('debug/memory/', ...)` call and whether it sits inside an
+    `if settings.DEBUG:` body. `if not settings.DEBUG:` / orelse branches count as
+    UNguarded — only the plain-truthy body is a valid home for the registration."""
+
+    def __init__(self):
+        self.registrations = []  # (lineno, guarded)
+        self._guard_stack = []
+
+    @staticmethod
+    def _is_settings_debug(test):
+        return (
+            isinstance(test, ast.Attribute)
+            and test.attr == "DEBUG"
+            and isinstance(test.value, ast.Name)
+            and test.value.id == "settings"
+        )
+
+    def visit_If(self, node):
+        self._guard_stack.append(self._is_settings_debug(node.test))
+        for child in node.body:
+            self.visit(child)
+        self._guard_stack.pop()
+        for child in node.orelse:  # else-branch of the guard is NOT gated
+            self.visit(child)
+
+    def visit_Call(self, node):
+        if (
+            isinstance(node.func, ast.Name)
+            and node.func.id == "path"
+            and node.args
+            and isinstance(node.args[0], ast.Constant)
+            and node.args[0].value == "debug/memory/"
+        ):
+            self.registrations.append((node.lineno, any(self._guard_stack)))
+        self.generic_visit(node)
+
+
+class DebugRouteStructuralPinTests(SimpleTestCase):
+    def test_debug_memory_registered_exactly_once_inside_settings_debug_block(self):
+        source = URLS_PATH.read_text(encoding="utf-8")
+
+        # Cheap sentinel first: exactly one mention of the route string in urls.py, so a
+        # duplicated (possibly unguarded) registration can't hide behind the AST check.
+        self.assertEqual(
+            source.count("'debug/memory/'"), 1,
+            "expected exactly one 'debug/memory/' registration in django_config/urls.py",
+        )
+
+        visitor = _DebugRouteVisitor()
+        visitor.visit(ast.parse(source))
+
+        self.assertEqual(
+            len(visitor.registrations), 1,
+            f"expected exactly one path('debug/memory/', ...) call, "
+            f"found {len(visitor.registrations)}",
+        )
+        lineno, guarded = visitor.registrations[0]
+        self.assertTrue(
+            guarded,
+            f"urls.py line {lineno}: path('debug/memory/', ...) must live inside an "
+            "`if settings.DEBUG:` block — unguarded registration exposes the diagnostic "
+            "endpoint (allocator tracebacks + tracemalloc control) in production",
+        )

--- a/Main/backend/tests/test_dockerfile_nonroot.py
+++ b/Main/backend/tests/test_dockerfile_nonroot.py
@@ -268,3 +268,65 @@ class DeployUserNamespaceTests(SimpleTestCase):
         # relabels the (private, this-container-only) mount to container_file_t so the
         # container can write it. Ownership AND SELinux must both be handled: ship :U,Z.
         self.assertIn("/home/deploy/fingpt/runtime:/app/runtime:U,Z", text)
+
+    # Frozen root-init capability set. Each cap maps 1:1 to a root-init step in
+    # entrypoint.sh -- nft firewall load -> NET_ADMIN, /app/runtime re-chown ->
+    # CHOWN, setpriv uid/gid drop -> SETUID/SETGID, --bounding-set=-net_admin ->
+    # SETPCAP -- so widening it means a root-init step was ADDED and must be
+    # justified in the deploy workflow's cap-map comment, never slipped in here.
+    ROOT_INIT_CAPS = sorted(["NET_ADMIN", "CHOWN", "SETUID", "SETGID", "SETPCAP"])
+
+    @staticmethod
+    def _joined_deploy_lines():
+        # The gate's podman run spans backslash continuations; fold them so flag
+        # extraction sees one logical line per command (same fold the entrypoint
+        # structural test uses).
+        return re.sub(r"\\\n\s*", " ", _read(DEPLOY_WORKFLOW)).splitlines()
+
+    def _execstart_line(self):
+        lines = [l for l in self._joined_deploy_lines()
+                 if "podman run" in l and "--name ${SYSTEMD_UNIT}" in l]
+        self.assertEqual(len(lines), 1, f"expected one ExecStart podman run, got {lines}")
+        return lines[0]
+
+    def _gate_line(self):
+        lines = [l for l in self._joined_deploy_lines()
+                 if "podman run" in l and "--egress-check-only" in l]
+        self.assertEqual(len(lines), 1, f"expected one gate podman run, got {lines}")
+        return lines[0]
+
+    @staticmethod
+    def _cap_pids_flags(line):
+        return sorted(re.findall(r"--(?:cap-add|cap-drop|pids-limit)=\S+", line))
+
+    def test_execstart_cap_set_is_frozen(self):
+        # assertEqual on the FULL extracted cap list, not assertIn per cap: a sixth
+        # --cap-add quietly appended to ExecStart must red this test -- preventing
+        # silent widening is the whole point. --cap-drop=ALL is part of the
+        # property: without it the five adds stack ON TOP of podman's default cap
+        # set instead of replacing it, and the "frozen set" is fiction.
+        line = self._execstart_line()
+        self.assertIn("--cap-drop=ALL", line)
+        self.assertEqual(
+            sorted(re.findall(r"--cap-add=([A-Z_]+)", line)), self.ROOT_INIT_CAPS
+        )
+
+    def test_execstart_pids_limit_pinned(self):
+        # Fork-bomb ceiling. 1024 covers today's worst case of ~400-600 tasks
+        # (gunicorn workers x threads + agent fan-out + Playwright/Chromium).
+        # Raise it DELIBERATELY (both podman run lines + this pin) if
+        # AGENT_MAX_CONCURRENCY or GUNICORN_WORKERS grows -- never by deleting
+        # the flag, which removes the ceiling entirely.
+        self.assertIn("--pids-limit=1024", self._execstart_line())
+
+    def test_gate_and_execstart_cap_pids_parity(self):
+        # The safety property of the frozen set: the pre-cutover gate must run the
+        # IDENTICAL cap/pids flags as the ExecStart it fronts, so all five caps are
+        # exercised end-to-end (nft + chown + setpriv + bounding-set drop) BEFORE
+        # cutover and a too-narrow set aborts the deploy with the old container
+        # still serving, instead of crash-looping the unit. Either line edited
+        # alone -- gate widened for a quick fix, or ExecStart narrowed without
+        # re-proving the gate -- must red here.
+        gate = self._cap_pids_flags(self._gate_line())
+        self.assertEqual(gate, self._cap_pids_flags(self._execstart_line()))
+        self.assertTrue(gate, "no cap/pids flags found on the gate podman run")

--- a/Main/backend/tests/test_endpoint_protection.py
+++ b/Main/backend/tests/test_endpoint_protection.py
@@ -1,0 +1,385 @@
+"""Root-G endpoint-protection hygiene: limiter coverage, method gates, health pin.
+
+Tier 1 — coverage sentinel: EVERY routed view except ``api.views.health`` must
+carry the production decoration
+``@ratelimit(key='api.identity.ratelimit_key', rate=settings.API_RATE_LIMIT,
+method=ALL, block=True)`` where ``ALL`` is the imported ``django_ratelimit.ALL``
+sentinel. The sentinel form matters: P0 Root C proved the STRING ``method='ALL'``
+never matches ``core._method_match``'s ``(None,)`` tuple, silently disabling the
+limiter — so the structural scan also forbids the string form at any call site.
+
+Tier 2 — method gates: ``clear_messages`` mutates state on a CSRF-exempt
+endpoint so it is POST-only; the chat/agent surface reads query params only so
+it is GET-only.
+
+health/ pin: django-ratelimit fails CLOSED when the counter cache is
+unreachable (``get_usage`` returns ``should_limit`` for a ``None`` count, and
+backend exceptions propagate as 500s), so a decorated health endpoint would go
+down WITH Redis and turn an outage into an LB-driven restart cascade. health
+must stay un-ratelimited (structural + behavioral at 1-req/min headroom) and
+fully independent of the cache backend.
+
+Run: uv run pytest tests/test_endpoint_protection.py -v
+"""
+import ast
+import importlib
+import json
+from pathlib import Path
+
+from django.conf import settings
+from django.core.cache import cache
+from django.core.cache.backends.base import BaseCache
+from django.test import RequestFactory, SimpleTestCase, override_settings
+from django_ratelimit.exceptions import Ratelimited
+
+import api.views as views_module
+import django_config.urls as urlconf
+
+# Captured at import time, BEFORE any override_settings is active, so the
+# restore-reload in AddWebtextRatelimit429Tests.tearDownClass re-binds the
+# decorators at the real production rate (see comment there).
+_REAL_RATE = settings.API_RATE_LIMIT
+
+BACKEND_DIR = Path(__file__).resolve().parent.parent
+
+# Every dir that may legitimately contain a @ratelimit call site. Scanned for
+# the forbidden string-method form; .venv lives outside all of these.
+RATELIMIT_SCAN_DIRS = ("api", "django_config", "datascraper", "tests")
+
+CANONICAL_KEY = "api.identity.ratelimit_key"
+
+# (module, view) pairs allowed to skip the production limiter. Every entry
+# needs a WHY; any other routed-but-undecorated view fails the sentinel.
+RATELIMIT_EXEMPT = {
+    ("api.views", "health"): (
+        "LB probe: the limiter fails closed when the counter cache is down, "
+        "so decorating health couples the probe to Redis availability"
+    ),
+    ("api.views_debug", "debug_memory"): (
+        "fail-closed token gate (403 unless DEBUG_MEMORY_TOKEN matches, and "
+        "403 when the token is unset) and DEBUG-gated route registration in "
+        "urls.py; ratelimit decoration for views_debug is owned by a separate "
+        "hygiene item — drop this entry when it lands"
+    ),
+}
+
+
+# ── structural helpers (pure AST, immune to importlib.reload churn) ──────────
+
+
+def _routed_views():
+    """(module, name) for every view wired in django_config.urls.
+
+    functools.wraps preserves __module__/__name__ through the csrf/method/
+    ratelimit wrapper stack, so these names key straight into the AST maps.
+    """
+    return sorted(
+        {(p.callback.__module__, p.callback.__name__) for p in urlconf.urlpatterns}
+    )
+
+
+def _module_ast(module_name):
+    source = Path(importlib.import_module(module_name).__file__)
+    return ast.parse(source.read_text(encoding="utf-8"), filename=str(source))
+
+
+def _view_decorators(module_name):
+    """Top-level function name -> list of decorator ast.Call nodes."""
+    return {
+        node.name: [d for d in node.decorator_list if isinstance(d, ast.Call)]
+        for node in _module_ast(module_name).body
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+    }
+
+
+def _is_ratelimit_call(call):
+    func = call.func
+    name = func.attr if isinstance(func, ast.Attribute) else getattr(func, "id", None)
+    return name == "ratelimit"
+
+
+def _call_kwargs(call):
+    return {kw.arg: kw.value for kw in call.keywords if kw.arg}
+
+
+def _is_production_ratelimit(call):
+    """Match the canonical decoration, kwarg by kwarg.
+
+    ``method`` must be the imported sentinel (a Name/Attribute reference named
+    ALL), never a string constant — the exact silent-no-op bug of P0 Root C.
+    """
+    if not _is_ratelimit_call(call):
+        return False
+    kw = _call_kwargs(call)
+    key = kw.get("key")
+    rate = kw.get("rate")
+    method = kw.get("method")
+    block = kw.get("block")
+    return (
+        isinstance(key, ast.Constant) and key.value == CANONICAL_KEY
+        and isinstance(rate, ast.Attribute) and rate.attr == "API_RATE_LIMIT"
+        and isinstance(rate.value, ast.Name) and rate.value.id == "settings"
+        and (
+            (isinstance(method, ast.Name) and method.id == "ALL")
+            or (isinstance(method, ast.Attribute) and method.attr == "ALL")
+        )
+        and isinstance(block, ast.Constant) and block.value is True
+    )
+
+
+class RatelimitCoverageSentinelTests(SimpleTestCase):
+    """Structural pin: adding a route without the limiter breaks the build."""
+
+    def test_every_routed_view_carries_production_ratelimit(self):
+        decorators_cache = {}
+        missing = []
+        for module_name, view_name in _routed_views():
+            if (module_name, view_name) in RATELIMIT_EXEMPT:
+                continue
+            if module_name not in decorators_cache:
+                decorators_cache[module_name] = _view_decorators(module_name)
+            calls = decorators_cache[module_name].get(view_name, [])
+            if not any(_is_production_ratelimit(c) for c in calls):
+                missing.append(f"{module_name}.{view_name}")
+        self.assertEqual(
+            missing, [],
+            "routed view(s) without the production @ratelimit decoration "
+            "(key='api.identity.ratelimit_key', rate=settings.API_RATE_LIMIT, "
+            "method=ALL sentinel, block=True) and not in RATELIMIT_EXEMPT: "
+            f"{missing}",
+        )
+
+    def test_exemptions_reference_real_views(self):
+        # A stale exemption (view renamed/deleted) must be pruned, not carried.
+        # Existence, not routing, is asserted: debug/memory is registered under
+        # `if settings.DEBUG` in urls.py, so it is absent from urlpatterns in
+        # the DEBUG=False test default yet still needs its exemption for
+        # DEBUG=True runs.
+        for module_name, view_name in RATELIMIT_EXEMPT:
+            module = importlib.import_module(module_name)
+            self.assertTrue(
+                callable(getattr(module, view_name, None)),
+                f"RATELIMIT_EXEMPT entry {module_name}.{view_name} no longer "
+                "exists — remove it",
+            )
+
+    def test_health_is_structurally_unratelimited(self):
+        # The exemption above only *allows* health to skip the limiter; this
+        # pins that nobody decorates it later (see HealthIndependenceTests for
+        # the WHY: fail-closed limiter + Redis outage = dead LB probe).
+        calls = _view_decorators("api.views").get("health", [])
+        self.assertFalse(
+            any(_is_ratelimit_call(c) for c in calls),
+            "api.views.health must NEVER carry @ratelimit",
+        )
+
+    def test_no_string_method_all_form_at_any_call_site(self):
+        offenders = []
+        seen = 0
+        for scan_dir in RATELIMIT_SCAN_DIRS:
+            for source in sorted((BACKEND_DIR / scan_dir).rglob("*.py")):
+                tree = ast.parse(source.read_text(encoding="utf-8"), filename=str(source))
+                for node in ast.walk(tree):
+                    if isinstance(node, ast.Call) and _is_ratelimit_call(node):
+                        seen += 1
+                        method = _call_kwargs(node).get("method")
+                        if isinstance(method, ast.Constant):
+                            offenders.append(f"{source}:{node.lineno}")
+        self.assertEqual(
+            offenders, [],
+            "ratelimit(method=<string>) is a silent no-op (never matches the "
+            f"django_ratelimit.ALL sentinel tuple); found at: {offenders}",
+        )
+        # Vacuity guard: a scanner that finds no call sites proves nothing.
+        self.assertGreaterEqual(
+            seen, 10, "string-ALL scan found implausibly few @ratelimit call sites"
+        )
+
+
+# ── behavioral: the NEW Tier-1 decoration actually fires (no decoration theater)
+
+
+# Tight per-identity limit + in-process LocMemCache so counters are
+# deterministic and isolated from the base FileBasedCache (same mechanics as
+# tests/test_ratelimit_enforced.py).
+RL_OVERRIDES = override_settings(
+    RATELIMIT_ENABLE=True,
+    API_RATE_LIMIT="1/m",
+    CACHES={
+        "default": {
+            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+            "LOCATION": "endpoint-protection-429-tests",
+        }
+    },
+)
+
+
+@RL_OVERRIDES
+class AddWebtextRatelimit429Tests(SimpleTestCase):
+    """input_webtext/ (a previously un-throttled ingest sink) must block the
+    second request from one identity once decorated."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # Re-import api.views with API_RATE_LIMIT='1/m' in effect so the
+        # decorators re-bind at a tight rate while keeping their real key= and
+        # method= arguments — the production wiring is genuinely under test.
+        cls._reloaded = importlib.reload(views_module)
+        cls.add_webtext = staticmethod(cls._reloaded.add_webtext)
+
+    @classmethod
+    def tearDownClass(cls):
+        # tearDownClass runs BEFORE Django disables the class-level override
+        # (that happens in a class *cleanup*), so a bare reload here would
+        # re-bind the decorators at 1/m and leak the tight limiter into every
+        # later test file in the same process — the exact leak that lives in
+        # test_ratelimit_enforced.py and 429s test_axiom_views when the suites
+        # share one process. Re-override to the real rate for the restore.
+        with override_settings(API_RATE_LIMIT=_REAL_RATE):
+            importlib.reload(views_module)
+        super().tearDownClass()
+
+    def setUp(self):
+        cache.clear()
+        self.factory = RequestFactory()
+
+    def _trusted_proxy_post(self, real_ip="198.51.100.77"):
+        # REMOTE_ADDR=127.0.0.1 is a default TRUSTED_PROXY, so get_client_ip()
+        # honors X-Real-IP and both hits share one identity bucket. The body is
+        # an empty JSON object on purpose: add_webtext 400s on 'No text content
+        # provided' before any session/context work, so the limiter is the only
+        # stateful actor and the test needs no SessionMiddleware. (A bare
+        # factory.post() would ship a multipart boundary that json.loads
+        # rejects into the generic 500 path instead.)
+        req = self.factory.post(
+            "/input_webtext/", data="{}", content_type="application/json"
+        )
+        req.META["REMOTE_ADDR"] = "127.0.0.1"
+        req.META["HTTP_X_REAL_IP"] = real_ip
+        return req
+
+    def test_second_post_from_same_identity_is_rate_limited(self):
+        first = self._trusted_proxy_post()
+        resp = self.add_webtext(first)
+        self.assertFalse(
+            getattr(first, "limited", False),
+            "first request must NOT be limited (fresh 1/m bucket)",
+        )
+        self.assertEqual(resp.status_code, 400)  # empty-body short-circuit
+
+        second = self._trusted_proxy_post()
+        with self.assertRaises(
+            Ratelimited,
+            msg="second request was NOT blocked -> the new add_webtext "
+            "decoration is a no-op",
+        ):
+            self.add_webtext(second)
+        self.assertTrue(
+            getattr(second, "limited", False),
+            "request.limited must be True once the bucket is exhausted",
+        )
+
+    def test_distinct_identities_keep_independent_buckets(self):
+        a1 = self._trusted_proxy_post(real_ip="203.0.113.21")
+        self.add_webtext(a1)
+        with self.assertRaises(Ratelimited):
+            self.add_webtext(self._trusted_proxy_post(real_ip="203.0.113.21"))
+
+        # Fresh identity -> fresh bucket -> allowed through to the view body.
+        b1 = self._trusted_proxy_post(real_ip="203.0.113.22")
+        resp = self.add_webtext(b1)
+        self.assertFalse(getattr(b1, "limited", False))
+        self.assertEqual(resp.status_code, 400)
+
+
+# ── Tier 2: method gates ─────────────────────────────────────────────────────
+
+
+METHOD_GATE_OVERRIDES = override_settings(
+    # RATELIMIT_ENABLE is read per-request in get_usage, so no module reload is
+    # needed; disabling it isolates the method gate as the only actor.
+    RATELIMIT_ENABLE=False,
+    CACHES={
+        "default": {
+            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+            "LOCATION": "endpoint-protection-method-tests",
+        }
+    },
+)
+
+
+@METHOD_GATE_OVERRIDES
+class MethodGateTests(SimpleTestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+
+    def test_get_clear_messages_is_405(self):
+        resp = views_module.clear(self.factory.get("/clear_messages/"))
+        self.assertEqual(resp.status_code, 405)
+        self.assertEqual(resp["Allow"], "POST")
+
+    def test_put_clear_messages_is_405(self):
+        resp = views_module.clear(self.factory.put("/clear_messages/"))
+        self.assertEqual(resp.status_code, 405)
+
+    def test_post_clear_messages_succeeds(self):
+        # RequestFactory attaches no session: _cookie_root falls back to a
+        # fresh uuid and clear_session is a plain cache.delete on locmem, so
+        # the happy path is hermetic.
+        resp = views_module.clear(self.factory.post("/clear_messages/"))
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(json.loads(resp.content)["status"], "success")
+
+    def test_post_to_get_only_chat_view_is_405(self):
+        resp = views_module.chat_response(
+            self.factory.post("/get_chat_response/", data={"question": "hi"})
+        )
+        self.assertEqual(resp.status_code, 405)
+        self.assertEqual(resp["Allow"], "GET")
+
+
+# ── health/ regression pin: un-ratelimited AND cache-backend independent ─────
+
+
+class RaisingCache(BaseCache):
+    """Counter cache that is hard-down: EVERY op raises.
+
+    Simulates a Redis outage under settings_prod's shared cache. health must
+    not notice; a (wrongly) ratelimited health would blow up inside
+    get_usage's cache.add before the view body ever ran.
+    """
+
+    def __init__(self, location, params):
+        super().__init__(params)
+
+    def _down(self, *args, **kwargs):
+        raise RuntimeError("counter cache unavailable (simulated Redis outage)")
+
+    add = _down
+    get = _down
+    set = _down
+    touch = _down
+    incr = _down
+    decr = _down
+    delete = _down
+    clear = _down
+    has_key = _down
+
+
+@override_settings(
+    RATELIMIT_ENABLE=True,
+    CACHES={"default": {"BACKEND": "tests.test_endpoint_protection.RaisingCache"}},
+)
+class HealthIndependenceTests(SimpleTestCase):
+    def test_health_stays_200_twice_with_counter_cache_down(self):
+        # Two calls: catches both failure shapes of an accidental decoration —
+        # a cache exception on call 1 and a fail-closed 429 path on call 2.
+        factory = RequestFactory()
+        for attempt in (1, 2):
+            resp = views_module.health(factory.get("/health/"))
+            self.assertEqual(
+                resp.status_code, 200,
+                f"health attempt {attempt} must be 200 even with the cache down",
+            )
+            self.assertEqual(json.loads(resp.content)["status"], "healthy")

--- a/Main/backend/tests/test_gitignore_env.py
+++ b/Main/backend/tests/test_gitignore_env.py
@@ -1,0 +1,94 @@
+"""Sentinel for the repo-wide dotenv ignore block (Root G hygiene).
+
+Concierge and Heartbeat keep their REAL dotenvs (.env.concierge /
+.env.heartbeat, written by hand on the droplet) right next to tracked
+.example templates, and the root .gitignore used to be a path-specific list
+(Main/backend/.env, chat_interface/...) that silently rotted each time a
+service was added -- a `git add -A` from the repo root would have staged
+live Discord/OpenAI credentials. The repo-wide `.env` / `.env.*` block
+closes that; these tests pin BOTH directions of it:
+
+  * every real dotenv shape is ignored (`git check-ignore` exits 0), and
+  * the four committed .example templates stay tracked -- the `!` negations
+    are load-bearing, since `.env.*` alone would ignore the templates on a
+    fresh clone and `git add` of an updated template would start failing.
+
+Lives here, NOT in Concierge/tests: the concierge droplet refresh ships the
+tree without .git, where these git invocations can only error. The whole
+module skips in that case (and wherever else .git is absent, e.g. a bare
+source export).
+
+Runs in the standard backend harness:
+    uv run pytest tests/test_gitignore_env.py -q
+"""
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+# tests/ -> backend/ -> Main/ -> repo root
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+# .git is a FILE (gitdir pointer) in linked worktrees; exists() covers both.
+pytestmark = pytest.mark.skipif(
+    shutil.which("git") is None or not (REPO_ROOT / ".git").exists(),
+    reason="not a git checkout (droplet refresh ships the tree without .git)",
+)
+
+# Real-secret paths that must never be stageable. The bare .env variants are
+# asserted alongside the suffixed ones: check-ignore evaluates patterns for
+# paths that need not exist, so this pins the rule for whichever shape a
+# future service (or a hand edit on the droplet) actually writes.
+REAL_DOTENVS = [
+    "Concierge/.env.concierge",
+    "Concierge/.env",
+    "Heartbeat/.env.heartbeat",
+    "Heartbeat/.env",
+]
+
+# The committed onboarding templates the two `!` negations re-include.
+TRACKED_TEMPLATES = [
+    "Concierge/.env.concierge.example",
+    "Heartbeat/.env.heartbeat.example",
+    "Main/backend/.env.example",
+    "Main/backend/.env.production.example",
+]
+
+
+def _git(*args: str) -> int:
+    # Exit code is the whole contract here; swallow output so a git warning
+    # can't pollute the pytest report.
+    return subprocess.run(
+        ["git", "-C", str(REPO_ROOT), *args],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    ).returncode
+
+
+@pytest.mark.parametrize("path", REAL_DOTENVS)
+def test_real_dotenvs_are_ignored(path):
+    # check-ignore -q: 0 = ignored, 1 = plain `git add` would stage it.
+    assert _git("check-ignore", "-q", "--", path) == 0, (
+        f"{path} is not gitignored -- `git add -A` would stage live secrets"
+    )
+
+
+@pytest.mark.parametrize("path", TRACKED_TEMPLATES)
+def test_example_templates_stay_tracked(path):
+    # ls-files --error-unmatch: 0 = tracked in the index. Trips if the
+    # negations are dropped and a later `git rm --cached` style cleanup (or a
+    # rewrite of the dotenv block) untracks the onboarding templates.
+    assert _git("ls-files", "--error-unmatch", "--", path) == 0, (
+        f"{path} is no longer tracked -- the .example negations were broken"
+    )
+
+
+@pytest.mark.parametrize("path", TRACKED_TEMPLATES)
+def test_example_templates_not_ignored_for_fresh_clones(path):
+    # Tracked files sail past ignore rules, so ls-files alone can't see a
+    # broken negation until someone re-adds the file. check-ignore must exit
+    # 1 (NOT ignored) or a fresh clone could never stage a template update.
+    assert _git("check-ignore", "-q", "--", path) == 1, (
+        f"{path} matches an ignore rule -- the `!` negation no longer wins"
+    )

--- a/Main/backend/tests/test_gunicorn_conf.py
+++ b/Main/backend/tests/test_gunicorn_conf.py
@@ -1,9 +1,13 @@
-"""Static guard: the gunicorn config disables the unused control socket.
+"""Static guards over gunicorn.conf.py: control socket stays off, access log stays redacted.
 
 gunicorn 25.1's control_socket defaults to ./gunicorn.ctl in WORKDIR /app, which is
 root-owned; as the non-root runtime user (uid 1001) that path is unwritable and the
 arbiter logs a recurring "Failed to start control socket: Permission denied" warning on
 every start and reload. We don't use the gunicornc management CLI, so it is disabled.
+
+The access log format must never log the query string: credentials have been passed
+there before (the old /api/debug/memory/?token=... pattern), and %(r)s — the raw
+request line — would write them verbatim into stdout log shipping.
 """
 import importlib.util
 import os
@@ -33,3 +37,57 @@ def test_control_socket_disable_is_a_real_gunicorn_setting():
     from gunicorn.config import KNOWN_SETTINGS
 
     assert "control_socket_disable" in {s.name for s in KNOWN_SETTINGS}
+
+
+def test_access_log_format_never_logs_the_query_string():
+    # %(r)s is the raw request line — path *and* query string — and %(q)s is the query
+    # string alone. Either one would write ?token=-style credentials (or any signed-URL
+    # secret) verbatim into stdout, which log shipping then persists. Pin the redacted
+    # replacement: method + query-stripped path + protocol, quoted, so the overall line
+    # keeps the combined-log shape downstream parsers expect.
+    mod = _load_gunicorn_conf()
+    assert "%(r)s" not in mod.access_log_format
+    assert "%(q)s" not in mod.access_log_format
+    assert '"%(m)s %(U)s %(H)s"' in mod.access_log_format
+
+
+# Exactly the non-dynamic atoms gunicorn's glogging.Logger.atoms() provides (the
+# {header}i/{header}o/{env}e forms are unused in our format). Values mimic a request
+# that smuggles a credential in the query string, so the render test below can prove
+# the formatted line drops it.
+_STUB_ATOMS = {
+    "h": "203.0.113.7",
+    "l": "-",
+    "u": "-",
+    "t": "[03/Jul/2026:00:00:00 +0000]",
+    "r": "GET /api/debug/memory/?token=hunter2 HTTP/1.1",
+    "s": "200",
+    "m": "GET",
+    "U": "/api/debug/memory/",
+    "q": "token=hunter2",
+    "H": "HTTP/1.1",
+    "b": "512",
+    "B": 512,
+    "f": "-",
+    "a": "curl/8.5.0",
+    "T": 0,
+    "D": 1234,
+    "M": 1,
+    "L": "0.001234",
+    "p": "<12345>",
+}
+
+
+def test_access_log_format_renders_against_gunicorn_atoms():
+    # Belt and braces, same rationale as the control-socket setting check above: gunicorn
+    # renders the format with %-interpolation over a SafeAtoms dict that maps unknown
+    # names to "-", so a typo'd atom would silently log dashes forever. Rendering against
+    # a *plain* dict of the real atom names makes any typo raise KeyError here in CI.
+    mod = _load_gunicorn_conf()
+    rendered = mod.access_log_format % _STUB_ATOMS
+    assert rendered == (
+        '203.0.113.7 - - [03/Jul/2026:00:00:00 +0000] '
+        '"GET /api/debug/memory/ HTTP/1.1" 200 512 "-" "curl/8.5.0" 1234'
+    )
+    # The credential present in the stub's request line/query string never reaches the log.
+    assert "hunter2" not in rendered

--- a/Main/backend/tests/test_mcp_child_env.py
+++ b/Main/backend/tests/test_mcp_child_env.py
@@ -1,0 +1,282 @@
+"""Security regression: MCP stdio children get an allow-listed env, not ours.
+
+Root G hygiene (2026-06-29 audit follow-up). mcp_client/mcp_manager.py used to
+seed every stdio child with `os.environ.copy()`, so sec-edgar-mcp and any
+npx-fetched server inherited OPENAI_API_KEY / DJANGO_SECRET_KEY / Redis + Mem0
+credentials it never needed — one `os.environ` dump in a compromised (or
+merely chatty) dependency would exfiltrate every backend secret. The spawn
+path now starts from the MCP SDK's safe base (get_default_environment():
+HOME/LOGNAME/PATH/SHELL/TERM/USER on posix) and layers on only what the
+server's config block declares: the byte-identical ${VAR} interpolation loop,
+the optional "inheritEnv" passthrough, and the MCP_LOG_LEVEL injection.
+
+Four layers of pinning, so a revert cannot slip through quietly:
+  1. behavioral   — capture StdioServerParameters via a fake stdio_client and
+                    prove a poisoned parent env does not reach the child;
+  2. structural   — `os.environ.copy(` must not reappear in non-comment lines
+                    of mcp_manager.py;
+  3. config       — no server's "inheritEnv" may name a secret-shaped var
+                    (the runtime passthrough is deliberately dumb; hygiene is
+                    enforced here, at review time);
+  4. real spawn   — the xbrl-taxonomy server (offline, bundled JSON) must
+                    initialize and answer a tool call under the allow-listed
+                    env, proving the base set is sufficient for a real child.
+"""
+import asyncio
+import io
+import json
+import os
+import re
+import sys
+import tokenize
+from pathlib import Path
+
+import pytest
+from mcp.client.stdio import DEFAULT_INHERITED_ENV_VARS
+
+from mcp_client import mcp_manager as mcp_manager_module
+from mcp_client.mcp_manager import MCPClientManager
+
+BACKEND_DIR = Path(__file__).resolve().parent.parent
+MANAGER_SOURCE = BACKEND_DIR / "mcp_client" / "mcp_manager.py"
+CONFIG_PATH = BACKEND_DIR / "mcp_server_config.json"
+
+# Representative secrets the backend actually holds at runtime (see
+# django_config settings / deploy env). Values are sentinels, never real.
+POISON_SECRETS = {
+    "OPENAI_API_KEY": "sk-poison-openai-000",
+    "ANTHROPIC_API_KEY": "sk-ant-poison-000",
+    "DJANGO_SECRET_KEY": "poison-django-secret",
+    "AWS_SECRET_ACCESS_KEY": "poison-aws-secret",
+    "REDIS_PASSWORD": "poison-redis-pass",
+    "MEM0_API_KEY": "poison-mem0-key",
+    # Deliberately secret-UNshaped: proves the fix is an allow-list, not a
+    # denylist of scary-looking names.
+    "TOTALLY_INNOCENT_PARENT_VAR": "still-must-not-leak",
+}
+
+# Var names a server config may legitimately inherit must not look like any
+# of these. Mirrors the leak_detector's notion of credential material.
+SECRET_NAME_PATTERN = re.compile(
+    r"(KEY|SECRET|TOKEN|PASSWORD|PASSWD|CREDENTIAL|PRIVATE|AUTH|COOKIE|SESSION)",
+    re.IGNORECASE,
+)
+
+
+class _FakeTransport:
+    """Stands in for stdio_client's context manager; never spawns anything."""
+
+    async def __aenter__(self):
+        return (object(), object())
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+class _FakeSession:
+    """Stands in for ClientSession; initialize() is the only call the spawn
+    path makes before registering the session."""
+
+    def __init__(self, read_stream, write_stream):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def initialize(self):
+        return None
+
+
+async def _capture_spawn_env(monkeypatch, server_name, server_config, *, verbose):
+    """Run the real _connect_server spawn path, capturing the
+    StdioServerParameters it hands to stdio_client."""
+    captured = {}
+
+    def fake_stdio_client(server_params):
+        captured["params"] = server_params
+        return _FakeTransport()
+
+    monkeypatch.setattr(mcp_manager_module, "stdio_client", fake_stdio_client)
+    monkeypatch.setattr(mcp_manager_module, "ClientSession", _FakeSession)
+
+    manager = MCPClientManager(verbose=verbose, printer=lambda _msg: None)
+    try:
+        await manager._connect_server(server_name, server_config)
+    finally:
+        await manager.exit_stack.aclose()
+    return captured["params"]
+
+
+async def test_child_env_is_allowlisted_not_inherited(monkeypatch):
+    """Poisoned parent env must not reach the child; ${VAR} interpolation,
+    PATH/HOME and MCP_LOG_LEVEL must survive the allow-listing."""
+    for name, value in POISON_SECRETS.items():
+        monkeypatch.setenv(name, value)
+    monkeypatch.setenv("HOME", os.environ.get("HOME", "/tmp/fake-home"))
+    monkeypatch.setenv("SEC_EDGAR_USER_AGENT", "FinGPT Test test@example.com")
+
+    # Use the SHIPPED sec-edgar block so the test tracks the real config's
+    # ${SEC_EDGAR_USER_AGENT} interpolation, not a synthetic lookalike.
+    servers = json.loads(CONFIG_PATH.read_text(encoding="utf-8"))["mcpServers"]
+    sec_edgar = servers["sec-edgar"]
+
+    params = await _capture_spawn_env(
+        monkeypatch, "sec-edgar", sec_edgar, verbose=True
+    )
+    child_env = params.env
+
+    for name in POISON_SECRETS:
+        assert name not in child_env, f"secret {name} leaked into child env"
+
+    # Config-declared values arrive interpolated, not as literal ${...}.
+    assert child_env["SEC_EDGAR_USER_AGENT"] == "FinGPT Test test@example.com"
+    assert child_env["SEC_EDGAR_RATE_LIMIT"] == "8"
+
+    # The safe base survives — a child that cannot see PATH/HOME cannot run.
+    assert child_env["PATH"] == os.environ["PATH"]
+    assert child_env["HOME"] == os.environ["HOME"]
+
+    # Log-level injection is untouched by the allow-listing (verbose=True).
+    assert child_env["MCP_LOG_LEVEL"] == "INFO"
+
+    # Strict upper bound: nothing outside base ∪ config-env ∪ MCP_LOG_LEVEL.
+    allowed = (
+        set(DEFAULT_INHERITED_ENV_VARS)
+        | set(sec_edgar.get("env", {}))
+        | {"MCP_LOG_LEVEL"}
+    )
+    assert set(child_env) <= allowed, sorted(set(child_env) - allowed)
+
+
+async def test_quiet_manager_still_injects_warning_level(monkeypatch):
+    """verbose=False must keep producing MCP_LOG_LEVEL=WARNING for children."""
+    params = await _capture_spawn_env(
+        monkeypatch,
+        "yahoo-finance",
+        {"command": "python", "args": ["-m", "mcp_server.yahoo_finance_server"]},
+        verbose=False,
+    )
+    assert params.env["MCP_LOG_LEVEL"] == "WARNING"
+
+
+async def test_inherit_env_passthrough_is_optin_and_exact(monkeypatch):
+    """"inheritEnv" copies exactly the named parent vars — set names arrive,
+    unset names are silently skipped, nothing else rides along."""
+    monkeypatch.setenv("FINGPT_TEST_PROXY", "http://proxy.internal:3128")
+    monkeypatch.delenv("FINGPT_TEST_UNSET", raising=False)
+
+    params = await _capture_spawn_env(
+        monkeypatch,
+        "synthetic",
+        {
+            "command": "python",
+            "args": ["-m", "mcp_server.yahoo_finance_server"],
+            "inheritEnv": ["FINGPT_TEST_PROXY", "FINGPT_TEST_UNSET"],
+        },
+        verbose=False,
+    )
+    assert params.env["FINGPT_TEST_PROXY"] == "http://proxy.internal:3128"
+    assert "FINGPT_TEST_UNSET" not in params.env
+
+
+def _source_without_comments(path: Path) -> str:
+    """Return the file's source with every #-comment removed (tokenizer-based,
+    so '#' inside string literals does not truncate lines)."""
+    source = path.read_text(encoding="utf-8")
+    lines = source.splitlines()
+    comment_starts = {}
+    for tok in tokenize.generate_tokens(io.StringIO(source).readline):
+        if tok.type == tokenize.COMMENT:
+            comment_starts[tok.start[0]] = tok.start[1]
+    stripped = [
+        line[: comment_starts[lineno]] if lineno in comment_starts else line
+        for lineno, line in enumerate(lines, 1)
+    ]
+    return "\n".join(stripped)
+
+
+def test_manager_source_never_copies_full_environ():
+    """Structural sentinel: the wholesale-inheritance idiom must not return to
+    mcp_manager.py outside of comments, in any whitespace disguise."""
+    code = _source_without_comments(MANAGER_SOURCE)
+    condensed = "".join(code.split())
+    assert "environ.copy(" not in condensed, (
+        "os.environ.copy() is back in mcp_manager.py — children would inherit "
+        "every backend secret again"
+    )
+    assert "dict(os.environ)" not in condensed, (
+        "dict(os.environ) is os.environ.copy() in a trenchcoat"
+    )
+    # Positive pin: the spawn path must still build from the SDK's safe base.
+    assert "get_default_environment(" in condensed, (
+        "spawn path no longer starts from get_default_environment() — "
+        "verify the child env is still allow-listed"
+    )
+
+
+def test_config_inherit_env_names_are_not_secret_shaped():
+    """Config sentinel: "inheritEnv" is a passthrough with no runtime
+    filtering, so no server may use it to smuggle a secret-shaped var."""
+    servers = json.loads(CONFIG_PATH.read_text(encoding="utf-8"))["mcpServers"]
+    assert servers, "mcp_server_config.json lost its mcpServers block"
+    for server_name, server_config in servers.items():
+        inherit = server_config.get("inheritEnv", [])
+        assert isinstance(inherit, list), (
+            f"{server_name}: inheritEnv must be a list of var names"
+        )
+        for name in inherit:
+            assert isinstance(name, str)
+            assert not SECRET_NAME_PATTERN.search(name), (
+                f"{server_name}: inheritEnv entry {name!r} is secret-shaped; "
+                "pass it via the interpolated 'env' block only if the child "
+                "genuinely needs it, and justify it in review"
+            )
+
+
+async def test_real_child_spawns_under_allowlisted_env(monkeypatch):
+    """Real-spawn smoke: the xbrl-taxonomy server (offline — bundled
+    us_gaap_2026.json, no network) must initialize, list tools and answer a
+    tool call with ONLY the allow-listed env, proving the base set is
+    sufficient for an actual child process."""
+    # Poison the parent even here: the child must come up fine WITHOUT them.
+    for name, value in POISON_SECRETS.items():
+        monkeypatch.setenv(name, value)
+    # `python -m mcp_server.xbrl.server` resolves the package via cwd.
+    monkeypatch.chdir(BACKEND_DIR)
+
+    manager = MCPClientManager(verbose=False, printer=lambda _msg: None)
+    config = {
+        # sys.executable == this venv's python, so the child sees the same
+        # installed `mcp` + `mcp_server` without needing PYTHONPATH leaks.
+        "command": sys.executable,
+        "args": ["-m", "mcp_server.xbrl.server"],
+    }
+
+    async def _smoke():
+        # Enter and exit the stack inside ONE task: anyio cancel scopes in
+        # stdio_client refuse to close from a different task, and wait_for
+        # wraps its awaitable in a new task.
+        try:
+            await manager._connect_server("xbrl-taxonomy", config)
+            session = manager.sessions["xbrl-taxonomy"]
+            tools = await session.list_tools()
+            result = await session.call_tool(
+                "validate_xbrl_tag", {"tag_name": "Assets"}
+            )
+            return tools, result
+        finally:
+            await manager.exit_stack.aclose()
+
+    tools, result = await asyncio.wait_for(_smoke(), timeout=90)
+
+    tool_names = {tool.name for tool in tools.tools}
+    assert "lookup_xbrl_tags" in tool_names
+    assert "validate_xbrl_tag" in tool_names
+
+    text = "".join(
+        item.text for item in result.content if getattr(item, "type", "") == "text"
+    )
+    assert "VALID" in text and "Assets" in text

--- a/Main/backend/tests/test_ratelimit_enforced.py
+++ b/Main/backend/tests/test_ratelimit_enforced.py
@@ -22,11 +22,17 @@ Run: uv run pytest tests/test_ratelimit_enforced.py -v
 """
 import importlib
 
+from django.conf import settings
 from django.core.cache import cache
 from django.test import RequestFactory, SimpleTestCase, override_settings
 from django_ratelimit.exceptions import Ratelimited
 
 import api.views as views_module
+
+# Captured at import time (test collection imports every module before any
+# override_settings is active), so the restore-reload in tearDownClass can
+# re-bind the decorators at the REAL production rate.
+_REAL_RATE = settings.API_RATE_LIMIT
 
 # Tight per-identity limit + an in-process LocMemCache so rate-limit counters
 # are deterministic and isolated from the base FileBasedCache.
@@ -59,8 +65,14 @@ class RatelimitEnforcedTests(SimpleTestCase):
     @classmethod
     def tearDownClass(cls):
         # Restore the module to its real (un-overridden) rate for the rest of
-        # the suite so we don't leak a 1/m limiter into other tests.
-        importlib.reload(views_module)
+        # the suite so we don't leak a 1/m limiter into other tests. The
+        # class-level override is STILL ACTIVE here (Django disables it in a
+        # class *cleanup*, which runs after tearDownClass), so a bare reload
+        # would re-bind every decorator at 1/m for the remainder of the
+        # process — 429-ing later suites that hit decorated views. Re-override
+        # to the captured real rate for the restore reload.
+        with override_settings(API_RATE_LIMIT=_REAL_RATE):
+            importlib.reload(views_module)
         super().tearDownClass()
 
     def setUp(self):


### PR DESCRIPTION
## What

Closes `finsearch-security-hygiene-09` — the last open item from the 2026-06-29 security audit. Eight fixes, each with its own pinning test; full backend suite green in one process (616 passed, 1 skipped — the CI shape).

| Item | Change | Pin |
|---|---|---|
| MCP child env | `os.environ.copy()` → SDK safe base + opt-in `inheritEnv`; secrets no longer reach stdio children | `test_mcp_child_env.py` (incl. real-spawn smoke) |
| gunicorn log | `%(r)s` → `"%(m)s %(U)s %(H)s"` — query strings out of app logs | `test_gunicorn_conf.py` (+ atom-render guard) |
| debug endpoint | `?token=` auth dropped (header-only); route DEBUG-gated → prod 404 | `test_debug_memory_endpoint.py`, `test_debug_route_gating.py` |
| .gitignore | repo-wide dotenv guard + template negations (history audited clean) | `test_gitignore_env.py` |
| Rate limits | 10 un-throttled views decorated (ALL **sentinel**); `clear_messages` POST-only; chat views GET-pinned; `health/` deliberately exempt | `test_endpoint_protection.py` (AST coverage sentinel) |
| Container | `--cap-drop=ALL` + 5 root-init caps + `--pids-limit=1024`, **identical on gate + ExecStart** | 3 new sentinels in `test_dockerfile_nonroot.py` |
| Edge headers | deferred header block: CSP `default-src 'none'`, Referrer-Policy `no-referrer`, Permissions-Policy deny-all, single HSTS | `test_caddyfile_headers.py` + `uptime.yml` live probe |
| Edge log | Caddy access log strips URI query (matches gunicorn redaction) | `test_caddyfile_headers.py` |

## Already live on the droplet (manual op, done before this PR merges)

The Caddyfile change shipped with backup → `caddy validate` → `systemctl reload` and was **positively verified**: CSP/RP/PP present, exactly one HSTS (defer dedupes Django's copy), `referrer-policy: no-referrer` replacing Django's `same-origin`, query-string redaction confirmed in journald, SSE streaming smoke-tested end-to-end. The new uptime.yml header probe therefore goes green immediately on merge.

## Deploy-risk notes

- The **pre-cutover gate runs the identical frozen cap set** and exits after the `setpriv` drop, so all five caps are exercised before cutover — a wrong set aborts with the old container still serving.
- First deploy of this PR is the real-world cap-set test; pre-flight on the droplet verified the runtime mount has no dirs missing owner-exec (the DAC_OVERRIDE hazard) on podman 5.6.2.
- Contract changes shipped as approved: `clear_messages` non-POST → 405 (shipped frontend already POSTs), chat views non-GET → 405, `debug/memory/` 403 → 404 in prod, `?token=` rejected (no caller found repo-wide).
- Fixes a pre-existing cross-suite test leak (`test_ratelimit_enforced` teardown reloaded views under the active 1/m override) that this batch would otherwise have surfaced as CI flakiness.

Deferred by design: read-only rootfs (gate exits before app phase — needs a full-boot check mode first); Tier-3 contract changes (chat GET→POST needs a dual-accept window with extension + Concierge); zero-consumer endpoint deletions (`get_agent_response`, `get_memory_stats`, `add_preferred_url`) — separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)