### PR TITLE
fix(mcp): writable HOME for the runtime user — restores the sec-edgar MCP server

### DIFF
--- a/Main/backend/Dockerfile
+++ b/Main/backend/Dockerfile
@@ -39,7 +39,8 @@ ENV PATH="/app/.venv/bin:$PATH" \
     PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 \
     PIP_NO_CACHE_DIR=1 \
     PIP_DISABLE_PIP_VERSION_CHECK=1 \
-    TRUTHLAYER_DB_PATH=/app/runtime/truthlayer.duckdb
+    TRUTHLAYER_DB_PATH=/app/runtime/truthlayer.duckdb \
+    HOME=/home/fingpt
 
 COPY . .
 
@@ -69,9 +70,18 @@ RUN echo "Verifying Playwright browsers..." && \
 # regenerable DuckDB truth-layer store there BEFORE gunicorn forks; in production it is a
 # persistent bind mount (podman -v ...:/app/runtime:U,Z) so the store survives restarts.
 # Owning these dirs in the image keeps them writable with no mount (compose/CI/bare run).
+# HOME (ENV above) + a real, fingpt-owned home dir are LOAD-BEARING: PID1 starts as
+# root-in-userns, and setpriv drops the uid WITHOUT touching the environment -- so
+# before the ENV pin the app (and every MCP stdio child, which inherits HOME via the
+# SDK's get_default_environment) ran with HOME=/root it could not write. edgartools
+# mkdirs ~/.edgar AT IMPORT, which killed the sec-edgar MCP child with EACCES on every
+# boot from the root-init redesign (Jul 1) until this fix; yfinance's ~/.cache tz store
+# degraded the same way, just non-fatally. --no-create-home stays (system-user idiom);
+# the dir is created explicitly and owned alongside the other writable runtime dirs.
 RUN groupadd --system --gid 1001 fingpt \
     && useradd --system --uid 1001 --gid fingpt --no-create-home fingpt \
-    && chown -R fingpt:fingpt /app/staticfiles /app/media /app/logs /tmp/fingpt_cache /app/runtime
+    && mkdir -p /home/fingpt \
+    && chown -R fingpt:fingpt /app/staticfiles /app/media /app/logs /tmp/fingpt_cache /app/runtime /home/fingpt
 
 ENTRYPOINT ["/app/entrypoint.sh"]
 

--- a/Main/backend/tests/test_dockerfile_nonroot.py
+++ b/Main/backend/tests/test_dockerfile_nonroot.py
@@ -110,6 +110,22 @@ class DockerfileNonRootTests(SimpleTestCase):
         self.assertGreater(chown_idx, verify_idx)
         self.assertLess(chown_idx, entry_idx)
 
+    def test_runtime_user_has_writable_home(self):
+        # setpriv drops the uid but NOT the environment: without the ENV pin the
+        # app and every MCP stdio child inherit PID1's HOME=/root, which uid1001
+        # cannot write. edgartools mkdirs ~/.edgar AT IMPORT, so the sec-edgar
+        # MCP child died with EACCES on every boot from the root-init redesign
+        # until this pin existed. HOME must point at a dir that is created and
+        # fingpt-owned in the image.
+        self.assertIn("HOME=/home/fingpt", self.text)
+        mkdir_lines = [l for l in self.lines if "mkdir -p /home/fingpt" in l]
+        self.assertEqual(
+            len(mkdir_lines), 1,
+            f"expected /home/fingpt created in exactly one line, got {mkdir_lines}",
+        )
+        chown = next(l for l in self.lines if "chown -R fingpt:fingpt" in l)
+        self.assertIn("/home/fingpt", chown)
+
     def test_store_persisted_on_runtime_volume(self):
         # The regenerable DuckDB store must build onto the /app/runtime volume
         # (persisted across restarts) — not the ephemeral image layer — and nothing


### PR DESCRIPTION
## What

Restores the **sec-edgar MCP server**, dead in prod since Jul 1 — and discovered only by the Root-G batch's (#330) live verification pass.

## Root cause

The root-init redesign (#326 era) made PID1 root-in-userns (`HOME=/root`), and `setpriv` drops to uid 1001 **without touching the environment**. The image's `useradd --no-create-home` means uid 1001 has no home at all. Result: the app and every MCP stdio child ran with `HOME=/root` they cannot write. `edgartools` mkdirs `~/.edgar` **at import**, so the sec-edgar child crashed with EACCES (surfacing as "Connection closed") on every boot — silently, because MCP connect failures are caught per-server. yfinance's `~/.cache` tz store degraded the same way, non-fatally.

Journald timeline: last successful sec-edgar connect Jul 1 05:55; failing on every boot from Jul 1 06:09. The previous image (pre-#330, full `os.environ.copy()`) showed the same 3-of-4 connect — the Root-G env allow-list did not cause this, its verification just finally *looked*.

## Fix

Image layer: `ENV HOME=/home/fingpt` + explicitly created, fingpt-owned `/home/fingpt` (added to the existing single chown line — ordering sentinels unaffected). Heals the app process, MCP children (`get_default_environment()` passes HOME through), and `podman exec` sessions alike.

Pinned by `test_runtime_user_has_writable_home`. 25/25 green on the Dockerfile + MCP-child-env suites.

## Post-deploy verification (I'll run it)

`journalctl` must show `Successfully connected to: sec-edgar` and "4 connected servers" / 19+ tools with the EDGAR set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)