### PR TITLE
security(backend): --read-only rootfs + full-boot pre-cutover gate (BOOT_CHECK_ONLY)

### DIFF
--- a/.github/workflows/backend-deploy.yml
+++ b/.github/workflows/backend-deploy.yml
@@ -172,6 +172,10 @@ jobs:
           username: ${{ env.DROPLET_USER }}
           key: ${{ secrets.DEPLOY_SSH_KEY }}
           port: 22
+          # The default 10m is now shared by the multi-GB image pull, the pre-cutover
+          # FULL-boot gate (store build + collectstatic + gunicorn up + /health/ poll,
+          # ~2-3min), cutover, and image retirement -- give it explicit headroom.
+          command_timeout: 20m
           envs: REMOTE_IMAGE,GHCR_USERNAME,GHCR_TOKEN,SYSTEMD_UNIT
           script: |
             set -euo pipefail
@@ -202,28 +206,44 @@ jobs:
               podman start fingpt-redis >/dev/null 2>&1 || true
             fi
 
-            # Pre-cutover firewall validation: run the NEW image's REAL entrypoint in
-            # check-only mode on fingpt-net BEFORE the systemctl restart's --replace kills
-            # the currently-serving container. --egress-check-only exercises the byte-
-            # identical root-init PID1 runs at cutover (generate + sentinel checks + nft
-            # load + transition-proof self-test + setpriv drop), then exits before the app
-            # phase; an inline re-copy of that sequence (this step's previous shape) can
-            # silently drift from the boot path it is supposed to prove. On failure, abort
-            # so the OLD container keeps serving (there is no auto-rollback). This closes
-            # the CI-invisible gap: the test job is pytest-only and never touches nft/netns.
-            # The gate runs under the IDENTICAL frozen cap/pids flags as the ExecStart
-            # below (cap-to-step map at the override; parity pinned in
-            # Main/backend/tests/test_dockerfile_nonroot.py). That parity IS the safety
-            # property: check-only mode exits right after the setpriv drop, so all five
-            # caps the root-init needs (nft + chown + setuid/setgid + bounding-set drop)
-            # are exercised HERE -- a too-narrow set aborts the deploy with the old
-            # container still serving, instead of crash-looping the new unit at cutover.
-            echo "Validating egress firewall on the new image (pre-cutover)..."
-            podman run --rm --cap-drop=ALL --cap-add=NET_ADMIN --cap-add=CHOWN --cap-add=SETUID --cap-add=SETGID --cap-add=SETPCAP --pids-limit=1024 --network fingpt-net \
-              --env REDIS_URL=redis://fingpt-redis:6379/0 \
-              "$REMOTE_IMAGE" --egress-check-only \
-              || { echo "ERROR: egress firewall pre-cutover validation FAILED; aborting deploy (old container left serving)"; exit 1; }
-            echo "Egress firewall pre-cutover validation passed."
+            # Pre-cutover FULL-BOOT validation: run the NEW image's REAL entrypoint on
+            # fingpt-net BEFORE the systemctl restart's --replace kills the currently-
+            # serving container. BOOT_CHECK_ONLY=1 (mode lives at the END of
+            # Main/backend/entrypoint.sh, wrapping the final exec) exercises the byte-
+            # identical PID1 path that runs at cutover: the full root-init (generate +
+            # sentinel checks + nft load + transition-proof self-test + setpriv drop --
+            # so this SUBSUMES the old --egress-check-only gate, which stays in the
+            # entrypoint for manual/local use), then the full app phase (store build,
+            # collectstatic, Playwright verify), then explicit writable-surface probes
+            # over the tmpfs set (these cover the fail-SOFT MCP-child $HOME writes a
+            # /health/ poll can never catch), then backgrounds the image's own CMD and
+            # polls /health/ INSIDE the container until gunicorn answers (hence no
+            # --publish: the gate's :8000 stays netns-private). No positional args
+            # after the image ref, so the Dockerfile CMD flows through byte-identical
+            # (zero-drift property). On failure, abort so the OLD container keeps
+            # serving (there is no auto-rollback). This closes the CI-invisible gap:
+            # the test job is pytest-only and never touches nft/netns/--read-only.
+            # The gate runs the IDENTICAL frozen cap/pids/read-only/tmpfs/memory flags
+            # as the ExecStart below (cap-to-step map + tmpfs map at the override;
+            # parity pinned in Main/backend/tests/test_dockerfile_nonroot.py), with
+            # exactly one deliberate asymmetry: /app/runtime here is a THROWAWAY
+            # tmpfs, never the real /home/deploy/fingpt/runtime bind mount. Mounting
+            # the real dir pre-cutover is dangerous: :U would re-chown it under the
+            # serving container, and a new-recipe store build would os.replace() the
+            # shared DuckDB while the old container still serves it
+            # (truthlayer/retrieve.py). Same isolation for redis: DB15 is a throwaway
+            # keyspace so gate boot-time writes can never touch the serving
+            # container's rate-limit/budget counters in DB0 (only settings_prod.py
+            # and ops/egress_firewall.py consume REDIS_URL, and the firewall
+            # self-test checks host:port reachability only, DB-agnostic).
+            echo "Validating full boot (root-init + read-only rootfs + /health/) on the new image (pre-cutover)..."
+            podman run --rm --cap-drop=ALL --cap-add=NET_ADMIN --cap-add=CHOWN --cap-add=SETUID --cap-add=SETGID --cap-add=SETPCAP --pids-limit=1024 --read-only --tmpfs=/tmp:rw,size=512m,mode=1777 --tmpfs=/app/staticfiles:rw,uid=1001,gid=1001 --tmpfs=/home/fingpt:rw,uid=1001,gid=1001 --tmpfs=/app/runtime:rw,size=512m --memory=1.7g --memory-swap=2g --network fingpt-net \
+              --env-file /home/deploy/fingpt/envs/.env.production \
+              --env REDIS_URL=redis://fingpt-redis:6379/15 \
+              --env BOOT_CHECK_ONLY=1 \
+              "$REMOTE_IMAGE" \
+              || { echo "ERROR: full-boot pre-cutover validation FAILED; aborting deploy (old container left serving)"; exit 1; }
+            echo "Full-boot pre-cutover validation passed."
 
             # Record the currently-deployed image for manual rollback (no auto-rollback).
             PREV_IMAGE=$(podman inspect --format '{{.ImageName}}' "$SYSTEMD_UNIT" 2>/dev/null || echo "unknown")
@@ -260,15 +280,34 @@ jobs:
             # --pids-limit=1024 is the fork-bomb ceiling: worst case today is ~400-600
             # tasks (gunicorn workers x threads + agent fan-out + Playwright/Chromium);
             # revisit if AGENT_MAX_CONCURRENCY or GUNICORN_WORKERS is raised.
-            # A read-only rootfs is DELIBERATELY deferred: the gate exits before the app
-            # phase, so --read-only would ship unvalidated pre-cutover -- and collectstatic
-            # writes /app/staticfiles at boot, which needs a tmpfs/volume design first.
+            # --read-only rootfs: the ONLY writable surfaces are the tmpfs set below,
+            # /dev/shm (podman-managed 64MB tmpfs; gunicorn --worker-tmp-dir, untouched
+            # by --read-only), and the /app/runtime bind mount. The tmpfs map:
+            #   /tmp              Chromium temp profiles + shm redirect
+            #                     (--disable-dev-shm-usage), nft mktemp at root-init,
+            #                     /tmp/fingpt_cache; sized + world-writable-sticky;
+            #   /app/staticfiles  collectstatic writes it at boot (0 files today, kept
+            #                     writable as future-proofing); uid1001 tmpfs;
+            #   /home/fingpt      fontconfig cache, edgartools ~/.edgar import-time
+            #                     marker, yfinance cache; MUST carry uid=1001,gid=1001
+            #                     or the MCP-child EACCES bug (#331 class) returns.
+            # /app/logs and /app/media are vestigial with ZERO writers -- deliberately
+            # NOT tmpfs, so a future stray write fails LOUDLY instead of vanishing
+            # into RAM. Playwright's DEPENDENCIES_VALIDATED marker is pre-baked at
+            # image build (Dockerfile) so first browser launch needs no rootfs write.
+            # The pre-cutover gate above boots the FULL app under these exact flags
+            # (BOOT_CHECK_ONLY=1) before cutover, so a missing/mis-owned tmpfs aborts
+            # the deploy with the old container still serving. Accepted residual: the
+            # gate's /app/runtime is a throwaway tmpfs, so the :U chown / :Z SELinux
+            # relabel path of the REAL bind mount (#322 class) is NOT exercised
+            # pre-cutover; it stays covered only by the post-cutover ~130s health
+            # window in the Verify step below.
             OVERRIDE_DIR="$HOME/.config/systemd/user/${SYSTEMD_UNIT}.service.d"
             mkdir -p "$OVERRIDE_DIR"
             cat > "$OVERRIDE_DIR/override.conf" <<EOF
             [Service]
             ExecStart=
-            ExecStart=/usr/bin/podman run --name ${SYSTEMD_UNIT} --replace --rm --cap-drop=ALL --cap-add=NET_ADMIN --cap-add=CHOWN --cap-add=SETUID --cap-add=SETGID --cap-add=SETPCAP --pids-limit=1024 --cgroups=split --sdnotify=conmon -d --memory=1.7g --memory-swap=2g --network fingpt-net -v /home/deploy/fingpt/runtime:/app/runtime:U,Z --publish 127.0.0.1:8000:8000 --env-file /home/deploy/fingpt/envs/.env.production --env REDIS_URL=redis://fingpt-redis:6379/0 ${REMOTE_IMAGE}
+            ExecStart=/usr/bin/podman run --name ${SYSTEMD_UNIT} --replace --rm --cap-drop=ALL --cap-add=NET_ADMIN --cap-add=CHOWN --cap-add=SETUID --cap-add=SETGID --cap-add=SETPCAP --pids-limit=1024 --read-only --tmpfs=/tmp:rw,size=512m,mode=1777 --tmpfs=/app/staticfiles:rw,uid=1001,gid=1001 --tmpfs=/home/fingpt:rw,uid=1001,gid=1001 --cgroups=split --sdnotify=conmon -d --memory=1.7g --memory-swap=2g --network fingpt-net -v /home/deploy/fingpt/runtime:/app/runtime:U,Z --publish 127.0.0.1:8000:8000 --env-file /home/deploy/fingpt/envs/.env.production --env REDIS_URL=redis://fingpt-redis:6379/0 ${REMOTE_IMAGE}
             EOF
 
             systemctl --user daemon-reload

--- a/Main/backend/Dockerfile
+++ b/Main/backend/Dockerfile
@@ -40,7 +40,8 @@ ENV PATH="/app/.venv/bin:$PATH" \
     PIP_NO_CACHE_DIR=1 \
     PIP_DISABLE_PIP_VERSION_CHECK=1 \
     TRUTHLAYER_DB_PATH=/app/runtime/truthlayer.duckdb \
-    HOME=/home/fingpt
+    HOME=/home/fingpt \
+    PREFERRED_LINKS_PATH=/app/runtime/preferred_links.json
 
 COPY . .
 
@@ -82,6 +83,33 @@ RUN groupadd --system --gid 1001 fingpt \
     && useradd --system --uid 1001 --gid fingpt --no-create-home fingpt \
     && mkdir -p /home/fingpt \
     && chown -R fingpt:fingpt /app/staticfiles /app/media /app/logs /tmp/fingpt_cache /app/runtime /home/fingpt
+
+# Pre-bake Playwright's DEPENDENCIES_VALIDATED marker so the --read-only rootfs
+# (backend-deploy.yml) never needs the write. At FIRST browser launch Playwright
+# validates host requirements (an ldd walk over the browser executable) and caches
+# success by writing a 0-byte DEPENDENCIES_VALIDATED marker next to the executable
+# (driver/package/lib/server/registry/index.js, _validateHostRequirementsForExecutable-
+# IfNeeded). The write itself is fail-SOFT (`.catch(() => {})`), so under --read-only
+# nothing crashes -- but the marker never lands and every fresh process re-runs the
+# validation on its first launch. Bake it organically instead: a real one-time
+# chromium launch as the runtime uid (setpriv, same drop the entrypoint performs;
+# there is deliberately no USER line), i.e. exactly the code path that writes the
+# marker in prod today. /ms-playwright ships world-writable in the Playwright base
+# image, so uid1001 can write it. --no-sandbox/--disable-dev-shm-usage: the docker
+# build environment lacks the userns the Chromium sandbox wants and its /dev/shm is
+# tiny; both flags only shape the spawned browser process, not the dependency
+# validation that writes the marker. The trailing `test -f` fails the BUILD loudly
+# if Playwright ever moves the marker. Residual: the marker's validity window is 30
+# days from its mtime (= image build time); past that, Playwright re-validates once
+# per process and fail-soft skips the re-write -- back to pre-marker behavior,
+# never a crash.
+RUN setpriv --reuid=1001 --regid=1001 --init-groups \
+        python -c "from playwright.sync_api import sync_playwright; \
+p = sync_playwright().start(); \
+b = p.chromium.launch(args=['--no-sandbox', '--disable-dev-shm-usage']); \
+b.close(); p.stop(); print('✓ Chromium one-time launch OK')" \
+    && test -f /ms-playwright/chromium_headless_shell-*/DEPENDENCIES_VALIDATED \
+    && echo "✓ DEPENDENCIES_VALIDATED marker baked"
 
 ENTRYPOINT ["/app/entrypoint.sh"]
 

--- a/Main/backend/datascraper/preferred_links_manager.py
+++ b/Main/backend/datascraper/preferred_links_manager.py
@@ -12,6 +12,16 @@ from threading import Lock
 
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
 
+# In-image/in-repo default storage file. Local dev reads AND writes it directly.
+# In the production container /app/data is root-owned and the rootfs is read-only,
+# so writes there EACCES -> 500 on /api/sync_preferred_urls/ (used by the shipped
+# extension). The prod image therefore pins PREFERRED_LINKS_PATH to
+# /app/runtime/preferred_links.json (Dockerfile ENV; /app/runtime is the writable
+# persistent volume) and this file becomes the read-only SEED the runtime copy is
+# initialized from on first use.
+DEFAULT_STORAGE_PATH = Path(__file__).resolve().parent.parent / 'data' / 'preferred_links.json'
+
+
 class PreferredLinksManager:
     """Manages preferred links with JSON file storage."""
 
@@ -21,13 +31,13 @@ class PreferredLinksManager:
 
         Args:
             storage_path: Path to the JSON storage file.
-                         Defaults to backend/data/preferred_links.json
+                         Defaults to $PREFERRED_LINKS_PATH if set (the prod image
+                         points it at the writable /app/runtime volume), else
+                         backend/data/preferred_links.json (local dev).
         """
         if storage_path is None:
-            backend_dir = Path(__file__).resolve().parent.parent
-            self.storage_path = backend_dir / 'data' / 'preferred_links.json'
-        else:
-            self.storage_path = Path(storage_path)
+            storage_path = os.environ.get('PREFERRED_LINKS_PATH') or DEFAULT_STORAGE_PATH
+        self.storage_path = Path(storage_path)
 
         self.storage_path.parent.mkdir(parents=True, exist_ok=True)
 
@@ -37,7 +47,25 @@ class PreferredLinksManager:
             self._init_storage()
 
     def _init_storage(self):
-        """Initialize the storage file with default structure."""
+        """Initialize the storage file, seeding from the in-image default file.
+
+        When the storage path is redirected off the default (prod: the writable
+        /app/runtime volume) and the runtime copy is missing, seed it from the
+        read-only in-image default file so curated defaults survive the move.
+        Falls back to the hardcoded defaults if the seed is absent or unreadable.
+        """
+        if DEFAULT_STORAGE_PATH.exists() and DEFAULT_STORAGE_PATH != self.storage_path.resolve():
+            try:
+                seed_data = json.loads(DEFAULT_STORAGE_PATH.read_text())
+                self._write_data(seed_data)
+                logging.info(
+                    f"Seeded preferred links storage at {self.storage_path} "
+                    f"from {DEFAULT_STORAGE_PATH}"
+                )
+                return
+            except (json.JSONDecodeError, OSError) as e:
+                logging.error(f"Error seeding preferred links from default file: {e}")
+
         default_links = [
             "https://finance.yahoo.com",
             "https://www.sec.gov/search-filings",

--- a/Main/backend/entrypoint.sh
+++ b/Main/backend/entrypoint.sh
@@ -108,4 +108,57 @@ python -c "from playwright.async_api import async_playwright; print('✓ Playwri
     exit 1
 }
 
+# Deploy pre-cutover FULL-BOOT gate mode (see backend-deploy.yml). By this point the
+# ENTIRE boot has already run under the deploy's exact --read-only/tmpfs/cap flags:
+# root-init (nft load + sentinels + self-test + setpriv drop), the OPENAI key gate,
+# the cache mkdir, the truth-layer store build, collectstatic, and the Playwright
+# verify above -- so this mode SUBSUMES the --egress-check-only gate. It then proves
+# the two things a later /health/ poll alone can never catch:
+#   (a) every writable surface is really writable by uid1001. MCP stdio children
+#       write $HOME fail-SOFT (logger.error in mcp_client/apps.py), so a missing or
+#       root-owned tmpfs there would pass every health check while silently killing
+#       the sec-edgar child -- exactly the EACCES class fixed in #331;
+#   (b) the image's own CMD ("$@", byte-identical: the deploy gate passes no
+#       positional args) comes up and answers /health/ within a bounded window.
+# Placement is load-bearing (pinned by test_dockerfile_nonroot): this branch wraps
+# the final exec, and the fall-through path still ends in exec "$@".
+if [ "${BOOT_CHECK_ONLY:-}" = "1" ]; then
+    echo "Boot check: probing writable surfaces..."
+    for dir in /app/staticfiles /app/runtime "${CACHE_FILE_PATH:-/tmp/fingpt_cache}" "$HOME"; do
+        probe="$dir/.boot-check-probe"
+        ( touch "$probe" && rm -f "$probe" ) 2>/dev/null \
+            || { echo "FATAL: boot check: cannot write $dir (missing/mis-owned tmpfs under --read-only?)" >&2; exit 1; }
+    done
+    echo "Boot check: writable surfaces OK; starting app for /health/ validation..."
+    "$@" &
+    APP_PID=$!
+    HEALTH_OK=0
+    tries=0
+    # ~90s window (30 x 3s; refused connections fail fast), same python-urllib
+    # probe as the Dockerfile HEALTHCHECK.
+    while [ "$tries" -lt 30 ]; do
+        if python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/health/', timeout=5)" 2>/dev/null; then
+            HEALTH_OK=1
+            break
+        fi
+        kill -0 "$APP_PID" 2>/dev/null \
+            || { echo "FATAL: boot check: app exited before /health/ answered" >&2; exit 1; }
+        tries=$((tries + 1))
+        sleep 3
+    done
+    # Bounded shutdown: SIGTERM the app, watchdog hard-SIGKILLs if it hangs, so the
+    # gate can never wedge the deploy past its own window.
+    kill "$APP_PID" 2>/dev/null || true
+    ( sleep 20; kill -9 "$APP_PID" 2>/dev/null ) &
+    WATCHDOG_PID=$!
+    wait "$APP_PID" 2>/dev/null || true
+    kill "$WATCHDOG_PID" 2>/dev/null || true
+    if [ "$HEALTH_OK" = "1" ]; then
+        echo "Boot check: /health/ answered; full boot validated under deploy flags."
+        exit 0
+    fi
+    echo "FATAL: boot check: /health/ did not answer within the ~90s window" >&2
+    exit 1
+fi
+
 exec "$@"

--- a/Main/backend/tests/test_dockerfile_nonroot.py
+++ b/Main/backend/tests/test_dockerfile_nonroot.py
@@ -126,6 +126,27 @@ class DockerfileNonRootTests(SimpleTestCase):
         chown = next(l for l in self.lines if "chown -R fingpt:fingpt" in l)
         self.assertIn("/home/fingpt", chown)
 
+    def test_playwright_dependencies_marker_prebaked_for_read_only_rootfs(self):
+        # Playwright writes a 0-byte DEPENDENCIES_VALIDATED marker next to the
+        # browser executable at FIRST launch (host-requirements validation cache).
+        # Under the deploy's --read-only rootfs that write fails -- fail-SOFT in
+        # the playwright driver, but then EVERY fresh process re-validates on its
+        # first launch. The image must bake the marker organically: a REAL one-time
+        # chromium launch (never a bare touch, which would skip the validation the
+        # marker attests) as the runtime uid via setpriv (no USER line exists,
+        # root-init-drop), with a loud `test -f` so the build fails if Playwright
+        # ever moves the marker.
+        folded = re.sub(r"\\\n\s*", " ", self.text)
+        bake = [l for l in folded.splitlines()
+                if l.startswith("RUN ") and "DEPENDENCIES_VALIDATED" in l]
+        self.assertEqual(len(bake), 1, f"expected one marker-bake RUN, got {bake}")
+        self.assertIn("setpriv --reuid=1001 --regid=1001", bake[0])
+        self.assertIn("chromium.launch", bake[0])
+        self.assertIn(
+            "test -f /ms-playwright/chromium_headless_shell-*/DEPENDENCIES_VALIDATED",
+            bake[0],
+        )
+
     def test_store_persisted_on_runtime_volume(self):
         # The regenerable DuckDB store must build onto the /app/runtime volume
         # (persisted across restarts) — not the ephemeral image layer — and nothing
@@ -165,19 +186,27 @@ class DeployUserNamespaceTests(SimpleTestCase):
         caps = data["services"]["api"].get("cap_add", [])
         self.assertIn("NET_ADMIN", caps)
 
-    def test_precutover_gate_runs_real_entrypoint_check_only(self):
+    def test_precutover_gate_runs_real_entrypoint_full_boot(self):
         # The deploy's pre-cutover gate must exercise the image's REAL entrypoint via
-        # --egress-check-only, not an inline re-copy of the root-init sequence: a
-        # hand-copied gate can silently drift from what PID1 actually runs at cutover
-        # (the previous inline copy had already dropped the [ -s ] and grep-sentinel
-        # guards). No --entrypoint override may bypass it anywhere in the deploy.
+        # BOOT_CHECK_ONLY=1, not an inline re-copy of the boot sequence: a hand-copied
+        # gate can silently drift from what PID1 actually runs at cutover. No
+        # --entrypoint override may bypass it anywhere in the deploy, and the gate
+        # passes NO positional args after the image ref -- the Dockerfile CMD flows
+        # through byte-identical (zero-drift property; the entrypoint backgrounds
+        # "$@" rather than hardcoding gunicorn).
         wf = _read(DEPLOY_WORKFLOW)
-        self.assertIn("--egress-check-only", wf)
         self.assertNotIn("--entrypoint", wf)
-        # Placement in entrypoint.sh is load-bearing: the check-only exit must come
-        # AFTER the setpriv drop (above the root-init block it would exit 0 with NO
-        # firewall loaded -- a vacuous gate) and BEFORE the app phase's heavy store
-        # build (so the gate stays fast and dependency-free).
+        gate = self._gate_line()
+        self.assertIn("--env BOOT_CHECK_ONLY=1", gate)
+        tail = gate.split('"$REMOTE_IMAGE"', 1)[1].strip()
+        self.assertTrue(
+            tail == "" or tail.startswith("||"),
+            f"gate must end at the image ref (no positional args), got tail {tail!r}",
+        )
+        # Placement in entrypoint.sh is load-bearing. The retained manual/local
+        # --egress-check-only branch: AFTER the setpriv drop (above the root-init
+        # block it would exit 0 with NO firewall loaded -- a vacuous gate) and
+        # BEFORE the app phase's heavy store build (fast and dependency-free).
         entry_lines = _read(ENTRYPOINT_SH).splitlines()
         flag_idx = next(i for i, l in enumerate(entry_lines)
                         if "--egress-check-only" in l and l.lstrip().startswith("if "))
@@ -186,6 +215,17 @@ class DeployUserNamespaceTests(SimpleTestCase):
         store_idx = next(i for i, l in enumerate(entry_lines) if "_ensure_built" in l)
         self.assertGreater(flag_idx, setpriv_idx)
         self.assertLess(flag_idx, store_idx)
+        # The boot-check branch: AFTER the Playwright verify block (so the FULL boot
+        # has run under the gate's flags) and wrapping the final exec -- the
+        # fall-through path must still end in a bare exec "$@".
+        boot_idx = next(i for i, l in enumerate(entry_lines)
+                        if "BOOT_CHECK_ONLY" in l and l.lstrip().startswith("if "))
+        playwright_idx = next(i for i, l in enumerate(entry_lines)
+                              if "Verifying Playwright runtime" in l)
+        self.assertGreater(boot_idx, playwright_idx)
+        logical = [l.strip() for l in entry_lines
+                   if l.strip() and not l.strip().startswith("#")]
+        self.assertEqual(logical[-1], 'exec "$@"')
 
     def test_image_retirement_keeps_new_and_rollback_target_only(self):
         # Deploys pull by DIGEST, so superseded images keep a repo@sha256 name, are
@@ -307,13 +347,21 @@ class DeployUserNamespaceTests(SimpleTestCase):
 
     def _gate_line(self):
         lines = [l for l in self._joined_deploy_lines()
-                 if "podman run" in l and "--egress-check-only" in l]
+                 if "podman run" in l and "BOOT_CHECK_ONLY=1" in l]
         self.assertEqual(len(lines), 1, f"expected one gate podman run, got {lines}")
         return lines[0]
 
     @staticmethod
     def _cap_pids_flags(line):
-        return sorted(re.findall(r"--(?:cap-add|cap-drop|pids-limit)=\S+", line))
+        # The frozen-flag extractor: valued flags are pinned in their equals-form
+        # spelling (--tmpfs=..., --memory=...) on BOTH podman run lines, so the
+        # space-form (--tmpfs /tmp) would extract nothing and red the parity test
+        # rather than silently passing; --read-only is valueless.
+        return sorted(re.findall(
+            r"--(?:cap-add|cap-drop|pids-limit|tmpfs|memory|memory-swap)=\S+"
+            r"|--read-only\b",
+            line,
+        ))
 
     def test_execstart_cap_set_is_frozen(self):
         # assertEqual on the FULL extracted cap list, not assertIn per cap: a sixth
@@ -335,14 +383,126 @@ class DeployUserNamespaceTests(SimpleTestCase):
         # the flag, which removes the ceiling entirely.
         self.assertIn("--pids-limit=1024", self._execstart_line())
 
-    def test_gate_and_execstart_cap_pids_parity(self):
+    def test_gate_and_execstart_flag_parity(self):
         # The safety property of the frozen set: the pre-cutover gate must run the
-        # IDENTICAL cap/pids flags as the ExecStart it fronts, so all five caps are
-        # exercised end-to-end (nft + chown + setpriv + bounding-set drop) BEFORE
-        # cutover and a too-narrow set aborts the deploy with the old container
-        # still serving, instead of crash-looping the unit. Either line edited
-        # alone -- gate widened for a quick fix, or ExecStart narrowed without
-        # re-proving the gate -- must red here.
+        # IDENTICAL cap/pids/read-only/tmpfs/memory flags as the ExecStart it
+        # fronts, so everything -- all five caps (nft + chown + setpriv +
+        # bounding-set drop), the read-only rootfs, and every tmpfs the boot needs
+        # to write -- is exercised end-to-end BEFORE cutover, and a too-narrow set
+        # aborts the deploy with the old container still serving, instead of
+        # crash-looping the unit. Either line edited alone -- gate widened for a
+        # quick fix, or ExecStart narrowed without re-proving the gate -- must red
+        # here. Exactly ONE deliberate asymmetry is carved out: the gate's
+        # throwaway --tmpfs=/app/runtime (the ExecStart uses the real bind mount;
+        # see test_gate_and_execstart_deliberate_asymmetries).
         gate = self._cap_pids_flags(self._gate_line())
-        self.assertEqual(gate, self._cap_pids_flags(self._execstart_line()))
-        self.assertTrue(gate, "no cap/pids flags found on the gate podman run")
+        runtime_tmpfs = [f for f in gate if f.startswith("--tmpfs=/app/runtime")]
+        self.assertEqual(
+            len(runtime_tmpfs), 1,
+            f"expected exactly one gate-only /app/runtime tmpfs, got {runtime_tmpfs}",
+        )
+        shared = [f for f in gate if f not in runtime_tmpfs]
+        self.assertEqual(shared, self._cap_pids_flags(self._execstart_line()))
+        self.assertTrue(shared, "no frozen flags found on the gate podman run")
+
+    def test_gate_and_execstart_deliberate_asymmetries(self):
+        # The complete, closed list of ways the gate may differ from ExecStart.
+        gate = self._gate_line()
+        execstart = self._execstart_line()
+        # 1. Runtime store: ExecStart mounts the REAL persistent dir (:U chown +
+        #    :Z SELinux relabel); the gate must use a THROWAWAY tmpfs and never
+        #    reference the real dir -- pre-cutover, :U would re-chown it under the
+        #    serving container and a new-recipe store build would os.replace() the
+        #    shared DuckDB while the old container serves it (truthlayer/retrieve.py).
+        self.assertIn("-v /home/deploy/fingpt/runtime:/app/runtime:U,Z", execstart)
+        self.assertIn("--tmpfs=/app/runtime", gate)
+        self.assertNotIn("/home/deploy/fingpt/runtime", gate)
+        # 2. Redis keyspace: the gate boots the full app, whose boot-time writes
+        #    must land in the throwaway DB15 -- never the serving container's
+        #    rate-limit/budget counters in DB0.
+        self.assertIn("--env REDIS_URL=redis://fingpt-redis:6379/15", gate)
+        self.assertNotIn("6379/0", gate)
+        self.assertIn("--env REDIS_URL=redis://fingpt-redis:6379/0", execstart)
+        # 3. No --publish on the gate: its :8000 stays netns-private (the health
+        #    poll runs INSIDE the container); publishing would collide with the
+        #    still-serving container's loopback bind and race the cutover.
+        self.assertNotIn("--publish", gate)
+        self.assertIn("--publish 127.0.0.1:8000:8000", execstart)
+        # Both lines carry the read-only rootfs and identical memory caps (also
+        # frozen by the parity test; asserted directly here to document intent).
+        for line in (gate, execstart):
+            self.assertIn("--read-only", line)
+            self.assertIn("--memory=1.7g", line)
+            self.assertIn("--memory-swap=2g", line)
+
+    # Frozen tmpfs target set shared by the gate and ExecStart. /tmp (Chromium temp
+    # profiles + shm redirect + nft mktemp + fingpt_cache), /app/staticfiles
+    # (collectstatic at boot), /home/fingpt (fontconfig + ~/.edgar + yfinance; must
+    # be uid1001-owned or the MCP-child EACCES bug returns). /app/logs and
+    # /app/media are vestigial with ZERO writers and are deliberately ABSENT: under
+    # --read-only a future stray write must fail LOUDLY, not vanish into RAM.
+    SHARED_TMPFS_TARGETS = sorted(["/tmp", "/app/staticfiles", "/home/fingpt"])
+
+    @staticmethod
+    def _tmpfs_targets(line):
+        return sorted(m.split(":", 1)[0] for m in re.findall(r"--tmpfs=(\S+)", line))
+
+    def test_tmpfs_target_sets_frozen(self):
+        # assertEqual on the FULL target set per line, not assertIn per target: a
+        # new tmpfs quietly appended to either line (e.g. papering over a stray
+        # write instead of fixing it) must red this test.
+        self.assertEqual(
+            self._tmpfs_targets(self._execstart_line()), self.SHARED_TMPFS_TARGETS
+        )
+        self.assertEqual(
+            self._tmpfs_targets(self._gate_line()),
+            sorted(self.SHARED_TMPFS_TARGETS + ["/app/runtime"]),
+        )
+
+    def test_tmpfs_options_pinned(self):
+        # /tmp must be sized (unbounded tmpfs is a memory-DoS surface) and
+        # world-writable-sticky (1777: Chromium/nft/cache all write it as
+        # uid1001); the uid1001 dirs must carry uid=1001,gid=1001 -- a bare tmpfs
+        # mounts root-owned and resurrects the EACCES class documented at the
+        # Dockerfile HOME comment.
+        for line in (self._execstart_line(), self._gate_line()):
+            self.assertIn("--tmpfs=/tmp:rw,size=512m,mode=1777", line)
+            self.assertIn("--tmpfs=/app/staticfiles:rw,uid=1001,gid=1001", line)
+            self.assertIn("--tmpfs=/home/fingpt:rw,uid=1001,gid=1001", line)
+        self.assertIn("--tmpfs=/app/runtime:rw,size=512m", self._gate_line())
+
+    def test_execstart_read_only_rootfs(self):
+        # The rootfs hardening itself, asserted directly on the serving line (the
+        # parity test would also catch it, but this documents the intent): a
+        # compromised app process cannot write outside the tmpfs set, /dev/shm,
+        # and the /app/runtime mount.
+        self.assertIn("--read-only", self._execstart_line())
+
+    def test_entrypoint_boot_check_branch_structure(self):
+        # Structural sentinel for the BOOT_CHECK_ONLY branch in entrypoint.sh: it
+        # must probe EVERY writable surface (the fail-SOFT MCP-child $HOME writes
+        # can never fail a /health/ poll -- mcp_client/apps.py logger.errors and
+        # serves on), background the image's own CMD (never a hardcoded gunicorn),
+        # poll the same /health/ endpoint as the Dockerfile HEALTHCHECK, and kill
+        # the backgrounded app under a hard deadline so the gate can never wedge
+        # the deploy.
+        lines = _read(ENTRYPOINT_SH).splitlines()
+        start = next(i for i, l in enumerate(lines)
+                     if "BOOT_CHECK_ONLY" in l and l.lstrip().startswith("if "))
+        end = next(i for i in range(start + 1, len(lines)) if lines[i] == "fi")
+        block = "\n".join(lines[start:end + 1])
+        # (a) writable-surface probes, one per surface, plus $HOME.
+        for surface in ("/app/staticfiles", "/app/runtime",
+                        '${CACHE_FILE_PATH:-/tmp/fingpt_cache}', '"$HOME"'):
+            self.assertIn(surface, block, f"boot check must probe {surface}")
+        self.assertIn("touch", block)
+        # (b) backgrounds the real CMD -- "$@", not a re-spelled command line.
+        self.assertIn('"$@" &', block)
+        self.assertNotIn("gunicorn", block)
+        # (c) polls /health/ with the same python-urllib probe as the HEALTHCHECK.
+        self.assertIn("urllib.request.urlopen", block)
+        self.assertIn("/health/", block)
+        # (d) bounded kill: SIGTERM plus a watchdog hard-SIGKILL, then wait.
+        self.assertIn('kill "$APP_PID"', block)
+        self.assertIn('kill -9 "$APP_PID"', block)
+        self.assertIn('wait "$APP_PID"', block)

--- a/Main/backend/tests/test_preferred_links_manager.py
+++ b/Main/backend/tests/test_preferred_links_manager.py
@@ -78,7 +78,10 @@ def test_seed_falls_back_to_hardcoded_defaults_when_default_file_absent(
     manager = PreferredLinksManager(storage_path=str(target))
     links = manager.get_links()
     assert links, "hardcoded defaults expected"
-    assert "https://finance.yahoo.com" in links
+    # Exact-match membership (not a substring/URL check): keeps CodeQL's
+    # py/incomplete-url-substring-sanitization heuristic from misfiring on a
+    # `"<url>" in <list>` that is really list membership, and states intent.
+    assert any(link == "https://finance.yahoo.com" for link in links)
 
 
 def test_writes_land_on_the_configured_path(monkeypatch, tmp_path):

--- a/Main/backend/tests/test_preferred_links_manager.py
+++ b/Main/backend/tests/test_preferred_links_manager.py
@@ -1,0 +1,102 @@
+"""PreferredLinksManager storage-path + seeding guards (read-only rootfs).
+
+The sync_preferred_urls endpoint (used by the shipped extension) writes through
+this manager. Its historical default path, backend/data/preferred_links.json,
+lives under root-owned /app/data in the production image, so the write EACCESed
+into a 500 long before the rootfs went --read-only. The fix: the storage path is
+env-configurable (PREFERRED_LINKS_PATH), the prod image pins it onto the writable
+/app/runtime volume (Dockerfile ENV), and a missing runtime copy is seeded from
+the read-only in-image default file so curated defaults survive the move. Local
+dev keeps the old in-repo path (env unset).
+"""
+import json
+import os
+
+from datascraper import preferred_links_manager as plm
+from datascraper.preferred_links_manager import (
+    DEFAULT_STORAGE_PATH,
+    PreferredLinksManager,
+)
+
+DOCKERFILE = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "Dockerfile")
+
+
+def test_default_path_used_when_env_unset(monkeypatch):
+    monkeypatch.delenv("PREFERRED_LINKS_PATH", raising=False)
+    manager = PreferredLinksManager()
+    assert manager.storage_path == DEFAULT_STORAGE_PATH
+
+
+def test_env_var_overrides_storage_path(monkeypatch, tmp_path):
+    target = tmp_path / "runtime" / "preferred_links.json"
+    monkeypatch.setenv("PREFERRED_LINKS_PATH", str(target))
+    manager = PreferredLinksManager()
+    assert manager.storage_path == target
+    assert target.exists()
+
+
+def test_explicit_arg_beats_env(monkeypatch, tmp_path):
+    monkeypatch.setenv("PREFERRED_LINKS_PATH", str(tmp_path / "from-env.json"))
+    explicit = tmp_path / "explicit.json"
+    manager = PreferredLinksManager(storage_path=str(explicit))
+    assert manager.storage_path == explicit
+
+
+def test_missing_runtime_copy_seeded_from_in_image_default(monkeypatch, tmp_path):
+    # The prod-shaped move: env points at an (empty) runtime volume; the first
+    # manager construction must seed the runtime copy from the in-image default
+    # file VERBATIM -- the curated defaults (data/preferred_links.json) are richer
+    # than the hardcoded fallback list.
+    target = tmp_path / "preferred_links.json"
+    monkeypatch.setenv("PREFERRED_LINKS_PATH", str(target))
+    manager = PreferredLinksManager()
+    seeded = json.loads(target.read_text())
+    assert seeded == json.loads(DEFAULT_STORAGE_PATH.read_text())
+    assert manager.get_links() == seeded["preferred_links"]
+
+
+def test_existing_runtime_copy_never_overwritten_by_seed(monkeypatch, tmp_path):
+    target = tmp_path / "preferred_links.json"
+    existing = {
+        "version": "1.0",
+        "preferred_links": ["https://example.com/user-curated"],
+        "metadata": {"last_updated": None, "total_links": 1},
+    }
+    target.write_text(json.dumps(existing))
+    monkeypatch.setenv("PREFERRED_LINKS_PATH", str(target))
+    manager = PreferredLinksManager()
+    assert manager.get_links() == ["https://example.com/user-curated"]
+
+
+def test_seed_falls_back_to_hardcoded_defaults_when_default_file_absent(
+    monkeypatch, tmp_path
+):
+    # Defense in depth: a checkout/image without data/preferred_links.json must
+    # still initialize (hardcoded defaults), not crash the first request.
+    monkeypatch.setattr(plm, "DEFAULT_STORAGE_PATH", tmp_path / "absent.json")
+    target = tmp_path / "preferred_links.json"
+    manager = PreferredLinksManager(storage_path=str(target))
+    links = manager.get_links()
+    assert links, "hardcoded defaults expected"
+    assert "https://finance.yahoo.com" in links
+
+
+def test_writes_land_on_the_configured_path(monkeypatch, tmp_path):
+    # The actual prod failure mode: sync writes must hit the configured (writable)
+    # path -- and only it.
+    target = tmp_path / "preferred_links.json"
+    monkeypatch.setenv("PREFERRED_LINKS_PATH", str(target))
+    manager = PreferredLinksManager()
+    manager.set_links(["https://reuters.com", "https://reuters.com", "https://ft.com"])
+    stored = json.loads(target.read_text())
+    assert stored["preferred_links"] == ["https://reuters.com", "https://ft.com"]  # deduped
+    assert stored["metadata"]["total_links"] == 2
+
+
+def test_dockerfile_pins_preferred_links_onto_runtime_volume():
+    # The image must point the manager at the writable persistent volume; without
+    # this pin the default path lands under root-owned /app/data on a --read-only
+    # rootfs and every extension sync 500s again.
+    with open(DOCKERFILE, "r", encoding="utf-8") as fh:
+        text = fh.read()
+    assert "PREFERRED_LINKS_PATH=/app/runtime/preferred_links.json" in text


### PR DESCRIPTION
## Read-only rootfs for the backend container + full-boot pre-cutover gate

**Deploy order:** independent of the others — but it is the **riskiest deploy** in the batch (touches the deploy pipeline; there is no auto-rollback). Its first deploy is the real-world test of both the new gate and the read-only posture. Recommend deploying when you can watch it.

### Why
Closes the deferred `--read-only` rootfs item recorded at `backend-deploy.yml:263-265`. Under `--read-only` the only writable surfaces become a tightly-scoped tmpfs set plus the existing `/app/runtime` bind mount, so a compromised agent cannot persist to the image filesystem.

### What
- **`--read-only` on ExecStart** with tmpfs for exactly the paths that are written at boot/runtime, verified against both static analysis and the live prod container:
  - `/tmp` (Chromium temp profiles + `--disable-dev-shm-usage` redirect + nft `mktemp` + `/tmp/fingpt_cache`), sized + `mode=1777`
  - `/app/staticfiles` (collectstatic; 0 files today, kept writable as future-proofing), `uid=1001`
  - `/home/fingpt` (fontconfig, edgartools `~/.edgar`, yfinance cache) — **`uid=1001,gid=1001` or the #331-class MCP-child EACCES returns**
  - `/app/logs` + `/app/media` are vestigial (zero writers) → **deliberately not tmpfs**, so a future stray write fails loudly.
- **`BOOT_CHECK_ONLY=1` full-boot gate** (end of `entrypoint.sh`): subsumes the old `--egress-check-only` gate (full root-init still runs first), then probes every writable surface + `$HOME` (covers the fail-soft MCP-child writes a `/health/` poll can't catch), backgrounds the byte-identical CMD, polls `/health/` in a bounded ~90s window, and SIGTERM+SIGKILL-watchdogs the app so the gate can never wedge the deploy. Gate runs the **identical** cap/pids/read-only/tmpfs/memory flags as ExecStart, with exactly one deliberate asymmetry: gate's `/app/runtime` is a throwaway tmpfs (never the real bind mount — mounting it pre-cutover would `:U`-rechown and cross-version-`os.replace()` the store under the serving container) and Redis DB15 (throwaway keyspace, never touches DB0 counters).
- **Playwright `DEPENDENCIES_VALIDATED` marker pre-baked** via a real one-time `setpriv` uid-1001 chromium launch at image build (`test -f` fails the build loudly if the marker moves) — so first browser launch needs no rootfs write.
- **Preferred-links storage relocated** to `PREFERRED_LINKS_PATH=/app/runtime/preferred_links.json`, seeded from the in-image default on first use. This also **fixes a pre-existing prod 500**: `/app/data` has been root-owned since the Jul-1 root-init redesign, so `sync_preferred_urls` (used by the extension) already EACCESed today.
- `command_timeout: 20m` on the deploy step (pull + full-boot gate + cutover + retirement now share it).

### Verification
- **Full backend suite: 632 passed, 1 skipped**; targeted deploy/preferred-links: 33 passed. `bash -n entrypoint.sh` clean.
- **Mutation-tested the sentinels** (the codebase's "silent no-op" lesson): stripping `--read-only` from ExecStart fails `test_execstart_read_only_rootfs`, `test_gate_and_execstart_deliberate_asymmetries`, and `test_gate_and_execstart_flag_parity`. The parity guards are real, not theater.

### Accepted residual
- The gate's throwaway `/app/runtime` tmpfs does **not** exercise the `:U` chown / `:Z` SELinux relabel path of the real bind mount (#322 class) — that stays covered only by the post-cutover ~130s health window. Documented at the ExecStart comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
