### PR TITLE
feat(concierge): switch chat-stream call from GET to POST JSON body

### DIFF
--- a/Concierge/README.md
+++ b/Concierge/README.md
@@ -2,7 +2,8 @@
 
 Interactive sibling of the News Heartbeat. A persistent `discord.py` Gateway service
 that maps free-form @mention/DM messages onto the **existing** FinSearch extension
-pipeline (`/get_chat_response_stream/`) and posts replies back. Backend is unchanged.
+pipeline (`POST /get_chat_response_stream/`, JSON body, SSE response) and posts replies
+back. Backend is unchanged.
 
 See `Docs/superpowers/specs/2026-06-28-discord-chat-adapter-design.md`.
 
@@ -58,7 +59,8 @@ processes against it.
 
 ### 2. Configure & run
 Follow **Run locally** above. `FINSEARCH_API_BASE` must be reachable from wherever
-Concierge runs (it streams from the backend's `/get_chat_response_stream/`). On the
+Concierge runs (it streams SSE from a `POST` to the backend's
+`/get_chat_response_stream/`, request params in a flat JSON body). On the
 droplet the backend is co-located, so the default `http://localhost:8000` works; from a
 laptop, point it at a tunnel (e.g. `ssh -L 8000:localhost:8000 finsearch-deploy`).
 
@@ -76,5 +78,6 @@ Beyond the happy path in **Live smoke (manual)** above:
 ### 4. Refresh the SSE fixture (optional)
 `tests/fixtures/sse_chat_stream.txt` is the recorded byte stream the client tests replay.
 To re-capture from a live backend (e.g. after a backend frame-format change), save the raw
-`/get_chat_response_stream/` response body verbatim — including `event:`/`data:` lines and
-the terminal `{"done": true, ...}` frame — over that file, then re-run `pytest -q`.
+response body of a `POST /get_chat_response_stream/` (JSON body, same keys the client
+sends) verbatim — including `event:`/`data:` lines and the terminal `{"done": true, ...}`
+frame — over that file, then re-run `pytest -q`.

--- a/Concierge/concierge/finsearch_client.py
+++ b/Concierge/concierge/finsearch_client.py
@@ -4,7 +4,6 @@ import json
 import re
 from dataclasses import dataclass
 from typing import AsyncIterator, Iterable, Iterator, Optional, Union
-from urllib.parse import urlencode
 
 import aiohttp
 from aiohttp.http_exceptions import LineTooLong
@@ -152,13 +151,17 @@ class FinSearchClient:
     async def stream_chat(self, *, question: str, session_id: str,
                           user_timezone: str, user_time: str
                           ) -> AsyncIterator[Union[ChatChunk, ChatResult]]:
-        params = {
+        # Frozen POST contract: same path, NO query string. Every request parameter travels
+        # in a flat JSON body with ALL values as strings. The backend dual-accepts GET and
+        # POST during the migration window, with a JSON-body value winning over any same-key
+        # query-string value; the SSE response is byte-identical to the old GET's.
+        payload = {
             "question": question, "session_id": session_id, "models": self._model,
             "is_advanced": "false", "use_memory": "true",
             "current_url": "https://discord.com",
             "user_timezone": user_timezone, "user_time": user_time,
         }
-        url = f"{self._base}/get_chat_response_stream/?{urlencode(params)}"
+        url = f"{self._base}/get_chat_response_stream/"
         session = await self._ensure_session()
         acc, done, final = [], False, {}
         try:
@@ -166,8 +169,8 @@ class FinSearchClient:
             # 3xx here means the backend is misrouting this client. Following it (e.g. http->https on
             # a plain-HTTP port) strands us in a ~60s TLS handshake before it aborts — refuse it and
             # fail fast into the friendly error instead.
-            async with session.get(url, allow_redirects=False,
-                                   headers=self._cookie_header(session_id) or None) as resp:
+            async with session.post(url, json=payload, allow_redirects=False,
+                                    headers=self._cookie_header(session_id) or None) as resp:
                 # Capture the conversation root cookie as soon as headers arrive (before the
                 # body streams), so we still remember it even if the stream later drops.
                 self._remember_cookie(session_id, resp)

--- a/Concierge/tests/test_finsearch_client.py
+++ b/Concierge/tests/test_finsearch_client.py
@@ -91,15 +91,21 @@ class _FakeResp:
     def raise_for_status(self): pass
 
 
-class _FakeGetCtx:
+class _FakeReqCtx:
     def __init__(self, resp): self._resp = resp
     async def __aenter__(self): return self._resp
     async def __aexit__(self, *a): return False
 
 
 class _FakeSession:
-    def __init__(self, resp): self._resp = resp; self.closed = False
-    def get(self, url, **kwargs): return _FakeGetCtx(self._resp)
+    """Implements ONLY .post (the frozen contract's method) and records every call, so a
+    regression back to session.get() fails loudly with AttributeError."""
+    def __init__(self, resp):
+        self._resp = resp; self.closed = False
+        self.calls = []            # (url, kwargs) per request; kwargs["json"] is the body
+    def post(self, url, **kwargs):
+        self.calls.append((url, kwargs))
+        return _FakeReqCtx(self._resp)
     async def close(self): self.closed = True
 
 
@@ -112,6 +118,28 @@ def _client_with(content):
 async def _drain(client):
     return [item async for item in client.stream_chat(
         question="q", session_id="discord:1:1", user_timezone="UTC", user_time="t")]
+
+
+@pytest.mark.asyncio
+async def test_stream_chat_posts_json_body_to_bare_path():
+    # Frozen POST contract: POST to the same path with NO query string; every request
+    # parameter travels in a flat JSON body, ALL values strings (aiohttp's json= kwarg sets
+    # Content-Type: application/json); redirects are still refused, never followed.
+    client = _client_with(_FakeContent([b'data: {"done": true}\n']))
+    await _drain(client)
+    assert len(client._session.calls) == 1
+    url, kwargs = client._session.calls[0]
+    assert url == "http://x/get_chat_response_stream/"
+    assert "?" not in url                       # URL carries NO query params
+    assert kwargs["allow_redirects"] is False
+    body = kwargs["json"]
+    assert body == {
+        "question": "q", "session_id": "discord:1:1", "models": "m",
+        "is_advanced": "false", "use_memory": "true",
+        "current_url": "https://discord.com",
+        "user_timezone": "UTC", "user_time": "t",
+    }
+    assert all(isinstance(v, str) for v in body.values())
 
 
 @pytest.mark.asyncio
@@ -224,15 +252,15 @@ class _RecordingResp:
 
 
 class _RecordingSession:
-    """Records the headers of every .get() and replays one queued response per call, so a
+    """Records the headers of every .post() and replays one queued response per call, so a
     test can assert exactly what Cookie header the client sent on each request."""
     def __init__(self, responses):
         self._responses = list(responses)
         self.sent_headers = []
         self.closed = False
-    def get(self, url, **kwargs):
+    def post(self, url, **kwargs):
         self.sent_headers.append(kwargs.get("headers") or {})
-        return _FakeGetCtx(self._responses.pop(0))
+        return _FakeReqCtx(self._responses.pop(0))
     async def close(self): self.closed = True
 
 


### PR DESCRIPTION
## Concierge: migrate chat-stream call from GET to POST JSON body

> ⚠️ **MERGE ORDER: requires the backend dual-accept PR #332 (`security/tier3-dual-accept`) to be DEPLOYED first.** Concierge auto-deploys on merge to `main`; if merged before the backend accepts POST, the bot's stream call hits a GET-only endpoint and 405s in production.

### What
`stream_chat` switches `session.get(url?querystring)` → `session.post(url, json=payload)` per the frozen POST contract: every parameter now travels in a flat JSON body (all string values), the URL carries no query string. `allow_redirects=False` (the ~60s-TLS-handshake guard) and the conversation-cookie header are preserved; the SSE response is byte-identical, so the aiohttp line-parsing side is unchanged.

### Verification
- **Concierge suite: 78 passed.** `_FakeSession` gained a `.post` capturing the JSON body; assertions pin the new contract (method, no query string, body keys/values). Redirect handling, SSE parsing, and error paths retested.
- Contract cross-checked against the backend and extension: the keys the backend reads match; Concierge's `is_advanced`/`use_memory` keys are ignored by the backend exactly as they were over GET.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
