### PR TITLE
feat(extension): migrate chat endpoints to POST fetch-streaming (v0.16.0)

### DIFF
--- a/Main/frontend/bun.lock
+++ b/Main/frontend/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "extension-chatbot-fin",
       "dependencies": {
-        "dompurify": "3.2.7",
+        "dompurify": "3.4.11",
         "katex": "^0.16.10",
         "markdown-it": "^14.1.0",
         "markdown-it-texmath": "^1.0.0",
@@ -322,7 +322,7 @@
 
     "debug": ["debug@4.4.0", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA=="],
 
-    "dompurify": ["dompurify@3.2.7", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw=="],
+    "dompurify": ["dompurify@3.4.11", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw=="],
 
     "electron-to-chromium": ["electron-to-chromium@1.5.150", "", {}, "sha512-rOOkP2ZUMx1yL4fCxXQKDHQ8ZXwisb2OycOQVKHgvB3ZI4CvehOd4y2tfnnLDieJ3Zs1RL1Dlp3cMkyIn7nnXA=="],
 

--- a/Main/frontend/package.json
+++ b/Main/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "extension-chatbot-fin",
-  "version": "0.15.2",
+  "version": "0.16.0",
   "description": "",
   "main": "src/main.js",
   "scripts": {
@@ -15,7 +15,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "dompurify": "3.4.11",
+    "dompurify": "3.2.7",
     "katex": "^0.16.10",
     "markdown-it": "^14.1.0",
     "markdown-it-texmath": "^1.0.0",

--- a/Main/frontend/package.json
+++ b/Main/frontend/package.json
@@ -15,7 +15,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "dompurify": "3.2.7",
+    "dompurify": "3.4.11",
     "katex": "^0.16.10",
     "markdown-it": "^14.1.0",
     "markdown-it-texmath": "^1.0.0",

--- a/Main/frontend/src/manifest.json
+++ b/Main/frontend/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Agentic FinSearch",
-  "version": "0.15.2",
+  "version": "0.16.0",
   "description": "Agentic FinSearch companion extension. Defaults to the hosted backend at agenticfinsearch.org, with optional local backend support.",
   "icons": {
     "16": "assets/16x16_icon.png",

--- a/Main/frontend/src/modules/api.js
+++ b/Main/frontend/src/modules/api.js
@@ -1,6 +1,7 @@
 // api.js
 
 import { buildBackendUrl } from './backendConfig.js';
+import { createSSEParser } from './sse.js';
 
 // Session ID management
 let currentSessionId = sessionStorage.getItem('fingpt_session_id');
@@ -54,48 +55,58 @@ function getUserTimeInfo() {
     };
 }
 
-// Function to get chat response from server (now supports MCP mode)
-function getChatResponse(question, selectedModel, promptMode, useRAG, useMCP) {
-    const encodedQuestion = encodeURIComponent(question);
-    const currentUrl = window.location.href;
-    const encodedCurrentUrl = encodeURIComponent(currentUrl);
-
-    // Get user's timezone and time
+// Build the flat JSON body for the frozen POST contract shared by the chat
+// endpoints. All values are strings and every key is optional; the server
+// merges JSON-body values over same-key query-string values (dual-accept
+// window). `preferred_links` stays a JSON-array-encoded STRING — the same
+// encoding the old GET query param carried.
+function buildChatRequestBody(question, selectedModel, promptMode) {
     const timeInfo = getUserTimeInfo();
-    const encodedTimezone = encodeURIComponent(timeInfo.timezone);
-    const encodedCurrentTime = encodeURIComponent(timeInfo.currentTime);
 
-    let endpoint;
-    if (useMCP) {
-        endpoint = 'get_mcp_response';
-    } else {
-        endpoint = promptMode ? 'get_adv_response' : 'get_chat_response';
+    const body = {
+        question: String(question),
+        models: String(selectedModel),
+        current_url: window.location.href,
+        use_unified: 'true',
+        user_timezone: timeInfo.timezone,
+        user_time: timeInfo.currentTime,
+    };
+
+    // Every key is optional in the contract: omit session_id rather than
+    // sending the literal string "null" the old GET template produced.
+    if (currentSessionId) {
+        body.session_id = String(currentSessionId);
     }
 
-    // Get preferred links from localStorage for advanced mode
-    let url = `${buildBackendUrl(`/${endpoint}/`)}?question=${encodedQuestion}` +
-        `&models=${selectedModel}` +
-        `&is_advanced=${promptMode}` +
-        `&use_rag=${useRAG}` +
-        `&use_memory=true` +
-        `&session_id=${currentSessionId}` +
-        `&current_url=${encodedCurrentUrl}` +
-        `&user_timezone=${encodedTimezone}` +
-        `&user_time=${encodedCurrentTime}`;
-
-    // Add preferred links if in advanced mode
+    // Add preferred links if in advanced/research mode
     if (promptMode) {
         try {
             const preferredLinks = JSON.parse(localStorage.getItem('preferredLinks') || '[]');
             if (preferredLinks.length > 0) {
-                url += `&preferred_links=${encodeURIComponent(JSON.stringify(preferredLinks))}`;
+                body.preferred_links = JSON.stringify(preferredLinks);
             }
         } catch (e) {
             console.error('Error getting preferred links:', e);
         }
     }
 
-    return fetch(url, { method: 'GET', credentials: 'include' })
+    return body;
+}
+
+// Function to get chat response from server
+function getChatResponse(question, selectedModel, promptMode, useRAG, useMCP) {
+    // The MCP toggle used to select a dedicated 'get_mcp_response' endpoint
+    // that does not exist in the backend (every call 404'd). The regular
+    // chat endpoint already runs the LLM with the available MCP tools, so
+    // all modes share the two real endpoints now.
+    const endpoint = promptMode ? 'get_adv_response' : 'get_chat_response';
+
+    return fetch(buildBackendUrl(`/${endpoint}/`), {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(buildChatRequestBody(question, selectedModel, promptMode)),
+    })
         .then(response => response.json())
         .catch(error => {
             console.error('There was a problem with your fetch operation:', error);
@@ -103,7 +114,22 @@ function getChatResponse(question, selectedModel, promptMode, useRAG, useMCP) {
         });
 }
 
-// Function to get streaming chat response using EventSource
+// Function to get streaming chat response via POST fetch-streaming SSE.
+//
+// This replaces the old GET + EventSource transport with the frozen POST
+// contract while reproducing the previous observable behavior exactly:
+// - same JSON event handling (error/content/status/used_urls/used_sources/
+//   done/memory_stats) and the same callback surface;
+// - same reconnect semantics: if the connection drops (or the stream ends
+//   without a `done` event) the request is retried up to 3 times, and — as
+//   with EventSource auto-reconnect before — each retry RE-ISSUES the
+//   request server-side (pre-existing semantics);
+// - a successful `event: connected` frame resets the retry counter, as the
+//   old 'connected' listener did;
+// - an HTTP error status is fatal without retry, matching EventSource's
+//   readyState CLOSED behavior on non-200 responses;
+// - the returned cleanup function cancels the stream (AbortController now,
+//   eventSource.close() before).
 function getChatResponseStream(question, selectedModel, promptMode, useRAG, useMCP, callbacks = {}) {
     const {
         onChunk,
@@ -112,20 +138,12 @@ function getChatResponseStream(question, selectedModel, promptMode, useRAG, useM
         onError,
         onStatus,
     } = callbacks;
-    const encodedQuestion = encodeURIComponent(question);
-    const currentUrl = window.location.href;
-    const encodedCurrentUrl = encodeURIComponent(currentUrl);
-
-    // Get user's timezone and time
-    const timeInfo = getUserTimeInfo();
-    const encodedTimezone = encodeURIComponent(timeInfo.timezone);
-    const encodedCurrentTime = encodeURIComponent(timeInfo.currentTime);
 
     // MCP mode doesn't support streaming yet
     if (useMCP) {
         return getChatResponse(question, selectedModel, promptMode, useRAG, useMCP)
             .then(data => {
-                const modelResponse = data.reply;
+                const modelResponse = data.resp ? data.resp[selectedModel] : data.reply;
                 if (typeof onComplete === 'function') {
                     onComplete(modelResponse, data);
                 }
@@ -137,63 +155,47 @@ function getChatResponseStream(question, selectedModel, promptMode, useRAG, useM
             });
     }
 
-    // Build SSE URL based on mode
-    let url;
-    if (promptMode) {
-        // Research mode streaming endpoint
-        url = `${buildBackendUrl('/get_adv_response_stream/')}` +
-            `?question=${encodedQuestion}` +
-            `&models=${selectedModel}` +
-            `&use_rag=${useRAG}` +
-            `&use_memory=true` +
-            `&session_id=${currentSessionId}` +
-            `&current_url=${encodedCurrentUrl}` +
-            `&user_timezone=${encodedTimezone}` +
-            `&user_time=${encodedCurrentTime}`;
+    // Build SSE endpoint based on mode (research vs thinking)
+    const url = buildBackendUrl(promptMode ? '/get_adv_response_stream/' : '/get_chat_response_stream/');
+    const requestBody = JSON.stringify(buildChatRequestBody(question, selectedModel, promptMode));
 
-        // Add preferred links for research mode
-        try {
-            const preferredLinks = JSON.parse(localStorage.getItem('preferredLinks') || '[]');
-            if (preferredLinks.length > 0) {
-                url += `&preferred_links=${encodeURIComponent(JSON.stringify(preferredLinks))}`;
-            }
-        } catch (e) {
-            console.error('Error getting preferred links:', e);
-        }
-    } else {
-        // Thinking mode streaming endpoint
-        url = `${buildBackendUrl('/get_chat_response_stream/')}` +
-            `?question=${encodedQuestion}` +
-            `&models=${selectedModel}` +
-            `&use_rag=${useRAG}` +
-            `&use_memory=true` +
-            `&session_id=${currentSessionId}` +
-            `&current_url=${encodedCurrentUrl}` +
-            `&user_timezone=${encodedTimezone}` +
-            `&user_time=${encodedCurrentTime}`;
-    }
-
-    // Create EventSource for SSE with credentials support
-    const eventSource = new EventSource(url, { withCredentials: true });
     let fullResponse = '';
     let connectionAttempts = 0;
     const maxReconnectAttempts = 3;
+    const reconnectDelayMs = 3000; // EventSource's default retry interval
     let usedUrls = [];  // Store source URLs for research mode
     let usedSources = [];  // Store detailed source metadata
+    let finished = false;      // done / fatal error / retries exhausted
+    let clientClosed = false;  // user-initiated cancel via the cleanup fn
+    let abortController = null;
 
-    // Handle connection event
-    eventSource.addEventListener('connected', (event) => {
-        console.log(`SSE connection established for ${promptMode ? 'research' : 'thinking'} mode`);
-        connectionAttempts = 0; // Reset on successful connection
-    });
+    // Stop all stream activity (the fetch-streaming analogue of
+    // eventSource.close()).
+    function closeStream() {
+        finished = true;
+        if (abortController) {
+            abortController.abort();
+        }
+    }
 
-    // Handle open event (connection established)
-    eventSource.onopen = (event) => {
-        console.log('EventSource connected successfully');
-    };
+    // Handle one parsed SSE event — the JSON handling is identical to the
+    // old eventSource.onmessage / 'connected' listener pair.
+    function handleServerEvent(event) {
+        if (finished || clientClosed) {
+            return;
+        }
 
-    // Handle message events
-    eventSource.onmessage = (event) => {
+        // Handle connection event
+        if (event.type === 'connected') {
+            console.log(`SSE connection established for ${promptMode ? 'research' : 'thinking'} mode`);
+            connectionAttempts = 0; // Reset on successful connection
+            return;
+        }
+
+        if (event.type !== 'message') {
+            return; // unknown event types were unlistened before; ignore
+        }
+
         try {
             const data = JSON.parse(event.data);
 
@@ -201,7 +203,7 @@ function getChatResponseStream(question, selectedModel, promptMode, useRAG, useM
                 if (typeof onError === 'function') {
                     onError(new Error(data.error));
                 }
-                eventSource.close();
+                closeStream();
                 return;
             }
 
@@ -236,7 +238,7 @@ function getChatResponseStream(question, selectedModel, promptMode, useRAG, useM
             }
 
             if (data.done) {
-                eventSource.close();
+                closeStream();
                 // Debug: Log what we're about to pass to completion
                 console.log('[Research Mode] Stream done. Final usedUrls:', usedUrls);
                 console.log('[Research Mode] data.used_urls:', data.used_urls);
@@ -263,40 +265,106 @@ function getChatResponseStream(question, selectedModel, promptMode, useRAG, useM
         } catch (e) {
             console.error('Error parsing SSE data:', e);
         }
-    };
+    }
 
-    // Handle errors with reconnection logic
-    eventSource.onerror = (error) => {
-        // Check readyState to determine the type of error
-        if (eventSource.readyState === EventSource.CONNECTING) {
-            connectionAttempts++;
-            console.log(`SSE reconnecting... Attempt ${connectionAttempts}`);
+    // Retry logic — mirrors the old onerror readyState===CONNECTING branch.
+    // NOTE: like EventSource auto-reconnect, a retry re-sends the POST, which
+    // re-issues the question server-side (pre-existing semantics).
+    function scheduleReconnect() {
+        connectionAttempts++;
+        console.log(`SSE reconnecting... Attempt ${connectionAttempts}`);
 
-            if (connectionAttempts > maxReconnectAttempts) {
-                console.error('SSE max reconnection attempts reached');
-                eventSource.close();
-                if (typeof onError === 'function') {
-                    onError(new Error('Connection failed after multiple attempts'));
-                }
-            }
-        } else if (eventSource.readyState === EventSource.CLOSED) {
-            console.error('SSE connection closed');
+        if (connectionAttempts > maxReconnectAttempts) {
+            console.error('SSE max reconnection attempts reached');
+            finished = true;
             if (typeof onError === 'function') {
-                onError(new Error('Connection closed unexpectedly'));
+                onError(new Error('Connection failed after multiple attempts'));
             }
-        } else {
-            console.error('SSE error:', error);
-            eventSource.close();
-            if (typeof onError === 'function') {
-                onError(error);
-            }
+            return;
         }
-    };
 
-    // Return a cleanup function
+        setTimeout(() => {
+            if (!finished && !clientClosed) {
+                connect();
+            }
+        }, reconnectDelayMs);
+    }
+
+    function connect() {
+        abortController = new AbortController();
+        const parser = createSSEParser(handleServerEvent);
+        const decoder = new TextDecoder('utf-8');
+
+        fetch(url, {
+            method: 'POST',
+            credentials: 'include',
+            headers: {
+                'Content-Type': 'application/json',
+                'Accept': 'text/event-stream',
+            },
+            body: requestBody,
+            signal: abortController.signal,
+        })
+            .then(response => {
+                if (!response.ok) {
+                    // EventSource treated a non-200 as fatal (readyState
+                    // CLOSED) — no retry.
+                    const err = new Error('Connection closed unexpectedly');
+                    err.isFatalSSE = true;
+                    throw err;
+                }
+                console.log('EventSource connected successfully');
+
+                const reader = response.body.getReader();
+                const pump = () => reader.read().then(({ done, value }) => {
+                    if (finished || clientClosed) {
+                        reader.cancel().catch(() => {});
+                        return;
+                    }
+                    if (done) {
+                        parser.feed(decoder.decode()); // flush the decoder
+                        parser.end();
+                        return;
+                    }
+                    parser.feed(decoder.decode(value, { stream: true }));
+                    return pump();
+                });
+                return pump();
+            })
+            .then(() => {
+                if (finished || clientClosed) {
+                    return;
+                }
+                // Stream ended without a `done` event: EventSource would
+                // auto-reconnect here, so we do too.
+                scheduleReconnect();
+            })
+            .catch(error => {
+                if (clientClosed || finished || error.name === 'AbortError') {
+                    return;
+                }
+                if (error.isFatalSSE) {
+                    finished = true;
+                    console.error('SSE connection closed');
+                    if (typeof onError === 'function') {
+                        onError(new Error('Connection closed unexpectedly'));
+                    }
+                    return;
+                }
+                // Network-level failure: EventSource would retry.
+                scheduleReconnect();
+            });
+    }
+
+    connect();
+
+    // Return a cleanup function (user-initiated cancel)
     return () => {
-        if (eventSource.readyState !== EventSource.CLOSED) {
-            eventSource.close();
+        if (!finished && !clientClosed) {
+            clientClosed = true;
+            if (abortController) {
+                abortController.abort();
+            }
             console.log('EventSource connection closed by client');
         }
     };
@@ -351,9 +419,16 @@ function getSourceUrls(searchQuery, currentUrl) {
 function logQuestion(question, button) {
     const currentUrl = window.location.href;
 
-    const requestUrl = `${buildBackendUrl('/log_question/')}?question=${encodeURIComponent(question)}&button=${encodeURIComponent(button)}&current_url=${encodeURIComponent(currentUrl)}`;
-
-    return fetch(requestUrl, { method: "GET", credentials: "include" })
+    return fetch(buildBackendUrl('/log_question/'), {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+            question: String(question),
+            button: String(button),
+            current_url: String(currentUrl),
+        }),
+    })
         .then(response => response.json())
         .then(data => {
             if (data.status !== 'success') {

--- a/Main/frontend/src/modules/api.js
+++ b/Main/frontend/src/modules/api.js
@@ -313,7 +313,7 @@ function getChatResponseStream(question, selectedModel, promptMode, useRAG, useM
                     err.isFatalSSE = true;
                     throw err;
                 }
-                console.log('EventSource connected successfully');
+                console.log('SSE stream connected successfully');
 
                 const reader = response.body.getReader();
                 const pump = () => reader.read().then(({ done, value }) => {
@@ -365,7 +365,7 @@ function getChatResponseStream(question, selectedModel, promptMode, useRAG, useM
             if (abortController) {
                 abortController.abort();
             }
-            console.log('EventSource connection closed by client');
+            console.log('SSE stream closed by client');
         }
     };
 }

--- a/Main/frontend/src/modules/components/settings_window.js
+++ b/Main/frontend/src/modules/components/settings_window.js
@@ -1,6 +1,5 @@
 // settings_window.js
 import { availableModels, selectedModel, getSelectedModel, setSelectedModel, fetchAvailableModels, getAvailableModels, getModelDetails } from '../config.js';
-import { buildBackendUrl } from '../backendConfig.js';
 //import { loadPreferredLinks, createAddLinkButton } from '../helpers.js';
 import { createLinkManager } from './link_manager.js';
 
@@ -230,61 +229,13 @@ function createSettingsWindow(isFixedModeRef, settingsButton, positionModeButton
         // Any immediate actions when the checkbox changes can be handled here
         console.log ("switch value:", ragSwitch.checked);
 
-        
         if(ragSwitch.checked && RAGPath !== '') {
-            console.log("BODY:", JSON.stringify({ 'filePaths': [RAGPath] }));
-        
-            // Retrieve all file contents
-            const fileHandles = [];
-            for await (const entry of RAGPath.values()) {
-                if (entry.kind === 'file') {
-                    fileHandles.push(entry);  // Store file handles
-                }
-            }
-            const filesPromises = fileHandles.map(async (handle) => {
-                const file = await handle.getFile();
-                const ext = file.name.split('.').pop().toLowerCase();
-                console.log(`[DEBUG] extension: ${ext}`)
-                let text = "hello";
-                if (ext === 'txt') {
-                    text = await file.text();
-                } else if (ext === 'pdf') {
-                    text = await extractTextFromPDF(file);
-                } else if (ext === 'docx') {
-                    text = await extractTextFromDocx(file);
-                } else {
-                    console.warn(`Unsupported file type: ${file.name}`);
-                }
-                console.log(`[DEBUG] extension: ${text}`)
-                return { name: file.name, content: text };
-            });
-            const filesData = await Promise.all(filesPromises);
-            console.log("filesdata: ", filesData);
-            
-            // Create a FormData object
-            const formData = new FormData();
-
-            // Convert your data to a JSON string and add it as a file
-            const jsonBlob = new Blob([JSON.stringify({ 'filePaths': filesData })], 
-                            { type: 'application/json' });
-            formData.append('json_data', jsonBlob, 'data.json');
-
-            // Making the POST request to Flask
-            fetch(buildBackendUrl('/api/folder_path'), {
-                method: 'POST',
-                body: formData
-            })
-            .then(response => response.json())
-            .then(data => {
-                if (data.message) {
-                    console.log("Success:", data.message);
-                } else if (data.error) {
-                    console.error("Error:", data.error);
-                }
-            })
-            .catch(error => {
-                console.error("Error processing data:", error);
-            });
+            // The old '/api/folder_path' upload was a Flask-era leftover:
+            // that route no longer exists in the Django backend, so the
+            // folder contents are no longer read or uploaded. The switch is
+            // disabled in the UI; if local-folder RAG is ever re-enabled,
+            // wire this handler to a real endpoint first.
+            console.warn('[RAG] Local folder upload is not supported by the current backend; the selected folder was not uploaded.');
         }
     };
 

--- a/Main/frontend/src/modules/handlers.js
+++ b/Main/frontend/src/modules/handlers.js
@@ -644,8 +644,10 @@ async function handleChatResponse(question, promptMode = false, useStreaming = t
         const responseTime = endTime - startTime;
         console.log(`Time taken for response: ${responseTime} ms`);
 
-        // Extract the reply: MCP gives `data.reply`, normal gives `data.resp[...]`
-        const modelResponse = useMCP ? data.reply : data.resp[selectedModel];
+        // Extract the reply. All modes (including the MCP toggle, which now
+        // shares the standard chat endpoint) return `data.resp[...]`; the
+        // `data.reply` fallback covers older servers' MCP-shaped payloads.
+        const modelResponse = data.resp ? data.resp[selectedModel] : data.reply;
 
         let responseText = '';
         if (!modelResponse) {

--- a/Main/frontend/src/modules/sse.js
+++ b/Main/frontend/src/modules/sse.js
@@ -1,0 +1,102 @@
+// sse.js — incremental Server-Sent Events parser for fetch()-based streaming.
+//
+// The extension used to consume SSE with the browser's EventSource, which
+// only supports GET. The chat endpoints moved to POST (frozen contract), so
+// the stream is now read via fetch() + ReadableStream and this parser
+// reassembles SSE frames from arbitrarily-chunked network reads.
+//
+// Spec-relevant behavior (mirrors what EventSource did for our streams):
+// - Lines end with \n, \r\n, or a lone \r; a trailing \r at the end of a
+//   chunk is held back until the next read in case it is half of a \r\n.
+// - `data:` lines accumulate; multi-line data is joined with '\n'.
+// - `event:` sets the event type (default 'message').
+// - Lines starting with ':' are comments and are ignored.
+// - `id:` and `retry:` fields are parsed but unused — the previous
+//   EventSource consumer never used them either (the backend sends neither).
+// - An event is dispatched only on a blank line; an unterminated final event
+//   at end-of-stream is dropped, exactly like EventSource.
+
+function createSSEParser(onEvent) {
+    let buffer = '';
+    let dataLines = [];
+    let eventType = '';
+
+    function dispatch() {
+        if (dataLines.length > 0) {
+            onEvent({ type: eventType || 'message', data: dataLines.join('\n') });
+        }
+        dataLines = [];
+        eventType = '';
+    }
+
+    function processLine(line) {
+        if (line === '') {
+            dispatch();
+            return;
+        }
+        if (line.charAt(0) === ':') {
+            return; // comment line
+        }
+
+        let field = line;
+        let value = '';
+        const colonIdx = line.indexOf(':');
+        if (colonIdx !== -1) {
+            field = line.slice(0, colonIdx);
+            value = line.slice(colonIdx + 1);
+            if (value.charAt(0) === ' ') {
+                value = value.slice(1);
+            }
+        }
+
+        if (field === 'data') {
+            dataLines.push(value);
+        } else if (field === 'event') {
+            eventType = value;
+        }
+        // 'id' / 'retry' / unknown fields: accepted and ignored.
+    }
+
+    return {
+        // Feed a decoded text chunk. Partial lines (and a possible trailing
+        // '\r' of a split '\r\n') are buffered until the next feed().
+        feed(text) {
+            buffer += text;
+            let start = 0;
+            let i = 0;
+            while (i < buffer.length) {
+                const ch = buffer[i];
+                if (ch === '\r') {
+                    if (i === buffer.length - 1) {
+                        // Might be the first half of a \r\n split across
+                        // chunks — wait for the next read.
+                        break;
+                    }
+                    processLine(buffer.slice(start, i));
+                    i += buffer[i + 1] === '\n' ? 2 : 1;
+                    start = i;
+                } else if (ch === '\n') {
+                    processLine(buffer.slice(start, i));
+                    i += 1;
+                    start = i;
+                } else {
+                    i += 1;
+                }
+            }
+            buffer = buffer.slice(start);
+        },
+
+        // Signal end-of-stream. A held trailing '\r' is now known to be a
+        // lone-CR line terminator (not the first half of a split '\r\n'),
+        // so its line is processed; any other unterminated partial line is
+        // dropped, exactly like EventSource at EOF.
+        end() {
+            if (buffer.charAt(buffer.length - 1) === '\r') {
+                processLine(buffer.slice(0, -1));
+            }
+            buffer = '';
+        },
+    };
+}
+
+export { createSSEParser };

--- a/Main/frontend/src/modules/sse.test.js
+++ b/Main/frontend/src/modules/sse.test.js
@@ -1,0 +1,87 @@
+import { describe, test, expect } from 'bun:test';
+import { createSSEParser } from './sse.js';
+
+// Feed `text` to a fresh parser in chunks of `size` chars, signal
+// end-of-stream (as the api.js consumer does), and collect the dispatched
+// events.
+function parseChunked(text, size) {
+    const events = [];
+    const parser = createSSEParser((evt) => events.push(evt));
+    for (let i = 0; i < text.length; i += size) {
+        parser.feed(text.slice(i, i + size));
+    }
+    parser.end();
+    return events;
+}
+
+const BACKEND_STREAM =
+    'event: connected\ndata: {"status": "connected"}\n\n' +
+    'data: {"content": "Hello", "done": false}\n\n' +
+    'data: {"content": " world", "done": false}\n\n' +
+    'data: {"content": "", "done": true, "used_urls": ["https://a.example"]}\n\n';
+
+describe('createSSEParser', () => {
+    test('parses the exact frame shapes the backend emits', () => {
+        const events = parseChunked(BACKEND_STREAM, BACKEND_STREAM.length);
+        expect(events).toEqual([
+            { type: 'connected', data: '{"status": "connected"}' },
+            { type: 'message', data: '{"content": "Hello", "done": false}' },
+            { type: 'message', data: '{"content": " world", "done": false}' },
+            { type: 'message', data: '{"content": "", "done": true, "used_urls": ["https://a.example"]}' },
+        ]);
+    });
+
+    test('is invariant to chunk boundaries (every chunk size, incl. 1 byte)', () => {
+        const reference = parseChunked(BACKEND_STREAM, BACKEND_STREAM.length);
+        for (let size = 1; size <= 17; size++) {
+            expect(parseChunked(BACKEND_STREAM, size)).toEqual(reference);
+        }
+    });
+
+    test('joins multi-line data with newlines', () => {
+        const events = parseChunked('data: line1\ndata: line2\n\n', 4);
+        expect(events).toEqual([{ type: 'message', data: 'line1\nline2' }]);
+    });
+
+    test('handles CRLF and lone-CR terminators, including a \\r\\n split across chunks', () => {
+        const stream = 'event: connected\r\ndata: x\r\n\r\ndata: y\r\r';
+        // Chunk size 17 puts the boundary exactly between '\r' and '\n'
+        // of the first line ('event: connected' is 16 chars + '\r' = 17).
+        for (const size of [1, 2, 3, 17, stream.length]) {
+            expect(parseChunked(stream, size)).toEqual([
+                { type: 'connected', data: 'x' },
+                { type: 'message', data: 'y' },
+            ]);
+        }
+    });
+
+    test('ignores comment lines and unknown fields, defaults type to message', () => {
+        const events = parseChunked(': keep-alive\nid: 7\nretry: 250\ndata: ok\n\n', 5);
+        expect(events).toEqual([{ type: 'message', data: 'ok' }]);
+    });
+
+    test('strips a single leading space from field values', () => {
+        expect(parseChunked('data:  two spaces\n\n', 3)).toEqual([
+            { type: 'message', data: ' two spaces' },
+        ]);
+        expect(parseChunked('data:nospace\n\n', 3)).toEqual([
+            { type: 'message', data: 'nospace' },
+        ]);
+    });
+
+    test('does not dispatch an event without data lines', () => {
+        expect(parseChunked('event: ping\n\n', 2)).toEqual([]);
+    });
+
+    test('drops an unterminated trailing event (EventSource parity)', () => {
+        expect(parseChunked('data: complete\n\ndata: partial', 6)).toEqual([
+            { type: 'message', data: 'complete' },
+        ]);
+    });
+
+    test('passes [DONE]-style sentinel lines through as plain data', () => {
+        expect(parseChunked('data: [DONE]\n\n', 5)).toEqual([
+            { type: 'message', data: '[DONE]' },
+        ]);
+    });
+});


### PR DESCRIPTION
## Extension: migrate chat endpoints from GET/EventSource to POST fetch-streaming (v0.16.0)

> ⚠️ **RELEASE ORDER: publish to the Chrome Web Store only AFTER the backend dual-accept PR #332 (`security/tier3-dual-accept`) is LIVE.** Merging this PR is safe (the extension does not auto-deploy — it ships via a manual unlisted-store upload). Load-unpacked dev installs never auto-update, so keep GET alive on the backend for weeks after the store upload and confirm via chat-endpoint access-log counts before the GET-removal PR.

### What
- **Non-stream calls** (`/get_chat_response/`, `/get_adv_response/`): `fetch` POST + JSON body, `credentials:'include'`, no query string.
- **Stream calls** (`/get_chat_response_stream/`, `/get_adv_response_stream/`): `EventSource` (GET-only by spec) replaced with `fetch` POST + `response.body.getReader()` + a new incremental SSE parser (`src/modules/sse.js`). **Behavior parity is the bar**, reproduced exactly: 3× reconnect at EventSource's 3s interval (each retry re-issues the request, pre-existing semantics), `event: connected` resets the retry counter, **non-2xx is fatal without retry** (matches EventSource CLOSED — no hot-loop on 4xx/5xx), and the returned cleanup fn maps to `AbortController.abort()`.
- **`log_question`** → POST JSON.
- **Dead-call cleanup**: `get_mcp_response` (never existed in the backend; 404'd) now uses the real chat endpoint; the Flask-era `/api/folder_path` upload is removed (RAG switch degrades to a `console.warn` instead of a 404).
- Version `0.15.2` → `0.16.0`.

### Verification
- **`bun run build:full` passes** (webpack compile + `check-dist` — all required `dist/` files present). `dist/` is a gitignored build artifact, rebuilt for the store upload.
- **SSE parser unit test: 9 pass, 30 assertions** — covers chunk-boundary invariance at every size (incl. 1 byte), CRLF + lone-CR + `\r\n` split across chunks, multi-line data, unterminated-trailing-event drop (EventSource parity), and `[DONE]` passthrough.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
