### PR TITLE
refactor(extension): remove dead MCP toggle plumbing

### DIFF
--- a/Main/frontend/src/modules/api.js
+++ b/Main/frontend/src/modules/api.js
@@ -94,11 +94,10 @@ function buildChatRequestBody(question, selectedModel, promptMode) {
 }
 
 // Function to get chat response from server
-function getChatResponse(question, selectedModel, promptMode, useRAG, useMCP) {
-    // The MCP toggle used to select a dedicated 'get_mcp_response' endpoint
-    // that does not exist in the backend (every call 404'd). The regular
-    // chat endpoint already runs the LLM with the available MCP tools, so
-    // all modes share the two real endpoints now.
+function getChatResponse(question, selectedModel, promptMode, useRAG) {
+    // Every mode shares the two real chat endpoints; the LLM already runs
+    // with the available MCP tools server-side, so there is no separate MCP
+    // endpoint or client-side toggle.
     const endpoint = promptMode ? 'get_adv_response' : 'get_chat_response';
 
     return fetch(buildBackendUrl(`/${endpoint}/`), {
@@ -130,7 +129,7 @@ function getChatResponse(question, selectedModel, promptMode, useRAG, useMCP) {
 //   readyState CLOSED behavior on non-200 responses;
 // - the returned cleanup function cancels the stream (AbortController now,
 //   eventSource.close() before).
-function getChatResponseStream(question, selectedModel, promptMode, useRAG, useMCP, callbacks = {}) {
+function getChatResponseStream(question, selectedModel, promptMode, useRAG, callbacks = {}) {
     const {
         onChunk,
         onSources,
@@ -138,22 +137,6 @@ function getChatResponseStream(question, selectedModel, promptMode, useRAG, useM
         onError,
         onStatus,
     } = callbacks;
-
-    // MCP mode doesn't support streaming yet
-    if (useMCP) {
-        return getChatResponse(question, selectedModel, promptMode, useRAG, useMCP)
-            .then(data => {
-                const modelResponse = data.resp ? data.resp[selectedModel] : data.reply;
-                if (typeof onComplete === 'function') {
-                    onComplete(modelResponse, data);
-                }
-            })
-            .catch(error => {
-                if (typeof onError === 'function') {
-                    onError(error);
-                }
-            });
-    }
 
     // Build SSE endpoint based on mode (research vs thinking)
     const url = buildBackendUrl(promptMode ? '/get_adv_response_stream/' : '/get_chat_response_stream/');

--- a/Main/frontend/src/modules/components/settings_window.js
+++ b/Main/frontend/src/modules/components/settings_window.js
@@ -174,22 +174,6 @@ function createSettingsWindow(isFixedModeRef, settingsButton, positionModeButton
 
 
 
-    // —– MCP Mode Toggle —–
-    // MCP Mode toggle temporarily disabled
-    /*
-    const mcpLabel = document.createElement('label');
-    mcpLabel.className = 'settings-checkbox-label';
-    mcpLabel.innerText = "MCP Mode";
-    const mcpSwitch = document.createElement('input');
-    mcpSwitch.type = "checkbox";
-    mcpSwitch.id = "mcpModeSwitch";
-    mcpSwitch.style.transform = 'translate(4px, -2px)';
-    mcpLabel.appendChild(mcpSwitch);
-    */
-
-
-
-
     // RAG Section
     // RAG settings temporarily disabled
     /*
@@ -335,7 +319,6 @@ function createSettingsWindow(isFixedModeRef, settingsButton, positionModeButton
     */
 
     // Append elements to settings window
-    // settings_window.appendChild(mcpLabel);
     // settings_window.appendChild(ragSectionContainer);
 
     settingsButton.onclick = function (event) {

--- a/Main/frontend/src/modules/handlers.js
+++ b/Main/frontend/src/modules/handlers.js
@@ -263,7 +263,6 @@ function createActionButtons(
   userQuestion,
   promptMode,
   useRAG,
-  useMCP,
   selectedModel
 ) {
   const buttonContainer = document.createElement('div');
@@ -474,18 +473,14 @@ async function handleChatResponse(question, promptMode = false, useStreaming = t
   const ragSwitchEl = document.getElementById('ragSwitch');
   const useRAG = ragSwitchEl ? !!ragSwitchEl.checked : false;
 
-  // Read the MCP mode toggle
-  const mcpSwitchEl = document.getElementById('mcpModeSwitch');
-  const useMCP = mcpSwitchEl ? !!mcpSwitchEl.checked : false;
-
   const selectedModel = getSelectedModel();
 
-  // Check if streaming is available (not for MCP or RAG modes)
-  const canStream = useStreaming && !useMCP && !useRAG;
+  // Check if streaming is available (not for RAG mode)
+  const canStream = useStreaming && !useRAG;
   if (!canStream) {
     pushAgentStatus({
       label: 'Processing',
-      detail: useMCP ? 'MCP mode' : useRAG ? 'RAG mode' : 'Standard pipeline',
+      detail: useRAG ? 'RAG mode' : 'Standard pipeline',
     });
   }
 
@@ -505,7 +500,6 @@ async function handleChatResponse(question, promptMode = false, useStreaming = t
       selectedModel,
       promptMode,
       useRAG,
-      useMCP,
       {
         // onChunk callback - called for each chunk of text
         onChunk: (_chunk, fullResponse) => {
@@ -549,7 +543,6 @@ async function handleChatResponse(question, promptMode = false, useStreaming = t
             question,
             promptMode,
             useRAG,
-            useMCP,
             selectedModel
           );
           attachValidateButtonIfClaims(actionButtons, {
@@ -638,15 +631,15 @@ async function handleChatResponse(question, promptMode = false, useStreaming = t
     );
   } else {
     // Use regular non-streaming response
-    getChatResponse(question, selectedModel, promptMode, useRAG, useMCP)
+    getChatResponse(question, selectedModel, promptMode, useRAG)
       .then((data) => {
         const endTime = performance.now();
         const responseTime = endTime - startTime;
         console.log(`Time taken for response: ${responseTime} ms`);
 
-        // Extract the reply. All modes (including the MCP toggle, which now
-        // shares the standard chat endpoint) return `data.resp[...]`; the
-        // `data.reply` fallback covers older servers' MCP-shaped payloads.
+        // Extract the reply. The chat endpoints return `data.resp[model]`;
+        // the `data.reply` fallback covers older servers' alternate payload
+        // shape.
         const modelResponse = data.resp ? data.resp[selectedModel] : data.reply;
 
         let responseText = '';
@@ -673,7 +666,6 @@ async function handleChatResponse(question, promptMode = false, useStreaming = t
           question,
           promptMode,
           useRAG,
-          useMCP,
           selectedModel
         );
         attachValidateButtonIfClaims(actionButtons, {


### PR DESCRIPTION
## What

MCP is now the default for every agent, so the client-side "MCP Mode" toggle is obsolete. Its UI was already disabled (commented out) in an earlier cleanup, which meant `useMCP` was hardwired to `false` at every call site. This PR removes the resulting dead plumbing.

## Why now

The toggle predates MCP being always-on. Because `document.getElementById('mcpModeSwitch')` returns `null` (the control is commented out), `useMCP` could never be `true`. The leftover code was actively misleading:

- an unreachable `if (useMCP)` branch in `getChatResponseStream` that routed to the non-streaming path — i.e. it would have *disabled streaming* if the toggle ever came back;
- a "MCP mode doesn't support streaming yet" comment describing code that can never run;
- a `!useMCP` term in the streaming gate and a `'MCP mode'` status label that can never show.

## Changes

- **api.js** — drop the `useMCP` param from `getChatResponse` / `getChatResponseStream`; delete the unreachable `if (useMCP)` non-streaming branch; correct the endpoint comment.
- **handlers.js** — drop the `mcpModeSwitch` read, the `!useMCP` term in `canStream`, the `'MCP mode'` detail label, and the `useMCP` argument at all call sites (including `createActionButtons`).
- **settings_window.js** — delete the commented-out MCP toggle tombstone.

## Scope / safety

- **No behavior change.** `useMCP` was provably always `false`, so no reachable path is altered.
- **RAG left untouched** — it's a separately parked feature (also currently commented out).
- **Base:** stacked on `security/extension-post-sse` (#335) because it edits the same post-migration `api.js`; GitHub will retarget this to `main` once #335 merges.

## Verification

- `bun test` — 55 pass, **no new failures**.
- `bun run build:full` — webpack compiles clean; `dist/main.js` contains zero `useMCP` / `mcpModeSwitch` references.

> ⚠️ Note (pre-existing, out of scope): 2 `markdownRenderer` DOMPurify XSS-sanitizer tests fail identically on the base branch `security/extension-post-sse` with this diff stashed. They live in code this PR never touches. Flagging so it isn't mistaken for a regression here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
