### PR TITLE
feat(signals): rolling artifact-retention cap (SIGNALS_KEEP_N, default 14)

### DIFF
--- a/Docs/superpowers/plans/2026-07-10-news-signals-retention-cap.md
+++ b/Docs/superpowers/plans/2026-07-10-news-signals-retention-cap.md
@@ -1,0 +1,386 @@
+# News-signals Artifact Retention Cap — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Cap `signals_dir` to the N most recent `signals-*.json` artifacts (default N=14), pruning older ones after each successful sweep so droplet storage can't grow unbounded.
+
+**Architecture:** Add a `SIGNALS_KEEP_N` config knob (validated ≥1 at load), a best-effort `prune_artifacts(cfg)` helper that keeps the newest N artifacts by `(mtime, name)`, a single call to it at the end of `run_sweep`, and a small hardening of `run_canary` so a file pruned mid-glob can't raise `FileNotFoundError`. State (`signals_state.json`) is deliberately left untouched.
+
+**Tech Stack:** Python 3 stdlib only (the Heartbeat CI is dependency-free), `unittest` + `unittest.mock`.
+
+**Spec:** `Docs/superpowers/specs/2026-07-10-news-signals-retention-cap-design.md`
+
+## Global Constraints
+
+- **Single-file deploy contract:** `Heartbeat/news_signals.py` must not import `news_heartbeat`; keep all logic self-contained (stdlib only).
+- **Dependency-free tests:** no `jsonschema`/third-party imports in `Heartbeat/tests/`; use `unittest` + `unittest.mock` like the existing suite.
+- **Write-order contract (spec §6.2):** artifact is written before its state entry; pruning must not reorder or interfere with this — it runs only after the write loop completes.
+- **Config-error exit code:** invalid config → `sys.exit(2)` (matches the `HEARTBEAT_WINDOW_HOURS` guard and the README exit-code table).
+- **Default retention:** `SIGNALS_KEEP_N` default is **14**, baked into `load_config`.
+- **Run tests with:** `cd Heartbeat && python -m pytest tests/test_news_signals.py -v` (or `python -m unittest`). All commands below assume CWD = `Heartbeat/`.
+
+---
+
+### Task 1: Config — `SIGNALS_KEEP_N` (default 14) with a fail-closed guard
+
+**Files:**
+- Modify: `Heartbeat/news_signals.py` — `load_config()` (currently lines 107–139)
+- Modify: `Heartbeat/.env.heartbeat.example` (after line 35, `# SIGNALS_MAX_FILE_MB=10`)
+- Test: `Heartbeat/tests/test_news_signals.py` — class `TestFoundation`, after `test_load_config_defaults_and_fallbacks`
+
+**Interfaces:**
+- Produces: `cfg["keep_n"]` — an `int ≥ 1` read from `SIGNALS_KEEP_N` (default 14). `make_cfg()` in the tests already calls `load_config()`, so every `cfg` fixture gains `keep_n` automatically.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `TestFoundation` in `tests/test_news_signals.py`, right after `test_load_config_defaults_and_fallbacks`:
+
+```python
+    def test_load_config_defaults_keep_n_to_14(self):
+        with unittest.mock.patch.dict(os.environ, {}, clear=True):
+            cfg = ns.load_config()
+        self.assertEqual(cfg["keep_n"], 14)
+
+    def test_load_config_honors_keep_n_override(self):
+        with unittest.mock.patch.dict(os.environ, {"SIGNALS_KEEP_N": "30"}, clear=True):
+            cfg = ns.load_config()
+        self.assertEqual(cfg["keep_n"], 30)
+
+    def test_load_config_rejects_non_positive_keep_n(self):
+        # A keep_n of 0 or negative would delete every artifact on the next
+        # sweep — fail closed at config load rather than wipe the directory.
+        for bad in ("0", "-5"):
+            with unittest.mock.patch.dict(os.environ, {"SIGNALS_KEEP_N": bad}, clear=True):
+                with self.assertRaises(SystemExit) as ctx:
+                    ns.load_config()
+            self.assertEqual(ctx.exception.code, 2)
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `python -m pytest tests/test_news_signals.py::TestFoundation -k keep_n -v`
+Expected: FAIL — `test_load_config_defaults_keep_n_to_14` and `_honors_keep_n_override` raise `KeyError: 'keep_n'`; `_rejects_non_positive_keep_n` fails because no `SystemExit` is raised.
+
+- [ ] **Step 3: Implement the config knob and guard**
+
+In `load_config()`, immediately **after** the existing `HEARTBEAT_WINDOW_HOURS` guard block (the `if window_hours < WINDOW_HOURS_MIN:` … `sys.exit(2)`), add:
+
+```python
+    keep_n = int(os.environ.get("SIGNALS_KEEP_N", "14"))
+    if keep_n < 1:
+        # a non-positive cap would prune every artifact on the next sweep;
+        # fail closed (exit 2 = config error, README exit-code table)
+        log(f"ERROR SIGNALS_KEEP_N must be >= 1, got {keep_n}")
+        sys.exit(2)
+```
+
+Then add this entry to the returned config dict (place it next to `"max_file_mb": ...`):
+
+```python
+        "keep_n": keep_n,
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `python -m pytest tests/test_news_signals.py::TestFoundation -k keep_n -v`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Document the knob in the env example**
+
+In `Heartbeat/.env.heartbeat.example`, after line 35 (`# SIGNALS_MAX_FILE_MB=10`), add:
+
+```bash
+# Rolling retention cap: keep only the N most recent signals-*.json artifacts;
+# older ones are pruned after each successful sweep. Bounds signals/ growth.
+# SIGNALS_KEEP_N=14
+```
+
+- [ ] **Step 6: Run the full suite (no regressions) and commit**
+
+Run: `python -m pytest tests/test_news_signals.py -q`
+Expected: PASS (existing tests + 3 new).
+
+```bash
+git add Heartbeat/news_signals.py Heartbeat/.env.heartbeat.example Heartbeat/tests/test_news_signals.py
+git commit -m "feat(signals): add SIGNALS_KEEP_N retention config (default 14, fail-closed)"
+```
+
+---
+
+### Task 2: `prune_artifacts(cfg)` — keep newest N, best-effort delete
+
+**Files:**
+- Modify: `Heartbeat/news_signals.py` — add a new function **immediately before** `run_sweep` (currently line 571)
+- Test: `Heartbeat/tests/test_news_signals.py` — new class `TestPrune` (place after `TestSweep`)
+
+**Interfaces:**
+- Consumes: `cfg["signals_dir"]` (a `Path`), `cfg["keep_n"]` (int ≥1) from Task 1.
+- Produces: `prune_artifacts(cfg) -> None`. Deletes `signals-*.json` files beyond the newest `keep_n` (ordered by `(mtime, name)` descending). Never raises; a failed `unlink` logs `WARN` and is skipped. Only touches files matching `signals-*.json`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add a new class after `TestSweep` in `tests/test_news_signals.py`:
+
+```python
+class TestPrune(unittest.TestCase):
+    def setUp(self):
+        self._td = tempfile.TemporaryDirectory()
+        self.home = Path(self._td.name)
+        self.addCleanup(self._td.cleanup)
+        self.cfg = make_cfg(self.home)
+        self.cfg["signals_dir"].mkdir(parents=True, exist_ok=True)
+
+    def _make_artifact(self, name, mtime):
+        p = self.cfg["signals_dir"] / name
+        p.write_text("{}", encoding="utf-8")
+        os.utime(p, (mtime, mtime))
+        return p
+
+    def test_prune_keeps_newest_n_by_mtime(self):
+        self.cfg["keep_n"] = 2
+        base = 1_700_000_000
+        for i in range(5):  # signals-0 oldest .. signals-4 newest
+            self._make_artifact(f"signals-{i}.json", base + i)
+        ns.prune_artifacts(self.cfg)
+        remaining = sorted(p.name for p in self.cfg["signals_dir"].glob("signals-*.json"))
+        self.assertEqual(remaining, ["signals-3.json", "signals-4.json"])
+
+    def test_prune_is_noop_when_at_or_below_cap(self):
+        self.cfg["keep_n"] = 5
+        base = 1_700_000_000
+        for i in range(3):
+            self._make_artifact(f"signals-{i}.json", base + i)
+        ns.prune_artifacts(self.cfg)
+        self.assertEqual(len(list(self.cfg["signals_dir"].glob("signals-*.json"))), 3)
+
+    def test_prune_only_touches_signal_artifacts(self):
+        self.cfg["keep_n"] = 1
+        base = 1_700_000_000
+        self._make_artifact("signals-0.json", base)
+        self._make_artifact("signals-1.json", base + 1)
+        lock = self.cfg["signals_dir"] / ".lock"
+        lock.write_text("", encoding="utf-8")
+        other = self.cfg["signals_dir"] / "signals_state.json"  # not signals-*.json
+        other.write_text("{}", encoding="utf-8")
+        ns.prune_artifacts(self.cfg)
+        self.assertTrue(lock.exists(), "the sweep .lock must never be pruned")
+        self.assertTrue(other.exists(), "non-artifact files must never be pruned")
+        self.assertTrue((self.cfg["signals_dir"] / "signals-1.json").exists())
+        self.assertFalse((self.cfg["signals_dir"] / "signals-0.json").exists())
+
+    def test_prune_survives_unlink_failure_without_raising(self):
+        self.cfg["keep_n"] = 1
+        base = 1_700_000_000
+        self._make_artifact("signals-0.json", base)
+        self._make_artifact("signals-1.json", base + 1)
+        with unittest.mock.patch("pathlib.Path.unlink",
+                                 side_effect=OSError("read-only fs")), \
+             unittest.mock.patch.object(ns, "log") as fake_log:
+            ns.prune_artifacts(self.cfg)  # must not raise
+        self.assertTrue(any("WARN" in c.args[0] for c in fake_log.call_args_list))
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `python -m pytest tests/test_news_signals.py::TestPrune -v`
+Expected: FAIL — `AttributeError: module 'news_signals' has no attribute 'prune_artifacts'`.
+
+- [ ] **Step 3: Implement `prune_artifacts`**
+
+Insert immediately before `def run_sweep(` in `news_signals.py`:
+
+```python
+def prune_artifacts(cfg):
+    """Rolling retention cap (spec 2026-07-10): keep only the newest
+    cfg["keep_n"] signals-*.json artifacts, unlink the rest. Ordered by
+    (mtime, name) descending so "most recent" matches the canary's staleness
+    notion, with name as a deterministic tiebreaker. Best-effort: a failed
+    unlink logs a WARN and is skipped — the artifacts are already durably
+    written, so cleanup failure must not fail the sweep. signals_state.json is
+    left untouched by design (deleting a state entry would invite reprocessing).
+    Runs under the sweep's flock, so no concurrent sweep races it."""
+    artifacts = sorted(cfg["signals_dir"].glob("signals-*.json"),
+                       key=lambda p: (p.stat().st_mtime, p.name), reverse=True)
+    for p in artifacts[cfg["keep_n"]:]:
+        try:
+            p.unlink()
+            log(f"pruned old artifact {p.name}")
+        except OSError as exc:
+            log(f"WARN could not prune {p.name}: {exc}")
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `python -m pytest tests/test_news_signals.py::TestPrune -v`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Heartbeat/news_signals.py Heartbeat/tests/test_news_signals.py
+git commit -m "feat(signals): add prune_artifacts helper (keep newest N, best-effort)"
+```
+
+---
+
+### Task 3: Wire pruning into `run_sweep` (state entries survive)
+
+**Files:**
+- Modify: `Heartbeat/news_signals.py` — `run_sweep()` (currently lines 571–597); add the prune call before the final `return 0`
+- Test: `Heartbeat/tests/test_news_signals.py` — class `TestSweep`
+
+**Interfaces:**
+- Consumes: `prune_artifacts(cfg)` from Task 2.
+- Produces: after a successful sweep, `signals_dir` holds ≤ `keep_n` artifacts; `signals_state.json` entries are unchanged.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `TestSweep` in `tests/test_news_signals.py`:
+
+```python
+    def test_sweep_prunes_to_keep_n_but_leaves_state(self):
+        # Pre-seed keep_n old artifacts, then process one fresh digest: the
+        # directory must settle at keep_n, and every state entry survives.
+        self.cfg["keep_n"] = 2
+        base = 1_700_000_000
+        for i in range(2):
+            p = self.cfg["signals_dir"] / f"signals-old-{i}.json"
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text("{}", encoding="utf-8")
+            os.utime(p, (base + i, base + i))
+        # seed a matching (stale) state entry that must NOT be pruned
+        self.cfg["state_path"].write_text(
+            json.dumps({"items-old.jsonl": {"processed_at": base, "status": "ok"}}),
+            encoding="utf-8")
+        write_items(self.cfg["digests"], [make_story()], name="items-2026-07-06.jsonl")
+        self.assertEqual(ns.run_sweep(self.cfg, llm=OK_LLM), 0)
+        arts = list(self.cfg["signals_dir"].glob("signals-*.json"))
+        self.assertEqual(len(arts), 2, "sweep must hold the directory at keep_n")
+        self.assertTrue((self.cfg["signals_dir"] / "signals-2026-07-06.json").exists(),
+                        "the freshly written artifact must be one of the survivors")
+        state = json.loads(self.cfg["state_path"].read_text())
+        self.assertIn("items-old.jsonl", state, "state entries must survive pruning")
+        self.assertIn("items-2026-07-06.jsonl", state)
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `python -m pytest tests/test_news_signals.py::TestSweep::test_sweep_prunes_to_keep_n_but_leaves_state -v`
+Expected: FAIL — three artifacts remain (2 old + 1 fresh), so `len(arts) == 3 != 2`.
+
+- [ ] **Step 3: Wire the prune call into `run_sweep`**
+
+In `run_sweep()`, replace the final `return 0` (the one after the `for items_path in todo:` loop) with:
+
+```python
+    prune_artifacts(cfg)
+    return 0
+```
+
+(The early `return 0` inside `if not todo:` stays as-is — an idle tick adds no artifacts, so it needs no prune.)
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `python -m pytest tests/test_news_signals.py::TestSweep::test_sweep_prunes_to_keep_n_but_leaves_state -v`
+Expected: PASS.
+
+- [ ] **Step 5: Run the full TestSweep class (no regressions) and commit**
+
+Run: `python -m pytest tests/test_news_signals.py::TestSweep -v`
+Expected: PASS (existing sweep tests unaffected — they write ≤2 artifacts under the default `keep_n=14`, so pruning is a no-op for them).
+
+```bash
+git add Heartbeat/news_signals.py Heartbeat/tests/test_news_signals.py
+git commit -m "feat(signals): prune artifacts at end of run_sweep, keep state intact"
+```
+
+---
+
+### Task 4: Harden `run_canary` against a file pruned mid-glob
+
+**Files:**
+- Modify: `Heartbeat/news_signals.py` — `run_canary()` (currently lines 639–661; the `mtimes = [...]` comprehension at 643–644)
+- Test: `Heartbeat/tests/test_news_signals.py` — class `TestCanary`
+
+**Interfaces:**
+- Produces: `run_canary` no longer raises `FileNotFoundError` when a globbed artifact disappears before its `stat()`; such a file is skipped.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `TestCanary` in `tests/test_news_signals.py`:
+
+```python
+    def test_canary_tolerates_artifact_pruned_mid_glob(self):
+        # A concurrent sweep can unlink an artifact between the canary's glob
+        # and its stat(). The canary must skip the vanished file, not crash.
+        fresh = self.cfg["signals_dir"] / "signals-fresh.json"
+        fresh.write_text("{}", encoding="utf-8")
+        ghost = self.cfg["signals_dir"] / "signals-ghost.json"  # never created
+        with unittest.mock.patch("pathlib.Path.glob", return_value=[ghost, fresh]):
+            self.assertEqual(ns.run_canary(self.cfg), 0)
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `python -m pytest tests/test_news_signals.py::TestCanary::test_canary_tolerates_artifact_pruned_mid_glob -v`
+Expected: FAIL — `ghost.stat()` raises `FileNotFoundError`, propagating out of the list comprehension.
+
+- [ ] **Step 3: Guard the per-file `stat()`**
+
+In `run_canary()`, replace:
+
+```python
+    mtimes = [p.stat().st_mtime
+              for p in cfg["signals_dir"].glob("signals-*.json")]
+```
+
+with:
+
+```python
+    mtimes = []
+    for p in cfg["signals_dir"].glob("signals-*.json"):
+        try:
+            mtimes.append(p.stat().st_mtime)
+        except FileNotFoundError:
+            # pruned by a concurrent sweep between glob and stat — a race,
+            # not staleness; skip it
+            continue
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `python -m pytest tests/test_news_signals.py::TestCanary::test_canary_tolerates_artifact_pruned_mid_glob -v`
+Expected: PASS.
+
+- [ ] **Step 5: Run the full suite and commit**
+
+Run: `python -m pytest tests/test_news_signals.py -q`
+Expected: PASS (all tests, old + new).
+
+```bash
+git add Heartbeat/news_signals.py Heartbeat/tests/test_news_signals.py
+git commit -m "fix(signals): canary skips artifacts pruned mid-glob (no false CRIT)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- §1 config `SIGNALS_KEEP_N` default 14 + fail-closed guard → Task 1 ✓
+- §2 `prune_artifacts`, `(mtime, name)` ordering, best-effort unlink → Task 2 ✓
+- §3 integration into `run_sweep` end-of-loop, under flock → Task 3 ✓
+- §4 state untouched → asserted in Task 2 (`test_prune_only_touches_signal_artifacts`) and Task 3 (`..._leaves_state`) ✓
+- §5 canary hardening → Task 4 ✓
+- §6 tests 1–6 → distributed across Tasks 1–4 ✓
+- §7 rollout: `.env.heartbeat.example` documented → Task 1 Step 5 ✓; PR/deploy handled at branch-finish time
+
+**Placeholder scan:** none — every step has concrete code/commands.
+
+**Type consistency:** `prune_artifacts(cfg)` defined in Task 2, consumed by name in Task 3; `cfg["keep_n"]` produced in Task 1, consumed in Tasks 2–3; all `signals-*.json` glob patterns and `cfg["signals_dir"]`/`cfg["state_path"]` keys match the existing module.
+
+## Notes for the implementer
+
+- CWD for all test commands is `Heartbeat/`. The suite is stdlib-only; `pytest` is optional — `python -m unittest tests.test_news_signals -v` works too.
+- `make_cfg()` builds `cfg` via `load_config()`, so after Task 1 every fixture carries `keep_n=14`; individual prune/sweep tests lower it (`self.cfg["keep_n"] = 2`) to exercise pruning without creating 14+ files.
+- Do not touch `signals_state.json` pruning — it is an explicit non-goal (see spec §4).

--- a/Docs/superpowers/specs/2026-07-10-news-signals-retention-cap-design.md
+++ b/Docs/superpowers/specs/2026-07-10-news-signals-retention-cap-design.md
@@ -1,0 +1,110 @@
+# News-signals artifact retention cap — design
+
+**Date:** 2026-07-10
+**Component:** `Heartbeat/news_signals.py`
+**Task:** `finsearch-nts-signals-retention-cap-01` (P2)
+**Related:** `Docs/superpowers/specs/2026-07-06-news-to-signals-pipeline-design.md` (the pipeline this caps)
+
+## Problem
+
+The news→signals sweep (`run_sweep`, fired by a 20-min systemd timer) writes one
+`signals-<stem>.json` artifact per unprocessed digest into `signals_dir`, then
+records the digest in `signals_state.json`. Nothing ever deletes artifacts, so
+the directory grows ~1 file/day without bound. The only existing size control is
+`SIGNALS_MAX_FILE_MB`, which caps a single *input* digest — it does nothing about
+*accumulation*. On the droplet this is a live storage risk; it is currently held
+in check by a manual hold at 14 artifacts.
+
+## Goal
+
+Bound `signals_dir` to the **N most recent** `signals-*.json` artifacts
+(default **N = 14**), pruning older artifacts after each successful sweep, with
+no change to pipeline correctness, the write-order contract, or the canary's
+staleness semantics.
+
+Non-goals: pruning digests (`items-*.jsonl`, owned by `news_heartbeat.py`);
+time-based / TTL retention; compaction of `signals_state.json`.
+
+## Design
+
+### 1. Config — `load_config()`
+
+Add one entry, read from the environment with a baked-in default of 14:
+
+```python
+"keep_n": int(os.environ.get("SIGNALS_KEEP_N", "14")),
+```
+
+Validate at load time, mirroring the existing `window_hours` floor guard: if
+`keep_n < 1`, log an error and `sys.exit(2)` (config error, per the README
+exit-code table). **Fail closed, don't clamp:** a `keep_n` of 0 or negative
+would delete *every* artifact on the next sweep, so a misconfigured cap must
+refuse to start rather than silently wipe the directory.
+
+### 2. `prune_artifacts(cfg)` — new helper
+
+- Glob `signals-*.json` in `cfg["signals_dir"]`.
+- Sort by `(mtime, name)` **descending**; keep the newest `cfg["keep_n"]`,
+  unlink the remainder.
+- **Ordering:** mtime is the primary key — "most recent" matches both the user's
+  wording and the canary's existing recency notion (`run_canary` keys staleness
+  off `max(mtime)`). `name` is a deterministic tiebreaker; ISO-date stems already
+  sort chronologically, so ties resolve stably.
+- **Best-effort:** wrap each `unlink` in `try/except OSError`; a failed delete
+  (permission, race) logs a `WARN` and is skipped. Pruning never raises, never
+  changes the sweep's exit code — the artifacts are already durably written, so
+  a cleanup failure is not a pipeline failure.
+
+### 3. Integration — `run_sweep(cfg, ...)`
+
+Call `prune_artifacts(cfg)` **once**, at the end of `run_sweep`, after the write
+loop completes. It runs inside the existing exclusive `flock` (`signals_dir/.lock`),
+so no concurrent sweep can race it. It runs only when there was work — the early
+`if not todo: return 0` short-circuits an idle tick — which is exactly when new
+artifacts were added, so end-of-sweep pruning is sufficient to hold the cap.
+
+### 4. `signals_state.json` — left untouched (deliberate)
+
+The task offered optional pruning of state entries; this design **does not** do
+it. State is keyed by `items-*.jsonl` digest name and exists only to prevent
+reprocessing. Deleting an artifact while keeping its state entry is safe.
+Deleting the *state* entry while its digest still exists would make the next
+sweep **reprocess** that digest → regenerate the old artifact with a fresh mtime
+→ churn (and pollute the "most recent" set). State entries are tiny
+(`{processed_at, status}`, ~1/day) and are not the storage concern; the multi-MB
+artifacts are. So: **prune artifacts only.**
+
+### 5. Canary hardening — `run_canary(cfg, ...)`
+
+`run_canary` currently computes `[p.stat().st_mtime for p in glob("signals-*.json")]`
+lock-free (by design — it must not block on an in-flight sweep's LLM call). Once a
+sweep can *delete* artifacts, a file can vanish between the glob and its `stat()`,
+raising `FileNotFoundError` → a false CRIT staleness alert. Fix: guard the per-file
+`stat()` and skip a file that disappears mid-iteration. Small, targeted hardening
+that is a direct consequence of introducing deletion; it does not otherwise change
+canary behavior.
+
+## Error handling summary
+
+| Condition | Behavior |
+|---|---|
+| `SIGNALS_KEEP_N < 1` | `sys.exit(2)` at config load (fail closed) |
+| `unlink` fails during prune | `WARN` logged, file skipped, sweep continues, exit code unchanged |
+| Artifact vanishes during canary glob | Skipped, canary uses remaining files |
+| ≤ N artifacts present | Prune is a no-op |
+
+## Tests (TDD, `tests/test_news_signals.py`, unittest)
+
+1. Prune keeps exactly N, deletes the oldest beyond N (ordered by mtime).
+2. Prune with ≤ N artifacts deletes nothing.
+3. `SIGNALS_KEEP_N < 1` → `SystemExit(2)` at config load.
+4. A sweep that writes new artifacts leaves the directory at ≤ N.
+5. State entries survive pruning (artifact deleted, `signals_state.json` key kept).
+6. Canary tolerates a file vanishing during its glob (no crash, correct newest).
+
+## Rollout
+
+- Document `SIGNALS_KEEP_N` (default 14) in `Heartbeat/.env.heartbeat.example`.
+- TDD implementation → PR to `Agentic-FinSearch` `main`.
+- Droplet picks it up via the Heartbeat deploy job; the manual 14-artifact hold
+  can then be released (code default already matches).

--- a/Heartbeat/.env.heartbeat.example
+++ b/Heartbeat/.env.heartbeat.example
@@ -33,4 +33,7 @@ DISCORD_CHANNEL_ID=
 # SIGNALS_DAMP_CAP=0.7
 # SIGNALS_DAMP_MIN_ARTICLES=2
 # SIGNALS_MAX_FILE_MB=10
+# Rolling retention cap: keep only the N most recent signals-*.json artifacts;
+# older ones are pruned after each successful sweep. Bounds signals/ growth.
+# SIGNALS_KEEP_N=14
 # SIGNALS_STALENESS_ALERT_H=20

--- a/Heartbeat/news_signals.py
+++ b/Heartbeat/news_signals.py
@@ -630,6 +630,7 @@ def run_sweep(cfg, now=None, llm=call_llm):
         save_state_atomic(state, cfg["state_path"])  # state SECOND
         log(f"wrote {out_path.name} status={artifact['status']} "
             f"signals={len(artifact['signals'])}")
+    prune_artifacts(cfg)
     return 0
 
 

--- a/Heartbeat/news_signals.py
+++ b/Heartbeat/news_signals.py
@@ -575,6 +575,35 @@ def warn_alias_gaps(watchlist):
                 f"— only symbol-in-headline stories will match (spec D8)")
 
 
+def prune_artifacts(cfg):
+    """Rolling retention cap (spec 2026-07-10): keep only the newest
+    cfg["keep_n"] signals-*.json artifacts, unlink the rest. Ordered by
+    (mtime, name) descending so "most recent" matches the canary's staleness
+    notion, with name as a deterministic tiebreaker. Best-effort: a failed
+    unlink logs a WARN and is skipped — the artifacts are already durably
+    written, so cleanup failure must not fail the sweep. signals_state.json is
+    left untouched by design (deleting a state entry would invite reprocessing).
+    Runs under the sweep's flock, so no concurrent sweep races it; a file that
+    vanishes between glob and stat is skipped rather than raised, keeping the
+    never-raise contract."""
+    artifacts = []
+    for p in cfg["signals_dir"].glob("signals-*.json"):
+        try:
+            artifacts.append((p.stat().st_mtime, p.name, p))
+        except OSError:
+            # a globbed file can vanish (or become unreadable) before its
+            # stat() — a race, not a retention decision; skip it so prune never
+            # raises and can't fail an otherwise-successful sweep
+            continue
+    artifacts.sort(key=lambda t: (t[0], t[1]), reverse=True)
+    for _, _, p in artifacts[cfg["keep_n"]:]:
+        try:
+            p.unlink()
+            log(f"pruned old artifact {p.name}")
+        except OSError as exc:
+            log(f"WARN could not prune {p.name}: {exc}")
+
+
 def run_sweep(cfg, now=None, llm=call_llm):
     now = time.time() if now is None else now
     state = load_state(cfg["state_path"])

--- a/Heartbeat/news_signals.py
+++ b/Heartbeat/news_signals.py
@@ -115,6 +115,12 @@ def load_config():
         log(f"ERROR HEARTBEAT_WINDOW_HOURS must be >= {WINDOW_HOURS_MIN}, "
             f"got {window_hours}")
         sys.exit(2)
+    keep_n = int(os.environ.get("SIGNALS_KEEP_N", "14"))
+    if keep_n < 1:
+        # a non-positive cap would prune every artifact on the next sweep;
+        # fail closed (exit 2 = config error, README exit-code table)
+        log(f"ERROR SIGNALS_KEEP_N must be >= 1, got {keep_n}")
+        sys.exit(2)
     return {
         "home": home,
         "digests": home / "digests",
@@ -135,6 +141,7 @@ def load_config():
         "damp_cap": float(os.environ.get("SIGNALS_DAMP_CAP", "0.7")),
         "damp_min_articles": int(os.environ.get("SIGNALS_DAMP_MIN_ARTICLES", "2")),
         "max_file_mb": int(os.environ.get("SIGNALS_MAX_FILE_MB", "10")),
+        "keep_n": keep_n,
         "staleness_alert_h": float(os.environ.get("SIGNALS_STALENESS_ALERT_H", "20")),
     }
 

--- a/Heartbeat/news_signals.py
+++ b/Heartbeat/news_signals.py
@@ -575,6 +575,26 @@ def warn_alias_gaps(watchlist):
                 f"— only symbol-in-headline stories will match (spec D8)")
 
 
+def _list_signals_artifacts(signals_dir):
+    """(mtime, name, path) for every signals-*.json artifact, skipping any that
+    vanish or become unreadable between glob and stat. That race is real for
+    both callers — the lock-free canary races an in-flight prune, and even the
+    flock-held pruner can have a file removed out from under it — and it can
+    surface as FileNotFoundError or, on the droplet's rootless UID-remapped :ro
+    artifact mount, as a PermissionError; both are OSError, so catch broadly and
+    skip (matching news_heartbeat.prune_old_digests). Never raises, so no caller
+    can be failed by a listing that races a delete."""
+    out = []
+    for p in signals_dir.glob("signals-*.json"):
+        try:
+            out.append((p.stat().st_mtime, p.name, p))
+        except OSError:
+            # vanished or unreadable mid-enumeration — a race, not a
+            # retention/staleness decision; skip it
+            continue
+    return out
+
+
 def prune_artifacts(cfg):
     """Rolling retention cap (spec 2026-07-10): keep only the newest
     cfg["keep_n"] signals-*.json artifacts, unlink the rest. Ordered by
@@ -583,19 +603,8 @@ def prune_artifacts(cfg):
     unlink logs a WARN and is skipped — the artifacts are already durably
     written, so cleanup failure must not fail the sweep. signals_state.json is
     left untouched by design (deleting a state entry would invite reprocessing).
-    Runs under the sweep's flock, so no concurrent sweep races it; a file that
-    vanishes between glob and stat is skipped rather than raised, keeping the
-    never-raise contract."""
-    artifacts = []
-    for p in cfg["signals_dir"].glob("signals-*.json"):
-        try:
-            artifacts.append((p.stat().st_mtime, p.name, p))
-        except OSError:
-            # a globbed file can vanish (or become unreadable) before its
-            # stat() — a race, not a retention decision; skip it so prune never
-            # raises and can't fail an otherwise-successful sweep
-            continue
-    artifacts.sort(key=lambda t: (t[0], t[1]), reverse=True)
+    Runs under the sweep's flock, so no concurrent sweep races it."""
+    artifacts = sorted(_list_signals_artifacts(cfg["signals_dir"]), reverse=True)
     for _, _, p in artifacts[cfg["keep_n"]:]:
         try:
             p.unlink()
@@ -677,14 +686,7 @@ def run_canary(cfg, now=None):
     """Spec §6-C: a wedged pipeline must be distinguishable from a quiet day.
     Exit 1 (unit shows failed) + CRIT log + Discord ping when stale."""
     now = time.time() if now is None else now
-    mtimes = []
-    for p in cfg["signals_dir"].glob("signals-*.json"):
-        try:
-            mtimes.append(p.stat().st_mtime)
-        except FileNotFoundError:
-            # pruned by a concurrent sweep between glob and stat — a race,
-            # not staleness; skip it
-            continue
+    mtimes = [mtime for mtime, _, _ in _list_signals_artifacts(cfg["signals_dir"])]
     newest = max(mtimes, default=None)
     if newest is not None and (now - newest) <= cfg["staleness_alert_h"] * 3600:
         log(f"canary: ok (newest artifact {(now - newest) / 3600:.1f}h old)")

--- a/Heartbeat/news_signals.py
+++ b/Heartbeat/news_signals.py
@@ -677,8 +677,14 @@ def run_canary(cfg, now=None):
     """Spec §6-C: a wedged pipeline must be distinguishable from a quiet day.
     Exit 1 (unit shows failed) + CRIT log + Discord ping when stale."""
     now = time.time() if now is None else now
-    mtimes = [p.stat().st_mtime
-              for p in cfg["signals_dir"].glob("signals-*.json")]
+    mtimes = []
+    for p in cfg["signals_dir"].glob("signals-*.json"):
+        try:
+            mtimes.append(p.stat().st_mtime)
+        except FileNotFoundError:
+            # pruned by a concurrent sweep between glob and stat — a race,
+            # not staleness; skip it
+            continue
     newest = max(mtimes, default=None)
     if newest is not None and (now - newest) <= cfg["staleness_alert_h"] * 3600:
         log(f"canary: ok (newest artifact {(now - newest) / 3600:.1f}h old)")

--- a/Heartbeat/tests/test_news_signals.py
+++ b/Heartbeat/tests/test_news_signals.py
@@ -955,6 +955,15 @@ class TestCanary(unittest.TestCase):
             self.assertEqual(ns.run_canary(self.cfg), 1)
         post.assert_not_called()
 
+    def test_canary_tolerates_artifact_pruned_mid_glob(self):
+        # A concurrent sweep can unlink an artifact between the canary's glob
+        # and its stat(). The canary must skip the vanished file, not crash.
+        fresh = self.cfg["signals_dir"] / "signals-fresh.json"
+        fresh.write_text("{}", encoding="utf-8")
+        ghost = self.cfg["signals_dir"] / "signals-ghost.json"  # never created
+        with unittest.mock.patch("pathlib.Path.glob", return_value=[ghost, fresh]):
+            self.assertEqual(ns.run_canary(self.cfg), 0)
+
 
 class TestMain(unittest.TestCase):
     def setUp(self):

--- a/Heartbeat/tests/test_news_signals.py
+++ b/Heartbeat/tests/test_news_signals.py
@@ -130,6 +130,25 @@ class TestFoundation(unittest.TestCase):
         self.assertEqual(cfg["per_ticker_cap"], 3)
         self.assertEqual(cfg["watchlist"], sorted(set(ns.DEFAULT_WATCHLIST.split())))
 
+    def test_load_config_defaults_keep_n_to_14(self):
+        with unittest.mock.patch.dict(os.environ, {}, clear=True):
+            cfg = ns.load_config()
+        self.assertEqual(cfg["keep_n"], 14)
+
+    def test_load_config_honors_keep_n_override(self):
+        with unittest.mock.patch.dict(os.environ, {"SIGNALS_KEEP_N": "30"}, clear=True):
+            cfg = ns.load_config()
+        self.assertEqual(cfg["keep_n"], 30)
+
+    def test_load_config_rejects_non_positive_keep_n(self):
+        # A keep_n of 0 or negative would delete every artifact on the next
+        # sweep — fail closed at config load rather than wipe the directory.
+        for bad in ("0", "-5"):
+            with unittest.mock.patch.dict(os.environ, {"SIGNALS_KEEP_N": bad}, clear=True):
+                with self.assertRaises(SystemExit) as ctx:
+                    ns.load_config()
+            self.assertEqual(ctx.exception.code, 2)
+
     def test_signals_model_overrides_heartbeat_model(self):
         import news_signals as ns
         env = {"SIGNALS_MODEL": "better-model", "HEARTBEAT_MODEL": "worse-model"}

--- a/Heartbeat/tests/test_news_signals.py
+++ b/Heartbeat/tests/test_news_signals.py
@@ -772,6 +772,30 @@ class TestSweep(unittest.TestCase):
         self.assertEqual(artifact["status"], "ok")
         self.assertEqual(artifact["signals"], {})
 
+    def test_sweep_prunes_to_keep_n_but_leaves_state(self):
+        # Pre-seed keep_n old artifacts, then process one fresh digest: the
+        # directory must settle at keep_n, and every state entry survives.
+        self.cfg["keep_n"] = 2
+        base = 1_700_000_000
+        for i in range(2):
+            p = self.cfg["signals_dir"] / f"signals-old-{i}.json"
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text("{}", encoding="utf-8")
+            os.utime(p, (base + i, base + i))
+        # seed a matching (stale) state entry that must NOT be pruned
+        self.cfg["state_path"].write_text(
+            json.dumps({"items-old.jsonl": {"processed_at": base, "status": "ok"}}),
+            encoding="utf-8")
+        write_items(self.cfg["digests"], [make_story()], name="items-2026-07-06.jsonl")
+        self.assertEqual(ns.run_sweep(self.cfg, llm=OK_LLM), 0)
+        arts = list(self.cfg["signals_dir"].glob("signals-*.json"))
+        self.assertEqual(len(arts), 2, "sweep must hold the directory at keep_n")
+        self.assertTrue((self.cfg["signals_dir"] / "signals-2026-07-06.json").exists(),
+                        "the freshly written artifact must be one of the survivors")
+        state = json.loads(self.cfg["state_path"].read_text())
+        self.assertIn("items-old.jsonl", state, "state entries must survive pruning")
+        self.assertIn("items-2026-07-06.jsonl", state)
+
 
 class TestPrune(unittest.TestCase):
     def setUp(self):

--- a/Heartbeat/tests/test_news_signals.py
+++ b/Heartbeat/tests/test_news_signals.py
@@ -773,6 +773,84 @@ class TestSweep(unittest.TestCase):
         self.assertEqual(artifact["signals"], {})
 
 
+class TestPrune(unittest.TestCase):
+    def setUp(self):
+        self._td = tempfile.TemporaryDirectory()
+        self.home = Path(self._td.name)
+        self.addCleanup(self._td.cleanup)
+        self.cfg = make_cfg(self.home)
+        self.cfg["signals_dir"].mkdir(parents=True, exist_ok=True)
+
+    def _make_artifact(self, name, mtime):
+        p = self.cfg["signals_dir"] / name
+        p.write_text("{}", encoding="utf-8")
+        os.utime(p, (mtime, mtime))
+        return p
+
+    def test_prune_keeps_newest_n_by_mtime(self):
+        self.cfg["keep_n"] = 2
+        base = 1_700_000_000
+        for i in range(5):  # signals-0 oldest .. signals-4 newest
+            self._make_artifact(f"signals-{i}.json", base + i)
+        ns.prune_artifacts(self.cfg)
+        remaining = sorted(p.name for p in self.cfg["signals_dir"].glob("signals-*.json"))
+        self.assertEqual(remaining, ["signals-3.json", "signals-4.json"])
+
+    def test_prune_is_noop_when_at_or_below_cap(self):
+        self.cfg["keep_n"] = 5
+        base = 1_700_000_000
+        for i in range(3):
+            self._make_artifact(f"signals-{i}.json", base + i)
+        ns.prune_artifacts(self.cfg)
+        self.assertEqual(len(list(self.cfg["signals_dir"].glob("signals-*.json"))), 3)
+
+    def test_prune_only_touches_signal_artifacts(self):
+        self.cfg["keep_n"] = 1
+        base = 1_700_000_000
+        self._make_artifact("signals-0.json", base)
+        self._make_artifact("signals-1.json", base + 1)
+        lock = self.cfg["signals_dir"] / ".lock"
+        lock.write_text("", encoding="utf-8")
+        other = self.cfg["signals_dir"] / "signals_state.json"  # not signals-*.json
+        other.write_text("{}", encoding="utf-8")
+        ns.prune_artifacts(self.cfg)
+        self.assertTrue(lock.exists(), "the sweep .lock must never be pruned")
+        self.assertTrue(other.exists(), "non-artifact files must never be pruned")
+        self.assertTrue((self.cfg["signals_dir"] / "signals-1.json").exists())
+        self.assertFalse((self.cfg["signals_dir"] / "signals-0.json").exists())
+
+    def test_prune_survives_unlink_failure_without_raising(self):
+        self.cfg["keep_n"] = 1
+        base = 1_700_000_000
+        self._make_artifact("signals-0.json", base)
+        self._make_artifact("signals-1.json", base + 1)
+        with unittest.mock.patch("pathlib.Path.unlink",
+                                 side_effect=OSError("read-only fs")), \
+             unittest.mock.patch.object(ns, "log") as fake_log:
+            ns.prune_artifacts(self.cfg)  # must not raise
+        self.assertTrue(any("WARN" in c.args[0] for c in fake_log.call_args_list))
+
+    def test_prune_skips_file_vanishing_before_stat(self):
+        # A globbed artifact can be removed before its stat() is read (a race
+        # with an external actor; the sweep's own flock only serializes sweeps).
+        # prune must skip the vanished file, not raise, and still retain the
+        # newest keep_n — otherwise an uncaught raise would fail the sweep.
+        self.cfg["keep_n"] = 1
+        base = 1_700_000_000
+        self._make_artifact("signals-0.json", base)
+        self._make_artifact("signals-1.json", base + 1)
+        real_stat = Path.stat
+        def flaky_stat(p, *a, **k):
+            if p.name == "signals-0.json":
+                raise FileNotFoundError(p.name)
+            return real_stat(p, *a, **k)
+        with unittest.mock.patch.object(Path, "stat", flaky_stat):
+            ns.prune_artifacts(self.cfg)  # must not raise
+        # signals-0 was skipped during sorting (treated as already gone);
+        # signals-1 is the sole survivor within keep_n=1.
+        self.assertTrue((self.cfg["signals_dir"] / "signals-1.json").exists())
+
+
 import fcntl
 
 


### PR DESCRIPTION
## What & why

Caps the Heartbeat news→signals artifact directory (`signals/`) to the **N most recent** `signals-*.json` files (default **N=14**), pruning older ones after each successful sweep so droplet storage can't grow unbounded. State (`signals_state.json`) is deliberately left untouched — deleting a state entry would invite reprocessing.

Spec: `Docs/superpowers/specs/2026-07-10-news-signals-retention-cap-design.md`
Plan: `Docs/superpowers/plans/2026-07-10-news-signals-retention-cap.md`

## Changes (4 commits)

1. **`SIGNALS_KEEP_N` config** (default 14, fail-closed) — `load_config()` reads the knob; `keep_n < 1` exits `2` (config-error, matches the `HEARTBEAT_WINDOW_HOURS` guard and the README exit-code table). Documented in `.env.heartbeat.example`.
2. **`prune_artifacts(cfg)`** — keeps the newest `keep_n` `signals-*.json` by `(mtime, name)` descending; best-effort unlink (a failed `unlink` logs `WARN` and is skipped). **Never raises** — a file that vanishes between glob and stat is skipped, not propagated.
3. **Wire into `run_sweep`** — one `prune_artifacts(cfg)` call at the end of a successful sweep, *after* the write loop (honors the write-order contract, spec §6.2). State entries survive.
4. **Harden `run_canary`** — an artifact pruned mid-glob (between the canary's glob and its `stat()`) is skipped rather than raising a false CRIT.

## Design notes

- **No data-loss paths.** With `keep_n ≥ 1` the just-written artifact always has the newest mtime and sorts to the top of the retained set — it can never be pruned. `signals_state.json` lives in a *different directory* than `signals/`, and the `signals-*` (hyphen) glob cannot match `signals_state` (underscore); a test plants a decoy `signals_state.json` in `signals/` and asserts it survives.
- **Concurrency.** `prune_artifacts` runs under the sweep's `.lock` (`LOCK_EX|LOCK_NB`), so no concurrent sweep races it. The canary runs lock-free by design, so the glob→stat race is real — hence the hardening in commit 4. Both TOCTOU windows (glob→stat, stat→unlink) are guarded.
- **Backward compatible.** Default 14 matches the current manual hold on the droplet; directories with ≤14 artifacts see a no-op. The manual hold can be released once this ships.
- One **owner-approved deviation** from the plan's verbatim code: commit 2 moves the `stat()` inside an `OSError` guard (collect-and-skip) so `prune_artifacts` honors its own "never raises" contract even if a file vanishes mid-enumeration — mirroring the canary hardening the plan itself mandates in commit 4.

## Tests

Stdlib-only (`unittest`), dependency-free, matching the existing suite. **+5 new tests** (3 config, 5 prune incl. a vanish-before-stat regression, 1 sweep integration, 1 canary). Each task was TDD RED→GREEN.

Full CI command green: `cd Heartbeat && python3 -m unittest discover -s tests` → **138 tests, OK**.

## Review

Executed via subagent-driven development: per-task spec+quality review on every commit (one fix loop on commit 2 for the stat() race), plus a final whole-branch review — **verdict: ready to merge**, zero Critical / zero Important. Six residual Minors (style/consistency nits, e.g. non-integer `SIGNALS_KEEP_N` raising `ValueError` like every other `int()` env parse) triaged as deferrable with no correctness or data-loss impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Md9qmLoWsRQG1x8yUv3BqE
