### PR TITLE
feat(signals): ?as_of point-in-time lookup on /api/signals/news/

### DIFF
--- a/Docs/superpowers/specs/2026-07-06-news-to-signals-pipeline-design.md
+++ b/Docs/superpowers/specs/2026-07-06-news-to-signals-pipeline-design.md
@@ -161,10 +161,11 @@ A machine-readable JSON Schema ships at `Heartbeat/schemas/signals-v1.schema.jso
 - `?tickers=AAPL,MSFT` — optional filter on `signals` keys (case-insensitive; unknown tickers simply absent).
 - **`?as_of=YYYY-MM-DD` (optional):** returns the newest artifact whose batch
   date is on or before the given day (point-in-time — no lookahead, robust to
-  weekend/missed-run gaps). Resolution is by the artifact's filename stem date
-  — candidates order by `(stem date, mtime, name)`, so a backfilled older day
-  never outranks a newer day; `(mtime, name)` stays the same-day-supplemental
-  tiebreak. Absent → newest overall.
+  weekend/missed-run gaps). Batch dates are UTC calendar dates (the producer
+  stamps artifacts with the UTC date). Resolution is by the artifact's filename
+  stem date — candidates order by `(stem date, mtime, name)`, so a backfilled
+  older day never outranks a newer day; `(mtime, name)` stays the
+  same-day-supplemental tiebreak. Absent → newest overall.
   A date earlier than all retained artifacts → `404 {"error": "no_signals"}`;
   a future date → the latest artifact; a malformed value → `400 {"error":
   "bad_as_of"}`. History depth is bounded by retention (`SIGNALS_KEEP_N`,

--- a/Docs/superpowers/specs/2026-07-06-news-to-signals-pipeline-design.md
+++ b/Docs/superpowers/specs/2026-07-06-news-to-signals-pipeline-design.md
@@ -167,7 +167,7 @@ A machine-readable JSON Schema ships at `Heartbeat/schemas/signals-v1.schema.jso
   older day never outranks a newer day; `(mtime, name)` stays the
   same-day-supplemental tiebreak. Absent → newest overall.
   A date earlier than all retained artifacts → `404 {"error": "no_signals"}`;
-  a future date → the latest artifact; a malformed value → `400 {"error":
+  a future date → the latest dated artifact; a malformed value → `400 {"error":
   "bad_as_of"}`. History depth is bounded by retention (`SIGNALS_KEEP_N`,
   default 14 dated artifacts): a date older than the oldest retained artifact
   404s identically to "never produced" — callers cannot distinguish the two

--- a/Docs/superpowers/specs/2026-07-06-news-to-signals-pipeline-design.md
+++ b/Docs/superpowers/specs/2026-07-06-news-to-signals-pipeline-design.md
@@ -159,6 +159,22 @@ A machine-readable JSON Schema ships at `Heartbeat/schemas/signals-v1.schema.jso
 
 - **200** — public serialization of the newest `signals-*.json` (newest = greatest mtime, filename as a deterministic tiebreak; same-day supplemental stems sort lexicographically before the date-only stem, so stem order alone is not recency): the artifact **minus** `generator`, `model`, `prompt_version` (recon-value stripping), **plus** `"staleness_hours"` computed server-side from `generated_at`.
 - `?tickers=AAPL,MSFT` — optional filter on `signals` keys (case-insensitive; unknown tickers simply absent).
+- **`?as_of=YYYY-MM-DD` (optional):** returns the newest artifact whose batch
+  date is on or before the given day (point-in-time — no lookahead, robust to
+  weekend/missed-run gaps). Resolution is by the artifact's filename stem date
+  — candidates order by `(stem date, mtime, name)`, so a backfilled older day
+  never outranks a newer day; `(mtime, name)` stays the same-day-supplemental
+  tiebreak. Absent → newest overall.
+  A date earlier than all retained artifacts → `404 {"error": "no_signals"}`;
+  a future date → the latest artifact; a malformed value → `400 {"error":
+  "bad_as_of"}`. History depth is bounded by retention (`SIGNALS_KEEP_N`,
+  default 14 dated artifacts): a date older than the oldest retained artifact
+  404s identically to "never produced" — callers cannot distinguish the two
+  from the response alone. The per-date ticker set is whatever the watchlist
+  was when that artifact was produced — it can change across the retained
+  window (e.g. a watchlist deploy). Callers detect a gap by comparing the
+  requested date to the returned `generated_at`. `staleness_hours` is
+  unchanged (relative to now). Composes with `?tickers=`.
 - **404** `{"error": "no_signals"}` — no artifact exists.
 - Headers: `ETag` (from `generated_at` + `source_items` + the normalized tickers filter, `+`-joined — Django's `parse_etags()` rejects commas inside an ETag), `Last-Modified` **on the unfiltered variant only** (it is identical across tickers variants, so an `If-Modified-Since`-only revalidation of a filtered request must get a full 200, never a 304 pointing at a differently-filtered cached body), `Cache-Control: public, max-age=300`; conditional GET returns 304. Rate-limited via the existing `django_ratelimit` + `api.identity.ratelimit_key` infra.
 - Serving path: container gets a **runtime-enforced `:ro` mount of `$HEARTBEAT_HOME/signals/` only** — never the whole digests tree (§7.2).

--- a/Main/backend/api/signals_views.py
+++ b/Main/backend/api/signals_views.py
@@ -37,7 +37,7 @@ def _as_of(request: HttpRequest):
     """Parse ?as_of=YYYY-MM-DD. Returns None (param absent) or a datetime.date.
     Raises ValueError on any malformed value — the view maps that to a 400."""
     raw = request.GET.get("as_of")
-    if not raw:
+    if raw is None:
         return None
     if not _AS_OF_RE.match(raw):
         raise ValueError(f"as_of must be YYYY-MM-DD, got {raw!r}")

--- a/Main/backend/api/signals_views.py
+++ b/Main/backend/api/signals_views.py
@@ -64,15 +64,17 @@ def _load_artifact(as_of=None):
     if not directory.is_dir():
         return None
     candidates = list(directory.glob("signals-*.json"))
-    if as_of is not None:
-        # Point-in-time: keep only artifacts whose batch date is on or before
-        # as_of. Non-dated stems (_stem_date is None) are skipped.
-        candidates = [p for p in candidates
-                      if (d := _stem_date(p)) is not None and d <= as_of]
-    if not candidates:
-        return None
     newest = None
     try:
+        if as_of is not None:
+            # Point-in-time: keep only artifacts whose batch date is on or
+            # before as_of. Non-dated stems (_stem_date is None) are skipped.
+            # Inside the try so a bad as_of argument fails closed (None ->
+            # 404), never a 500 — the module contract.
+            candidates = [p for p in candidates
+                          if (d := _stem_date(p)) is not None and d <= as_of]
+        if not candidates:
+            return None
         if as_of is None:
             newest = max(candidates, key=lambda p: (p.stat().st_mtime, p.name))
         else:

--- a/Main/backend/api/signals_views.py
+++ b/Main/backend/api/signals_views.py
@@ -75,6 +75,8 @@ def _load_artifact(as_of=None):
                           if (d := _stem_date(p)) is not None and d <= as_of]
         if not candidates:
             return None
+        # stat() stays inside the try in both branches: a file pruned between
+        # glob() and stat() fails closed, never 500s.
         if as_of is None:
             newest = max(candidates, key=lambda p: (p.stat().st_mtime, p.name))
         else:

--- a/Main/backend/api/signals_views.py
+++ b/Main/backend/api/signals_views.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 _PUBLIC_STRIP = ("generator", "model", "prompt_version")
 
 
-def _load_latest():
+def _load_artifact():
     configured = getattr(settings, "SIGNALS_DIR", "")
     if not configured:
         return None
@@ -66,7 +66,7 @@ def _get_artifact(request: HttpRequest):
     """One disk load per request: @condition calls _etag and _last_modified
     before the view body runs, and all three need the artifact."""
     if not hasattr(request, "_signals_artifact"):
-        request._signals_artifact = _load_latest()
+        request._signals_artifact = _load_artifact()
     return request._signals_artifact
 
 

--- a/Main/backend/api/signals_views.py
+++ b/Main/backend/api/signals_views.py
@@ -6,12 +6,16 @@ signals-*.json (newest by mtime, filename as a deterministic tiebreak —
 same-day supplemental stems sort lexicographically before the date-only
 stem, so stem order alone is not recency) from settings.SIGNALS_DIR, minus
 generator/model/prompt_version, plus server-computed staleness_hours.
+An optional ?as_of=YYYY-MM-DD selects the newest artifact dated on or before
+that day (point-in-time — no lookahead, robust to gaps); a malformed value is
+a 400 {"error": "bad_as_of"}.
 Every failure path is a 404 {"error": "no_signals"} — never a 500 leaking
 pipeline state.
 """
 import json
 import logging
-from datetime import datetime, timezone
+import re
+from datetime import date, datetime, timezone
 from pathlib import Path
 from urllib.parse import quote
 
@@ -26,8 +30,33 @@ logger = logging.getLogger(__name__)
 
 _PUBLIC_STRIP = ("generator", "model", "prompt_version")
 
+_AS_OF_RE = re.compile(r"\A\d{4}-\d{2}-\d{2}\Z")
 
-def _load_artifact():
+
+def _as_of(request: HttpRequest):
+    """Parse ?as_of=YYYY-MM-DD. Returns None (param absent) or a datetime.date.
+    Raises ValueError on any malformed value — the view maps that to a 400."""
+    raw = request.GET.get("as_of")
+    if not raw:
+        return None
+    if not _AS_OF_RE.match(raw):
+        raise ValueError(f"as_of must be YYYY-MM-DD, got {raw!r}")
+    return date.fromisoformat(raw)  # also rejects impossible dates (e.g. 2026-13-40)
+
+
+def _stem_date(path: Path):
+    """The leading YYYY-MM-DD of a signals-<...>.json filename, or None for a
+    non-dated stem (e.g. signals-a.json). ?as_of resolves by the date a batch
+    is *for* (its filename stem), reusing the (mtime, name) tiebreak below for
+    same-day supplemental reruns."""
+    head = path.name[len("signals-"):len("signals-") + 10]
+    try:
+        return date.fromisoformat(head)
+    except ValueError:
+        return None
+
+
+def _load_artifact(as_of=None):
     configured = getattr(settings, "SIGNALS_DIR", "")
     if not configured:
         return None
@@ -35,18 +64,25 @@ def _load_artifact():
     if not directory.is_dir():
         return None
     candidates = list(directory.glob("signals-*.json"))
+    if as_of is not None:
+        # Point-in-time: keep only artifacts whose batch date is on or before
+        # as_of. Non-dated stems (_stem_date is None) are skipped.
+        candidates = [p for p in candidates
+                      if (d := _stem_date(p)) is not None and d <= as_of]
     if not candidates:
         return None
     newest = None
     try:
-        # Newest by mtime, filename as a deterministic tiebreak: same-day
-        # supplemental stems (items-<date>-<HHMMSS>.jsonl ->
-        # signals-<date>-<HHMMSS>.json) sort lexicographically BEFORE the
-        # date-only stem ("." > "-" in ASCII), so stem order alone is not
-        # recency — a same-day re-run would otherwise serve the stale
-        # artifact. stat() stays inside the try: a file pruned between
-        # glob() and stat() fails closed, never 500s.
-        newest = max(candidates, key=lambda p: (p.stat().st_mtime, p.name))
+        if as_of is None:
+            newest = max(candidates, key=lambda p: (p.stat().st_mtime, p.name))
+        else:
+            # Calendar order first: a backfilled/reprocessed older-day
+            # artifact (rewritten in place -> fresh mtime) must never outrank
+            # a newer-dated artifact inside the as_of window; (mtime, name)
+            # stays the same-day-supplemental tiebreak. Every candidate here
+            # has a non-None stem date (filtered above).
+            newest = max(candidates, key=lambda p: (
+                _stem_date(p), p.stat().st_mtime, p.name))
         artifact = json.loads(newest.read_text(encoding="utf-8"))
         generated = datetime.fromisoformat(artifact["generated_at"])
         if generated.tzinfo is None:
@@ -64,9 +100,16 @@ def _load_artifact():
 
 def _get_artifact(request: HttpRequest):
     """One disk load per request: @condition calls _etag and _last_modified
-    before the view body runs, and all three need the artifact."""
+    before the view body runs, and all three need the artifact. A malformed
+    ?as_of resolves to None here so the conditional validators never raise;
+    the view re-parses and returns 400."""
     if not hasattr(request, "_signals_artifact"):
-        request._signals_artifact = _load_artifact()
+        try:
+            as_of = _as_of(request)
+        except ValueError:
+            request._signals_artifact = None
+        else:
+            request._signals_artifact = _load_artifact(as_of)
     return request._signals_artifact
 
 
@@ -109,6 +152,10 @@ def _last_modified(request: HttpRequest):
            method=ALL, block=True)
 @condition(etag_func=_etag, last_modified_func=_last_modified)
 def news_signals(request: HttpRequest) -> JsonResponse:
+    try:
+        _as_of(request)
+    except ValueError:
+        return JsonResponse({'error': 'bad_as_of'}, status=400)
     artifact = _get_artifact(request)
     if artifact is None:
         return JsonResponse({'error': 'no_signals'}, status=404)

--- a/Main/backend/tests/test_signals_endpoint.py
+++ b/Main/backend/tests/test_signals_endpoint.py
@@ -370,3 +370,12 @@ class SignalsEndpointTests(SimpleTestCase):
             resp = self.client.get(URL, {"as_of": "2026-07-05", "tickers": "msft"})
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(list(resp.json()["signals"]), ["MSFT"])
+
+    def test_empty_as_of_400s(self):
+        # ?as_of= (present but empty) must not silently serve the latest
+        # artifact — that is the lookahead bias as_of exists to prevent.
+        self._write("2026-07-06", make_artifact(self._recent_iso(1.0)))
+        with override_settings(SIGNALS_DIR=str(self.dir), **_HERMETIC):
+            resp = self.client.get(URL + "?as_of=")
+        self.assertEqual(resp.status_code, 400)
+        self.assertEqual(resp.json(), {"error": "bad_as_of"})

--- a/Main/backend/tests/test_signals_endpoint.py
+++ b/Main/backend/tests/test_signals_endpoint.py
@@ -209,8 +209,8 @@ class SignalsEndpointTests(SimpleTestCase):
         # without per-request memoization one GET pays 3x glob+stat+read.
         self._write("2026-07-06", make_artifact(self._recent_iso()))
         with override_settings(SIGNALS_DIR=str(self.dir), **_HERMETIC), \
-             mock.patch.object(signals_views, "_load_latest",
-                               wraps=signals_views._load_latest) as loader:
+             mock.patch.object(signals_views, "_load_artifact",
+                               wraps=signals_views._load_artifact) as loader:
             resp = self.client.get(URL)
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(loader.call_count, 1)

--- a/Main/backend/tests/test_signals_endpoint.py
+++ b/Main/backend/tests/test_signals_endpoint.py
@@ -268,3 +268,105 @@ class SignalsEndpointTests(SimpleTestCase):
         self.assertEqual(plain.status_code, 404)
         self.assertEqual(filtered.status_code, 404)
         self.assertEqual(filtered.json(), {"error": "no_signals"})
+
+    def test_as_of_serves_that_days_artifact(self):
+        self._write("2026-07-05", make_artifact(self._recent_iso(50.0), signals={
+            "MSFT": dict(DEFAULT_SIGNAL, guid="d05")}))
+        self._write("2026-07-06", make_artifact(self._recent_iso(1.0), signals={
+            "MSFT": dict(DEFAULT_SIGNAL, guid="d06")}))
+        with override_settings(SIGNALS_DIR=str(self.dir), **_HERMETIC):
+            resp = self.client.get(URL, {"as_of": "2026-07-05"})
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json()["signals"]["MSFT"]["guid"], "d05")
+
+    def test_as_of_falls_back_to_nearest_earlier_on_gap(self):
+        # No 07-05 artifact; point-in-time on-or-before resolves to 07-03.
+        self._write("2026-07-03", make_artifact(self._recent_iso(80.0), signals={
+            "MSFT": dict(DEFAULT_SIGNAL, guid="d03")}))
+        self._write("2026-07-06", make_artifact(self._recent_iso(1.0), signals={
+            "MSFT": dict(DEFAULT_SIGNAL, guid="d06")}))
+        with override_settings(SIGNALS_DIR=str(self.dir), **_HERMETIC):
+            resp = self.client.get(URL, {"as_of": "2026-07-05"})
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json()["signals"]["MSFT"]["guid"], "d03")
+
+    def test_as_of_before_all_history_404s(self):
+        self._write("2026-07-06", make_artifact(self._recent_iso(1.0)))
+        with override_settings(SIGNALS_DIR=str(self.dir), **_HERMETIC):
+            resp = self.client.get(URL, {"as_of": "2026-07-01"})
+        self.assertEqual(resp.status_code, 404)
+        self.assertEqual(resp.json(), {"error": "no_signals"})
+
+    def test_malformed_as_of_400s(self):
+        self._write("2026-07-06", make_artifact(self._recent_iso(1.0)))
+        with override_settings(SIGNALS_DIR=str(self.dir), **_HERMETIC):
+            for bad in ("2026-7-5", "07-05-2026", "yesterday",
+                        "2026-13-40", "2026-07-06T00:00:00", "2026/07/06"):
+                resp = self.client.get(URL, {"as_of": bad})
+                self.assertEqual(resp.status_code, 400, bad)
+                self.assertEqual(resp.json(), {"error": "bad_as_of"}, bad)
+
+    def test_as_of_in_future_returns_latest(self):
+        self._write("2026-07-05", make_artifact(self._recent_iso(50.0), signals={
+            "MSFT": dict(DEFAULT_SIGNAL, guid="d05")}))
+        self._write("2026-07-06", make_artifact(self._recent_iso(1.0), signals={
+            "MSFT": dict(DEFAULT_SIGNAL, guid="d06")}))
+        with override_settings(SIGNALS_DIR=str(self.dir), **_HERMETIC):
+            resp = self.client.get(URL, {"as_of": "2027-01-01"})
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json()["signals"]["MSFT"]["guid"], "d06")
+
+    def test_as_of_picks_newest_same_day_supplemental_by_mtime(self):
+        morning = make_artifact(self._recent_iso(8.0), signals={
+            "MSFT": dict(DEFAULT_SIGNAL, guid="morning")})
+        supplemental = make_artifact(self._recent_iso(0.1), signals={
+            "MSFT": dict(DEFAULT_SIGNAL, guid="supplemental")})
+        self._write("2026-07-06", morning)
+        supp = self.dir / "signals-2026-07-06-153042.json"
+        supp.write_text(json.dumps(supplemental), encoding="utf-8")
+        now = time.time()
+        os.utime(self.dir / "signals-2026-07-06.json", (now - 100, now - 100))
+        os.utime(supp, (now, now))
+        with override_settings(SIGNALS_DIR=str(self.dir), **_HERMETIC):
+            resp = self.client.get(URL, {"as_of": "2026-07-06"})
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json()["signals"]["MSFT"]["guid"], "supplemental")
+
+    def test_as_of_prefers_newer_stem_date_over_newer_mtime(self):
+        # Backfill/reprocess skew: an older-day artifact rewritten in place
+        # gets a fresh mtime; the correctly-dated 07-05 artifact must still
+        # win under as_of=2026-07-05 (calendar order beats mtime).
+        self._write("2026-07-05", make_artifact(self._recent_iso(50.0), signals={
+            "MSFT": dict(DEFAULT_SIGNAL, guid="d05")}))
+        self._write("2026-07-03", make_artifact(self._recent_iso(80.0), signals={
+            "MSFT": dict(DEFAULT_SIGNAL, guid="d03-backfilled")}))
+        now = time.time()
+        os.utime(self.dir / "signals-2026-07-05.json", (now - 100, now - 100))
+        os.utime(self.dir / "signals-2026-07-03.json", (now, now))
+        with override_settings(SIGNALS_DIR=str(self.dir), **_HERMETIC):
+            resp = self.client.get(URL, {"as_of": "2026-07-05"})
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json()["signals"]["MSFT"]["guid"], "d05")
+
+    def test_as_of_etag_tracks_resolved_artifact(self):
+        self._write("2026-07-05", make_artifact(self._recent_iso(50.0)))
+        self._write("2026-07-06", make_artifact(self._recent_iso(1.0)))
+        with override_settings(SIGNALS_DIR=str(self.dir), **_HERMETIC):
+            e05 = self.client.get(URL, {"as_of": "2026-07-05"})["ETag"]
+            e06 = self.client.get(URL, {"as_of": "2026-07-06"})["ETag"]
+            # A future as_of resolves to the same artifact as 07-06 -> its ETag
+            # revalidates with a 304.
+            revalidated = self.client.get(URL, {"as_of": "2027-01-01"},
+                                          HTTP_IF_NONE_MATCH=e06)
+        self.assertNotEqual(e05, e06)
+        self.assertEqual(revalidated.status_code, 304)
+
+    def test_as_of_composes_with_tickers_filter(self):
+        self._write("2026-07-05", make_artifact(self._recent_iso(50.0), signals={
+            "MSFT": dict(DEFAULT_SIGNAL),
+            "AAPL": dict(DEFAULT_SIGNAL, guid="g2")}))
+        self._write("2026-07-06", make_artifact(self._recent_iso(1.0)))
+        with override_settings(SIGNALS_DIR=str(self.dir), **_HERMETIC):
+            resp = self.client.get(URL, {"as_of": "2026-07-05", "tickers": "msft"})
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(list(resp.json()["signals"]), ["MSFT"])


### PR DESCRIPTION
## Summary
- Adds optional `?as_of=YYYY-MM-DD` to `GET /api/signals/news/`: serves the newest signals artifact whose filename stem-date is on or before that day (point-in-time, no lookahead) so ATL's backtester can key fetches to historical dates.
- Selection under `as_of` orders candidates by `(stem_date, mtime, name)` — calendar date first, so a backfilled/reprocessed older day (fresh mtime) never outranks a newer day; `(mtime, name)` remains the same-day-supplemental tiebreak. The no-param path is byte-for-byte unchanged.
- Fail-closed: malformed or empty `as_of` → `400 {"error": "bad_as_of"}`; date before all retained artifacts → `404 {"error": "no_signals"}`; future date → latest. No new response keys; ETag stays keyed on the resolved artifact so conditional GET is as-of-correct with no scheme change.
- Documents the parameter (incl. UTC batch dates + retention-bounded history depth `SIGNALS_KEEP_N`) in the §4.4 endpoint contract.

## Test plan
- [x] `uv run pytest tests/test_signals_endpoint.py -q` — 27 passed (17 existing + 10 new), pristine
- [x] Full backend suite `uv run pytest tests -q` — 675 passed, 1 skipped, 38 subtests
- [x] Final whole-branch review (adversarial): 16 probes through the live middleware stack — zero 500s, no 304/cache poisoning, unicode-digit/leap-day/null-byte/100KB-junk inputs all 400

Plan: `Docs/superpowers/plans/2026-07-10-signals-asof-endpoint.md`. Design: `Docs/superpowers/specs/2026-07-10-signals-asof-and-dow30-reconcile-design.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)