### PR TITLE
feat(heartbeat): codify Dow-30 watchlist + parity test; reconcile aliases

### DIFF
--- a/Heartbeat/.env.heartbeat.example
+++ b/Heartbeat/.env.heartbeat.example
@@ -13,7 +13,10 @@ HEARTBEAT_MODEL=gpt-4o-mini
 
 # Pipeline
 HEARTBEAT_DRY_RUN=1
-HEARTBEAT_WATCHLIST=AAPL MSFT NVDA GOOGL AMZN META TSLA BRK-B JPM BTC-USD
+# Optional override. The code default is Dow-30 ∪ extras (34 tickers), defined
+# as DOW_30/WATCHLIST_EXTRAS in news_signals.py + news_heartbeat.py. Leave unset
+# to track the code default; set only to hot-patch the universe without a deploy.
+# HEARTBEAT_WATCHLIST=AAPL AMGN AMZN AXP BA BRK-B BTC-USD CAT CRM CSCO CVX DIS GOOGL GS HD HON IBM JNJ JPM KO MCD META MMM MRK MSFT NKE NVDA PG SHW TRV TSLA UNH V WMT
 HEARTBEAT_WINDOW_HOURS=24
 HEARTBEAT_HOME=/home/deploy/fingpt/heartbeat
 

--- a/Heartbeat/README.md
+++ b/Heartbeat/README.md
@@ -105,11 +105,13 @@ Deploy (droplet, systemd --user, mirrors the heartbeat):
     ssh finsearch-deploy 'systemctl --user daemon-reload &&
       systemctl --user enable --now finsearch-signals.timer finsearch-signals-canary.timer'
 
-Universe change (spec D2) — set on the droplet in
-`~/fingpt/envs/.env.heartbeat` (35 tickers: heartbeat default ∪ DJIA-30;
-ATL's bogus `AMEX` slot is deliberately excluded — it can never have data):
-
-    HEARTBEAT_WATCHLIST=AAPL AMZN AXP BA BRK-B BTC-USD CAT CSCO CVX DIS GOOGL GS HD IBM INTC JNJ JPM KO MA MCD META MMM MRK MSFT NKE NVDA PFE PG TRV TSLA UNH V WBA WMT XOM
+Universe (spec 2026-07-10) — the watchlist is defined **in code** as
+`DOW_30 ∪ WATCHLIST_EXTRAS` (34 tickers) in `news_signals.py` and
+`news_heartbeat.py` (parity-tested in `tests/test_watchlist.py`). The droplet
+does **not** set `HEARTBEAT_WATCHLIST`; the code default drives it, so changing
+the universe is a one-line edit + a normal deploy. `HEARTBEAT_WATCHLIST` remains
+an optional emergency override (space-separated) if you must hot-patch without a
+deploy.
 
 Staging checklist (run once at deploy time, spec §9):
 1. Drop two items files back-to-back; `systemctl --user start finsearch-signals.service`;

--- a/Heartbeat/news_heartbeat.py
+++ b/Heartbeat/news_heartbeat.py
@@ -41,7 +41,19 @@ MARKET_FEEDS = {
 }
 TICKER_FEED = ("https://feeds.finance.yahoo.com/rss/2.0/headline"
                "?s={ticker}&region=US&lang=en-US")
-DEFAULT_WATCHLIST = "AAPL MSFT NVDA GOOGL AMZN META TSLA BRK-B JPM BTC-USD"
+# Dow Jones Industrial Average constituents.
+# Source: S&P Dow Jones Indices; effective 2026-06-29 (GOOGL replaced VZ).
+# Reconcile against the official index — never a hand-maintained copy — when
+# the composition changes. Parity-tested against news_heartbeat.py
+# (Heartbeat/tests/test_watchlist.py). To add/remove a ticker, edit one list.
+DOW_30 = [
+    "AAPL", "AMGN", "AMZN", "AXP", "BA", "CAT", "CRM", "CSCO", "CVX", "DIS",
+    "GOOGL", "GS", "HD", "HON", "IBM", "JNJ", "JPM", "KO", "MCD", "MMM",
+    "MRK", "MSFT", "NKE", "NVDA", "PG", "SHW", "TRV", "UNH", "V", "WMT",
+]
+# Non-Dow tickers FinSearch also tracks for its own community digests.
+WATCHLIST_EXTRAS = ["META", "TSLA", "BRK-B", "BTC-USD"]
+DEFAULT_WATCHLIST = " ".join(sorted(set(DOW_30) | set(WATCHLIST_EXTRAS)))
 DISCLAIMER = ("Summaries by Agentic FinSearch · Sources: Yahoo Finance & linked "
               "publishers · Not financial advice")
 

--- a/Heartbeat/news_heartbeat.py
+++ b/Heartbeat/news_heartbeat.py
@@ -45,7 +45,8 @@ TICKER_FEED = ("https://feeds.finance.yahoo.com/rss/2.0/headline"
 # Source: S&P Dow Jones Indices; effective 2026-06-29 (GOOGL replaced VZ).
 # Reconcile against the official index — never a hand-maintained copy — when
 # the composition changes. Parity-tested against news_heartbeat.py
-# (Heartbeat/tests/test_watchlist.py). To add/remove a ticker, edit one list.
+# (Heartbeat/tests/test_watchlist.py). To add/remove a ticker, edit this
+# list and its TICKER_ALIASES entry (news_signals.py only; test-enforced).
 DOW_30 = [
     "AAPL", "AMGN", "AMZN", "AXP", "BA", "CAT", "CRM", "CSCO", "CVX", "DIS",
     "GOOGL", "GS", "HD", "HON", "IBM", "JNJ", "JPM", "KO", "MCD", "MMM",

--- a/Heartbeat/news_signals.py
+++ b/Heartbeat/news_signals.py
@@ -32,7 +32,8 @@ PROMPT_VERSION = 1
 # Source: S&P Dow Jones Indices; effective 2026-06-29 (GOOGL replaced VZ).
 # Reconcile against the official index — never a hand-maintained copy — when
 # the composition changes. Parity-tested against news_heartbeat.py
-# (Heartbeat/tests/test_watchlist.py). To add/remove a ticker, edit one list.
+# (Heartbeat/tests/test_watchlist.py). To add/remove a ticker, edit this
+# list and its TICKER_ALIASES entry (news_signals.py only; test-enforced).
 DOW_30 = [
     "AAPL", "AMGN", "AMZN", "AXP", "BA", "CAT", "CRM", "CSCO", "CVX", "DIS",
     "GOOGL", "GS", "HD", "HON", "IBM", "JNJ", "JPM", "KO", "MCD", "MMM",

--- a/Heartbeat/news_signals.py
+++ b/Heartbeat/news_signals.py
@@ -24,7 +24,7 @@ import urllib.request
 from datetime import datetime, timezone
 from pathlib import Path
 
-VERSION = "2026-07-06.1"
+VERSION = "2026-07-10.1"
 SCHEMA_VERSION = 1
 PROMPT_VERSION = 1
 

--- a/Heartbeat/news_signals.py
+++ b/Heartbeat/news_signals.py
@@ -28,7 +28,19 @@ VERSION = "2026-07-06.1"
 SCHEMA_VERSION = 1
 PROMPT_VERSION = 1
 
-DEFAULT_WATCHLIST = "AAPL MSFT NVDA GOOGL AMZN META TSLA BRK-B JPM BTC-USD"
+# Dow Jones Industrial Average constituents.
+# Source: S&P Dow Jones Indices; effective 2026-06-29 (GOOGL replaced VZ).
+# Reconcile against the official index — never a hand-maintained copy — when
+# the composition changes. Parity-tested against news_heartbeat.py
+# (Heartbeat/tests/test_watchlist.py). To add/remove a ticker, edit one list.
+DOW_30 = [
+    "AAPL", "AMGN", "AMZN", "AXP", "BA", "CAT", "CRM", "CSCO", "CVX", "DIS",
+    "GOOGL", "GS", "HD", "HON", "IBM", "JNJ", "JPM", "KO", "MCD", "MMM",
+    "MRK", "MSFT", "NKE", "NVDA", "PG", "SHW", "TRV", "UNH", "V", "WMT",
+]
+# Non-Dow tickers FinSearch also tracks for its own community digests.
+WATCHLIST_EXTRAS = ["META", "TSLA", "BRK-B", "BTC-USD"]
+DEFAULT_WATCHLIST = " ".join(sorted(set(DOW_30) | set(WATCHLIST_EXTRAS)))
 REQUIRED_FIELDS = ("guid", "title", "link", "source", "published", "score")
 FIELD_CAPS = {"title": 500, "description": 5000, "link": 2000, "source": 200,
               "guid": 200}
@@ -196,21 +208,21 @@ ROUNDUP_RE = [re.compile(p) for p in ROUNDUP_PATTERNS]
 # Lowercase name tokens per ticker (union watchlist, spec D2). Symbols shorter
 # than SYMBOL_MATCH_MIN_LEN rely on aliases alone. >>> OWNER-TUNED.
 TICKER_ALIASES = {
-    "AAPL": ("apple",), "AMZN": ("amazon",),
+    "AAPL": ("apple",), "AMGN": ("amgen",), "AMZN": ("amazon",),
     "AXP": ("american express", "amex"), "BA": ("boeing",),
     "BRK-B": ("berkshire",), "BTC-USD": ("bitcoin",),
-    "CAT": ("caterpillar",), "CSCO": ("cisco",), "CVX": ("chevron",),
-    "DIS": ("disney",), "GOOGL": ("google", "alphabet"),
-    "GS": ("goldman",), "HD": ("home depot",), "IBM": ("ibm",),
-    "INTC": ("intel",), "JNJ": ("johnson & johnson",),
+    "CAT": ("caterpillar",), "CRM": ("salesforce",), "CSCO": ("cisco",),
+    "CVX": ("chevron",), "DIS": ("disney",), "GOOGL": ("google", "alphabet"),
+    "GS": ("goldman",), "HD": ("home depot",), "HON": ("honeywell",),
+    "IBM": ("ibm",), "JNJ": ("johnson & johnson",),
     "JPM": ("jpmorgan", "jp morgan"), "KO": ("coca-cola",),
-    "MA": ("mastercard",), "MCD": ("mcdonald",),
+    "MCD": ("mcdonald",),
     "META": ("meta platforms", "facebook", "instagram"), "MMM": ("3m",),
     "MRK": ("merck",), "MSFT": ("microsoft",), "NKE": ("nike",),
-    "NVDA": ("nvidia",), "PFE": ("pfizer",), "PG": ("procter",),
+    "NVDA": ("nvidia",), "PG": ("procter",),
+    "SHW": ("sherwin-williams", "sherwin williams"),
     "TRV": ("travelers",), "TSLA": ("tesla",), "UNH": ("unitedhealth",),
-    "V": ("visa",), "WBA": ("walgreens",), "WMT": ("walmart",),
-    "XOM": ("exxon",),
+    "V": ("visa",), "WMT": ("walmart",),
 }
 SYMBOL_MATCH_MIN_LEN = 3
 

--- a/Heartbeat/tests/fixtures/signals-fixture.json
+++ b/Heartbeat/tests/fixtures/signals-fixture.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "profile": "default",
   "generated_at": "2026-07-06T15:00:00+00:00",
-  "generator": "news_signals.py/2026-07-06.1",
+  "generator": "news_signals.py/2026-07-10.1",
   "model": "gpt-4o-mini",
   "prompt_version": 1,
   "source_items": "items-fixture.jsonl",

--- a/Heartbeat/tests/test_news_signals.py
+++ b/Heartbeat/tests/test_news_signals.py
@@ -285,17 +285,15 @@ class TestSubjectGate(unittest.TestCase):
 
     def test_alias_match_is_word_bounded_not_substring(self):
         # A naive `alias in lowered` substring check false-matches company
-        # aliases embedded inside unrelated words. All three are real words
+        # aliases embedded inside unrelated words. Both are real words
         # that show up routinely in financial headlines.
-        self.assertFalse(ns.is_subject(
-            "This Magnificent Artificial Intelligence Stock Rallies", "INTC"))
         self.assertFalse(ns.is_subject(
             "San Francisco Fed officials weigh in on rate path", "CSCO"))
         self.assertFalse(ns.is_subject(
             "Analysts say the merger looks advisable for shareholders", "V"))
         # genuine mentions must still pass once word-bounded
-        self.assertTrue(ns.is_subject("Intel unveils new AI chip", "INTC"))
         self.assertTrue(ns.is_subject("Cisco beats on earnings", "CSCO"))
+        self.assertTrue(ns.is_subject("Visa fees draw new scrutiny", "V"))
 
     def test_alias_3m_does_not_match_bare_dollar_or_share_figures(self):
         # "3m" is the only way to catch prose that names the company as "3M"

--- a/Heartbeat/tests/test_watchlist.py
+++ b/Heartbeat/tests/test_watchlist.py
@@ -1,0 +1,70 @@
+"""Watchlist single-source-of-truth + cross-file parity (spec 2026-07-10).
+
+DOW_30 is duplicated in news_signals.py and news_heartbeat.py by design — the
+heartbeat is stdlib-only, single-file per script, so there is no shared module.
+This test is the anti-drift guard, same discipline as the schema-parity test.
+"""
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import news_signals as ns
+import news_heartbeat as nh
+
+# Current Dow-30, verified 2026-07-10 (S&P DJI, effective 2026-06-29).
+EXPECTED_DOW_30 = {
+    "AAPL", "AMGN", "AMZN", "AXP", "BA", "CAT", "CRM", "CSCO", "CVX", "DIS",
+    "GOOGL", "GS", "HD", "HON", "IBM", "JNJ", "JPM", "KO", "MCD", "MMM",
+    "MRK", "MSFT", "NKE", "NVDA", "PG", "SHW", "TRV", "UNH", "V", "WMT",
+}
+# Stale / erroneous tickers that must never reappear (the pre-fix bug set,
+# incl. DOW — the ticket wrongly wanted it, but it left the index in 2024).
+FORBIDDEN = {"AMEX", "DOW", "INTC", "MA", "PFE", "WBA", "XOM", "VZ"}
+
+
+class TestWatchlistParity(unittest.TestCase):
+    def test_dow30_matches_across_both_scripts(self):
+        self.assertEqual(ns.DOW_30, nh.DOW_30)
+
+    def test_extras_match_across_both_scripts(self):
+        self.assertEqual(ns.WATCHLIST_EXTRAS, nh.WATCHLIST_EXTRAS)
+
+    def test_default_watchlist_matches_across_both_scripts(self):
+        self.assertEqual(ns.DEFAULT_WATCHLIST, nh.DEFAULT_WATCHLIST)
+
+    def test_dow30_is_exactly_the_current_index(self):
+        self.assertEqual(set(ns.DOW_30), EXPECTED_DOW_30)
+        self.assertEqual(len(ns.DOW_30), 30)
+        self.assertEqual(len(set(ns.DOW_30)), 30)          # unique
+        self.assertTrue(all(t == t.upper() for t in ns.DOW_30))
+
+    def test_no_stale_or_erroneous_tickers(self):
+        self.assertEqual(set(ns.DOW_30) & FORBIDDEN, set())
+        self.assertEqual(set(ns.WATCHLIST_EXTRAS) & FORBIDDEN, set())
+
+    def test_extras_are_disjoint_from_dow30(self):
+        self.assertEqual(set(ns.WATCHLIST_EXTRAS) & set(ns.DOW_30), set())
+
+    def test_default_watchlist_is_sorted_union_of_34(self):
+        expected = " ".join(sorted(set(ns.DOW_30) | set(ns.WATCHLIST_EXTRAS)))
+        self.assertEqual(ns.DEFAULT_WATCHLIST, expected)
+        self.assertEqual(len(ns.DEFAULT_WATCHLIST.split()), 34)
+
+    def test_reconcile_additions_present(self):
+        for t in ("AMGN", "CRM", "HON", "SHW"):
+            self.assertIn(t, ns.DOW_30, t)
+
+    def test_ticker_aliases_cover_exactly_the_watchlist(self):
+        # news_signals-only: the subject-relevance gate (spec D8) matches
+        # name-based headlines through TICKER_ALIASES, so a ticker in the
+        # watchlist but not the alias table is only half-added (and
+        # warn_alias_gaps WARNs every sweep). Set EQUALITY also proves the
+        # stale INTC/MA/PFE/WBA/XOM aliases are gone.
+        union = set(ns.DOW_30) | set(ns.WATCHLIST_EXTRAS)
+        self.assertEqual(set(ns.TICKER_ALIASES), union)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Codifies the news watchlist in code as `DOW_30` (current Dow-30, S&P DJI effective 2026-06-29: +GOOGL −VZ; verified against the S&P press release) ∪ `WATCHLIST_EXTRAS` (META TSLA BRK-B BTC-USD) = 34 tickers. The blocks are byte-identical in `news_signals.py` and `news_heartbeat.py` (stdlib-only single-file deploy contract — no shared module), guarded by a new 9-test parity suite (`Heartbeat/tests/test_watchlist.py`).
- Reconciles `TICKER_ALIASES` in lockstep: adds AMGN/CRM/HON/SHW, removes stale INTC/MA/PFE/WBA/XOM; table is now set-equal to the watchlist (test-enforced). The word-boundary alias test retargets its fixture from removed INTC to surviving CSCO/V aliases.
- `.env.heartbeat.example` + README: `HEARTBEAT_WATCHLIST` is now a commented optional override; the code default is the source of truth.
- Bumps `VERSION` to `2026-07-10.1` (artifact provenance across the reconcile) and regenerates the golden fixture per its documented flow.

## Deploy-window note (expected, not a regression)
The droplet's stale 35-ticker `HEARTBEAT_WATCHLIST` override masks the new code default until the separate Part-C runbook removes it, so the watchlist itself does not change at deploy time. The alias table DOES apply immediately: between this deploy and Part C, `warn_alias_gaps` will WARN for INTC/MA/PFE/WBA/XOM on every non-empty sweep (journald-only), and name-based tagging for those five outgoing tickers stops. Run Part C promptly after the deploy goes green.

## Test plan
- [x] `python3 -m unittest discover -s tests` from Heartbeat/ — 147/147 OK (CI runs the same invocation)
- [x] Watchlist parity suite 9/9; DOW_30 verified char-by-char against S&P ground truth by two independent reviewers
- [x] Final whole-branch review: env-override precedence unchanged (explicitly tested), no import-time watchlist reads, stdlib-only compat preserved

Plan: `Docs/superpowers/plans/2026-07-10-dow30-watchlist-reconcile.md` (Part A). Design: `Docs/superpowers/specs/2026-07-10-signals-asof-and-dow30-reconcile-design.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)