### PR TITLE
fix(heartbeat): calendar-aware artifact retention (stem date before mtime)

### DIFF
--- a/Docs/superpowers/plans/2026-07-10-signals-asof-dow30-deferred.md
+++ b/Docs/superpowers/plans/2026-07-10-signals-asof-dow30-deferred.md
@@ -10,7 +10,15 @@ Deferred-items log for the 2026-07-10 plan pair (`2026-07-10-signals-asof-endpoi
 
 **Why deferred:** D1 — the producer is untouched by PR #340 (`git diff origin/main...feat/signals-asof -- Heartbeat/` was empty); the design spec deliberately scoped retention out (spec §"backfilled/reprocessed" note). Pre-existing property of PR #339.
 
-**Next-session entry point:** `Heartbeat/news_signals.py:607` — align the prune sort with `(stem_date, mtime, name)` (mirroring `Main/backend/api/signals_views.py:_load_artifact`), or document mtime-based retention in the §4.4 contract. Effort: ~1h incl. a regression test.
+**Resolution (2026-07-11):** option (a) taken — `prune_artifacts` now sorts by `(stem_date, mtime, name)` via a producer-side `_stem_date` twin (name-string input); 3 `TestPrune` additions; VERSION `2026-07-11.1` + fixture regen; §4.4 retention sentence amended. The canary's staleness notion stays pure-mtime by design.
+
+### §PR-A.3 — Pre-existing ResourceWarning: unclosed `.lock` file in heartbeat suite
+
+**Status: deferred 2026-07-11 (found during §PR-A.1 execution; pre-existing on main, verified via `git stash` A/B run)**
+
+**What:** `TestMain.test_held_lock_exits_three` emits 3× `ResourceWarning: unclosed file ...signals/.lock` in the full heartbeat suite run. Unrelated to the §PR-A.1 change; breaks pristine-output discipline the same way §PR-A.2 did for the backend suite.
+
+**Next-session entry point:** `Heartbeat/tests/test_news_signals.py` (`TestMain.test_held_lock_exits_three`) — close or context-manage the lock file handle the test (or the code path it exercises) leaves open. Effort: ~15 min.
 
 ### §PR-A.2 — Flaky pre-existing DeprecationWarning in test output
 

--- a/Docs/superpowers/plans/2026-07-10-signals-asof-dow30-deferred.md
+++ b/Docs/superpowers/plans/2026-07-10-signals-asof-dow30-deferred.md
@@ -4,7 +4,7 @@ Deferred-items log for the 2026-07-10 plan pair (`2026-07-10-signals-asof-endpoi
 
 ### §PR-A.1 — Producer retention (`prune_artifacts`) is mtime-ordered, not calendar-aware
 
-**Status: deferred 2026-07-11 in PR #340 (defer rule D1 — unrelated module untouched by the PR)**
+**Status: RESOLVED 2026-07-11 — prune sort aligned with `(stem_date, mtime, name)` (option a), branch `fix/prune-calendar-aware`.**
 
 **What:** `Heartbeat/news_signals.py:598-613` prunes to `SIGNALS_KEEP_N` newest artifacts by raw `(mtime, name)`. After an old day's artifact is rewritten in place with a fresh mtime (state-file surgery, or crash-recovery reprocessing after extended downtime), the next prune (needs ≥15 artifacts on disk) can evict a calendar-newer artifact while keeping the backfilled older day — a `?as_of=<evicted day>` then 404s for a date inside the nominal retention window. Verified CONFIRMED but narrow: no automated path reprocesses a state-recorded items file; PR A's read path is already hardened (`(stem_date, mtime, name)` selection).
 

--- a/Docs/superpowers/specs/2026-07-06-news-to-signals-pipeline-design.md
+++ b/Docs/superpowers/specs/2026-07-06-news-to-signals-pipeline-design.md
@@ -169,8 +169,11 @@ A machine-readable JSON Schema ships at `Heartbeat/schemas/signals-v1.schema.jso
   A date earlier than all retained artifacts → `404 {"error": "no_signals"}`;
   a future date → the latest dated artifact; a malformed value → `400 {"error":
   "bad_as_of"}`. History depth is bounded by retention (`SIGNALS_KEEP_N`,
-  default 14 dated artifacts): a date older than the oldest retained artifact
-  404s identically to "never produced" — callers cannot distinguish the two
+  default 14 dated artifacts; since 2026-07-11 the producer prunes by the
+  same `(stem date, mtime, name)` order as resolution, so a backfilled older
+  day can never evict a calendar-newer artifact from the window): a date
+  older than the oldest retained artifact 404s identically to "never
+  produced" — callers cannot distinguish the two
   from the response alone. The per-date ticker set is whatever the watchlist
   was when that artifact was produced — it can change across the retained
   window (e.g. a watchlist deploy). Callers detect a gap by comparing the

--- a/Heartbeat/news_signals.py
+++ b/Heartbeat/news_signals.py
@@ -21,10 +21,10 @@ import time
 import unicodedata
 import urllib.error
 import urllib.request
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from pathlib import Path
 
-VERSION = "2026-07-10.1"
+VERSION = "2026-07-11.1"
 SCHEMA_VERSION = 1
 PROMPT_VERSION = 1
 
@@ -608,16 +608,39 @@ def _list_signals_artifacts(signals_dir):
     return out
 
 
+def _stem_date(name):
+    """The leading YYYY-MM-DD of a signals-<...>.json filename, or None for a
+    non-dated stem. Mirrors Main/backend/api/signals_views.py:_stem_date
+    (which takes a Path) so retention ranks artifacts exactly the way the
+    read path resolves ?as_of."""
+    head = name[len("signals-"):len("signals-") + 10]
+    try:
+        return date.fromisoformat(head)
+    except ValueError:
+        return None
+
+
 def prune_artifacts(cfg):
     """Rolling retention cap (spec 2026-07-10): keep only the newest
     cfg["keep_n"] signals-*.json artifacts, unlink the rest. Ordered by
-    (mtime, name) descending so "most recent" matches the canary's staleness
-    notion, with name as a deterministic tiebreaker. Best-effort: a failed
-    unlink logs a WARN and is skipped — the artifacts are already durably
-    written, so cleanup failure must not fail the sweep. signals_state.json is
-    left untouched by design (deleting a state entry would invite reprocessing).
-    Runs under the sweep's flock, so no concurrent sweep races it."""
-    artifacts = sorted(_list_signals_artifacts(cfg["signals_dir"]), reverse=True)
+    (stem date, mtime, name) descending — calendar date first, mirroring the
+    read path's ?as_of selection (signals_views._load_artifact) — so an older
+    day rewritten in place with a fresh mtime (state-file surgery,
+    crash-recovery reprocessing) can never evict a calendar-newer artifact
+    from the retention window (deferred item §PR-A.1). (mtime, name) stays
+    the same-day-supplemental tiebreak; non-dated stems (unreachable from
+    this producer) rank oldest and are pruned first. The canary's staleness
+    notion stays pure-mtime — staleness is about write recency, retention
+    about calendar coverage. Best-effort: a failed unlink logs a WARN and is
+    skipped — the artifacts are already durably written, so cleanup failure
+    must not fail the sweep. signals_state.json is left untouched by design
+    (deleting a state entry would invite reprocessing). Runs under the
+    sweep's flock, so no concurrent sweep races it."""
+    artifacts = sorted(
+        _list_signals_artifacts(cfg["signals_dir"]),
+        key=lambda t: (_stem_date(t[1]) or date.min, t[0], t[1]),
+        reverse=True,
+    )
     for _, _, p in artifacts[cfg["keep_n"]:]:
         try:
             p.unlink()

--- a/Heartbeat/tests/fixtures/signals-fixture.json
+++ b/Heartbeat/tests/fixtures/signals-fixture.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "profile": "default",
   "generated_at": "2026-07-06T15:00:00+00:00",
-  "generator": "news_signals.py/2026-07-10.1",
+  "generator": "news_signals.py/2026-07-11.1",
   "model": "gpt-4o-mini",
   "prompt_version": 1,
   "source_items": "items-fixture.jsonl",

--- a/Heartbeat/tests/test_news_signals.py
+++ b/Heartbeat/tests/test_news_signals.py
@@ -872,6 +872,46 @@ class TestPrune(unittest.TestCase):
         # signals-1 is the sole survivor within keep_n=1.
         self.assertTrue((self.cfg["signals_dir"] / "signals-1.json").exists())
 
+    def test_prune_is_calendar_aware_backfill_cannot_evict_newer_day(self):
+        # §PR-A.1 regression: an old day's artifact rewritten in place
+        # (state-file surgery / crash-recovery reprocessing -> fresh mtime)
+        # must not outrank calendar-newer artifacts at prune time; otherwise
+        # ?as_of=<evicted day> 404s inside the nominal retention window.
+        self.cfg["keep_n"] = 2
+        base = 1_700_000_000
+        self._make_artifact("signals-2026-07-08.json", base + 1)
+        self._make_artifact("signals-2026-07-09.json", base + 2)
+        # oldest calendar day, but backfilled -> newest mtime
+        self._make_artifact("signals-2026-07-07.json", base + 99)
+        ns.prune_artifacts(self.cfg)
+        remaining = sorted(p.name for p in self.cfg["signals_dir"].glob("signals-*.json"))
+        self.assertEqual(
+            remaining, ["signals-2026-07-08.json", "signals-2026-07-09.json"])
+
+    def test_prune_non_dated_stems_rank_oldest(self):
+        # Unreachable from this producer (all stems are date-prefixed), but a
+        # hand-placed non-dated stem must not crash the sort and must rank
+        # oldest (pruned first) regardless of mtime — mirroring the read
+        # path's "latest dated artifact" contract (spec §4.4).
+        self.cfg["keep_n"] = 1
+        base = 1_700_000_000
+        self._make_artifact("signals-2026-07-09.json", base)
+        self._make_artifact("signals-manual.json", base + 99)
+        ns.prune_artifacts(self.cfg)
+        remaining = [p.name for p in self.cfg["signals_dir"].glob("signals-*.json")]
+        self.assertEqual(remaining, ["signals-2026-07-09.json"])
+
+    def test_prune_same_day_supplementals_tiebreak_by_mtime(self):
+        # Pin (passes before and after): same stem date falls back to mtime,
+        # matching the read path's same-day-supplemental tiebreak.
+        self.cfg["keep_n"] = 1
+        base = 1_700_000_000
+        self._make_artifact("signals-2026-07-09.json", base + 5)
+        self._make_artifact("signals-2026-07-09-supplemental.json", base + 9)
+        ns.prune_artifacts(self.cfg)
+        remaining = [p.name for p in self.cfg["signals_dir"].glob("signals-*.json")]
+        self.assertEqual(remaining, ["signals-2026-07-09-supplemental.json"])
+
 
 import fcntl
 


### PR DESCRIPTION
Resolves deferred item **§PR-A.1** (`Docs/superpowers/plans/2026-07-10-signals-asof-dow30-deferred.md`).

## Problem

`prune_artifacts` kept the newest `SIGNALS_KEEP_N` artifacts by raw `(mtime, name)`. An old day's artifact rewritten in place with a fresh mtime (state-file surgery, crash-recovery reprocessing) could evict a calendar-newer artifact — making the API's `?as_of=<evicted day>` 404 for a date inside the nominal retention window, while the backfilled older day survived.

## Fix

Retention now sorts by `(stem_date, mtime, name)` descending — the exact selection key the read path uses for `?as_of` resolution (`Main/backend/api/signals_views.py:_load_artifact`) — via a producer-side `_stem_date(name)` twin. Non-dated stems (unreachable from this producer) rank oldest and prune first, matching the §4.4 "latest dated artifact" contract. The canary's staleness notion stays pure-mtime by design (staleness = write recency; retention = calendar coverage). `_list_signals_artifacts`'s `(mtime, name, path)` tuple shape is untouched for its canary consumer.

- 3 new `TestPrune` regression tests (backfill-cannot-evict, non-dated-ranks-oldest, same-day-supplemental mtime tiebreak pin); RED verified before implementation
- VERSION `2026-07-10.1` → `2026-07-11.1` + golden fixture regen (generator line only)
- Spec §4.4 retention sentence amended; deferred log updated (§PR-A.1 RESOLVED, new §PR-A.3 records a pre-existing unrelated ResourceWarning found during this work)

## Tests

Full heartbeat suite 150/150 (was 147), stdlib-only. Task review: Approved, sort math hand-traced. Final ship-gate review: READY TO MERGE, zero Critical/Important findings; confirmed the new sort key is total (no new throw surface, no new stat() calls) and the mid-listing vanish race handling is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017JHuWqq62JsJtDFa64TT1X