### PR TITLE
fix(api): remove deprecated asyncio.get_event_loop() from runtime paths

### DIFF
--- a/Docs/superpowers/plans/2026-07-10-signals-asof-dow30-deferred.md
+++ b/Docs/superpowers/plans/2026-07-10-signals-asof-dow30-deferred.md
@@ -14,13 +14,21 @@ Deferred-items log for the 2026-07-10 plan pair (`2026-07-10-signals-asof-endpoi
 
 ### §PR-A.2 — Flaky pre-existing DeprecationWarning in test output
 
-**Status: RESOLVED 2026-07-11 — `get_running_loop()` with quiet-zero fallback, branch `fix/resource-monitor-event-loop`.**
+**Status: RESOLVED 2026-07-11 — `get_running_loop()` with quiet-zero fallback, branch `fix/resource-monitor-event-loop`. Extension: twin `views.py:565/748` save/restore captures fixed in the same PR; remaining call sites logged as §PR-A.4.**
 
 **What:** `Main/backend/api/utils/resource_monitor.py:63` — `asyncio.get_event_loop()` raises `DeprecationWarning: There is no current event loop` during `test_artifact_loaded_from_disk_once_per_request` in some runs (nondeterministic; also the lone warning in the 675-test full-suite run). Breaks pristine-output discipline.
 
 **Why deferred:** D1 — `resource_monitor.py` is untouched by PR #340; the triggering test predates the branch.
 
 **Next-session entry point:** `Main/backend/api/utils/resource_monitor.py:63` — replace with `asyncio.get_running_loop()` inside try/except or `asyncio.new_event_loop()` per intent. Effort: ~15 min.
+
+### §PR-A.4 — Two remaining get_event_loop call sites with get-or-create semantics
+
+**Status: deferred 2026-07-11 (found during §PR-A.2 execution; neither warns in the current suite)**
+
+**What:** `Main/backend/datascraper/openai_search.py:794` and `Main/backend/mcp_client/mcp_manager.py:73` still call `asyncio.get_event_loop()`. Unlike the fixed sites, these *rely* on get-or-create semantics (`mcp_manager` stores `self._loop` for later use), so a mechanical `get_running_loop()` swap could change behavior; each needs its own intent analysis. Python 3.14 makes the implicit creation an error, so these must be revisited before any 3.14 upgrade.
+
+**Next-session entry point:** trace how `openai_search.py:794`'s `loop` and `mcp_manager.py:73`'s `self._loop` are consumed; replace with explicit `new_event_loop()`/`asyncio.run()` ownership or a running-loop requirement per intent. Effort: ~1h.
 
 ### Triage log — reviewed and intentionally not changed (not deferrals)
 

--- a/Docs/superpowers/plans/2026-07-10-signals-asof-dow30-deferred.md
+++ b/Docs/superpowers/plans/2026-07-10-signals-asof-dow30-deferred.md
@@ -14,7 +14,7 @@ Deferred-items log for the 2026-07-10 plan pair (`2026-07-10-signals-asof-endpoi
 
 ### §PR-A.2 — Flaky pre-existing DeprecationWarning in test output
 
-**Status: deferred 2026-07-11 in PR #340 (defer rule D1 — unrelated module untouched by the PR)**
+**Status: RESOLVED 2026-07-11 — `get_running_loop()` with quiet-zero fallback, branch `fix/resource-monitor-event-loop`.**
 
 **What:** `Main/backend/api/utils/resource_monitor.py:63` — `asyncio.get_event_loop()` raises `DeprecationWarning: There is no current event loop` during `test_artifact_loaded_from_disk_once_per_request` in some runs (nondeterministic; also the lone warning in the 675-test full-suite run). Breaks pristine-output discipline.
 

--- a/Main/backend/api/utils/resource_monitor.py
+++ b/Main/backend/api/utils/resource_monitor.py
@@ -60,9 +60,14 @@ class ResourceSnapshot:
     def _get_asyncio_task_count(self) -> int:
         """Get count of running asyncio tasks."""
         try:
-            loop = asyncio.get_event_loop()
-            tasks = asyncio.all_tasks(loop)
-            return len(tasks)
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            # No running loop in this thread (sync context) -> no tasks.
+            # asyncio.get_event_loop() here would emit DeprecationWarning
+            # ("There is no current event loop") and create a stray loop.
+            return 0
+        try:
+            return len(asyncio.all_tasks(loop))
         except Exception:
             return 0
 

--- a/Main/backend/api/views.py
+++ b/Main/backend/api/views.py
@@ -565,9 +565,11 @@ def chat_response_stream(request: HttpRequest) -> StreamingHttpResponse:
                 # loop is ever *running* in this sync streaming path, and
                 # get_event_loop()'s only extra behavior was auto-creating a
                 # throwaway loop (with a DeprecationWarning) merely to be
-                # saved and restored. Nothing in this backend sets a
-                # not-running loop on worker threads, so restoring None
-                # (= unset) is the correct, Python-3.14-forward binding.
+                # saved and restored. The only not-running bindings a worker
+                # thread can carry here are *closed* loops (datascraper's
+                # sync wrappers close theirs without unsetting), so restoring
+                # None (= unset) never discards a usable binding — the
+                # correct, Python-3.14-forward behavior.
                 try:
                     previous_loop = asyncio.get_running_loop()
                 except RuntimeError:
@@ -755,9 +757,11 @@ def adv_response_stream(request: HttpRequest) -> StreamingHttpResponse:
                 # loop is ever *running* in this sync streaming path, and
                 # get_event_loop()'s only extra behavior was auto-creating a
                 # throwaway loop (with a DeprecationWarning) merely to be
-                # saved and restored. Nothing in this backend sets a
-                # not-running loop on worker threads, so restoring None
-                # (= unset) is the correct, Python-3.14-forward binding.
+                # saved and restored. The only not-running bindings a worker
+                # thread can carry here are *closed* loops (datascraper's
+                # sync wrappers close theirs without unsetting), so restoring
+                # None (= unset) never discards a usable binding — the
+                # correct, Python-3.14-forward behavior.
                 try:
                     previous_loop = asyncio.get_running_loop()
                 except RuntimeError:

--- a/Main/backend/api/views.py
+++ b/Main/backend/api/views.py
@@ -560,9 +560,16 @@ def chat_response_stream(request: HttpRequest) -> StreamingHttpResponse:
                     session_id=session_id,
                 )
 
-                previous_loop = None
+                # Save the thread's loop binding to restore in the finally.
+                # get_running_loop(), not deprecated get_event_loop(): no
+                # loop is ever *running* in this sync streaming path, and
+                # get_event_loop()'s only extra behavior was auto-creating a
+                # throwaway loop (with a DeprecationWarning) merely to be
+                # saved and restored. Nothing in this backend sets a
+                # not-running loop on worker threads, so restoring None
+                # (= unset) is the correct, Python-3.14-forward binding.
                 try:
-                    previous_loop = asyncio.get_event_loop()
+                    previous_loop = asyncio.get_running_loop()
                 except RuntimeError:
                     previous_loop = None
 
@@ -743,9 +750,16 @@ def adv_response_stream(request: HttpRequest) -> StreamingHttpResponse:
                     user_time=params.get('user_time')
                 )
 
-                previous_loop = None
+                # Save the thread's loop binding to restore in the finally.
+                # get_running_loop(), not deprecated get_event_loop(): no
+                # loop is ever *running* in this sync streaming path, and
+                # get_event_loop()'s only extra behavior was auto-creating a
+                # throwaway loop (with a DeprecationWarning) merely to be
+                # saved and restored. Nothing in this backend sets a
+                # not-running loop on worker threads, so restoring None
+                # (= unset) is the correct, Python-3.14-forward binding.
                 try:
-                    previous_loop = asyncio.get_event_loop()
+                    previous_loop = asyncio.get_running_loop()
                 except RuntimeError:
                     previous_loop = None
 

--- a/Main/backend/tests/test_resource_snapshot_enhanced.py
+++ b/Main/backend/tests/test_resource_snapshot_enhanced.py
@@ -1,4 +1,5 @@
 """Tests for enhanced ResourceSnapshot with USS and GC stats."""
+import os
 import pytest
 
 
@@ -63,3 +64,27 @@ def test_to_dict_includes_new_fields():
     assert 'uss_mb' in d
     assert 'gc_counts' in d
     assert 'gc_uncollectable' in d
+
+
+# ── asyncio task count tests (§PR-A.2) ─────────────────────────────
+
+def test_asyncio_task_count_sync_context_is_quiet_zero(recwarn):
+    """§PR-A.2 regression: asyncio.get_event_loop() in a thread with no set
+    loop emitted 'DeprecationWarning: There is no current event loop'
+    (nondeterministically — it depends on whether an earlier test left a
+    loop set). get_running_loop() never warns: no running loop -> 0."""
+    from api.utils.resource_monitor import ResourceSnapshot
+    snap = ResourceSnapshot.__new__(ResourceSnapshot)
+    snap.pid = os.getpid()
+    assert snap._get_asyncio_task_count() == 0
+    assert [w for w in recwarn.list
+            if issubclass(w.category, DeprecationWarning)] == []
+
+
+async def test_asyncio_task_count_inside_running_loop_counts_current_task():
+    """The happy path still counts tasks on the running loop (at least the
+    task executing this test)."""
+    from api.utils.resource_monitor import ResourceSnapshot
+    snap = ResourceSnapshot.__new__(ResourceSnapshot)
+    snap.pid = os.getpid()
+    assert snap._get_asyncio_task_count() >= 1


### PR DESCRIPTION
Resolves deferred item **§PR-A.2** (`Docs/superpowers/plans/2026-07-10-signals-asof-dow30-deferred.md`) plus its discovered twin sites — the backend's 678-test suite is now warning-free.

## Changes

1. **`api/utils/resource_monitor.py`** — `_get_asyncio_task_count()` used deprecated `asyncio.get_event_loop()`, which nondeterministically emitted `DeprecationWarning: There is no current event loop` during suite runs. Now `get_running_loop()` with an explicit quiet-zero fallback (sync context → 0, same value as before, minus the warning). 2 new tests pin both branches (RED reproduced pre-fix).
2. **`api/views.py`** — the twin streaming save/restore blocks captured `previous_loop` via `get_event_loop()`, whose only extra behavior was auto-creating a throwaway loop (with a warning) merely to save and restore it. Now `get_running_loop()` → `None`; the existing `finally: set_event_loop(previous_loop)` is untouched. Verified against source: the only not-running bindings worker threads can carry are *closed* loops (datascraper's sync wrappers close without unsetting), so restoring `None` never discards a usable binding — and both remaining `get_event_loop` consumers were traced to identical runtime outcomes either way (`openai_search.py` converges to `asyncio.run()` for every non-running binding; `mcp_manager.py`'s call is inside `async def`).
3. **Deferred log** — §PR-A.2 marked resolved; new **§PR-A.4** records the two deliberately-untouched call sites with get-or-create/store semantics (`datascraper/openai_search.py:794`, `mcp_client/mcp_manager.py:73`) for per-module intent analysis before any Python 3.14 upgrade.

## Tests

Full suite 678 passed / 1 skipped / 38 subtests, **no warnings block** (verified across independent runs). Task review: Approved, spec-verbatim. Final ship-gate review: READY TO MERGE — all downstream consumers of both edited paths traced to observational-only or byte-identical behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017JHuWqq62JsJtDFa64TT1X