### PR TITLE
fix(api): retire the last two asyncio.get_event_loop() call sites (§PR-A.4)

### DIFF
--- a/Docs/superpowers/plans/2026-07-10-signals-asof-dow30-deferred.md
+++ b/Docs/superpowers/plans/2026-07-10-signals-asof-dow30-deferred.md
@@ -32,7 +32,7 @@ Deferred-items log for the 2026-07-10 plan pair (`2026-07-10-signals-asof-endpoi
 
 ### §PR-A.4 — Two remaining get_event_loop call sites with get-or-create semantics
 
-**Status: deferred 2026-07-11 (found during §PR-A.2 execution; neither warns in the current suite)**
+**Status: RESOLVED 2026-07-11 — intent-split per site, branch `fix/event-loop-hygiene`. `mcp_manager.py:73` runs inside a coroutine, so the get-or-create semantics never engaged: it borrows the running loop (`get_running_loop()`) for `run_async_from_sync`'s cross-thread bridge. `openai_search.py:794`'s sync wrapper collapsed to guard + `asyncio.run()`: both reachable paths already ended in `asyncio.run` (Django WSGI worker threads have no loop), and the `is_running()` branch was broken-by-construction — `run_coroutine_threadsafe` rejects a Task with TypeError, and `.result()` from the loop's own thread would deadlock. The guard raises before building the coroutine so misuse from async context gets a clear RuntimeError with no abandoned-coroutine RuntimeWarning. AST sentinel (`tests/test_event_loop_hygiene.py`) pins zero `get_event_loop` call sites across backend runtime code — the 3.14-readiness criterion — plus behavior pins for both replacements.**
 
 **What:** `Main/backend/datascraper/openai_search.py:794` and `Main/backend/mcp_client/mcp_manager.py:73` still call `asyncio.get_event_loop()`. Unlike the fixed sites, these *rely* on get-or-create semantics (`mcp_manager` stores `self._loop` for later use), so a mechanical `get_running_loop()` swap could change behavior; each needs its own intent analysis. Python 3.14 makes the implicit creation an error, so these must be revisited before any 3.14 upgrade.
 

--- a/Main/backend/datascraper/openai_search.py
+++ b/Main/backend/datascraper/openai_search.py
@@ -790,44 +790,29 @@ def create_responses_api_search(
     if async_client is None:
         raise RuntimeError("OPENAI_API_KEY is not configured; cannot execute OpenAI search.")
 
+    # Guard before building the coroutine: asyncio.run would raise the same
+    # error but abandon its argument (RuntimeWarning: coroutine never
+    # awaited). Callers already inside a loop must await the async API.
     try:
-        loop = asyncio.get_event_loop()
-        if loop.is_running():
-            task = asyncio.create_task(
-                create_responses_api_search_async(
-                    user_query,
-                    message_history,
-                    model,
-                    preferred_links,
-                    stream=False,
-                    user_timezone=user_timezone,
-                    user_time=user_time
-                )
-            )
-            return asyncio.run_coroutine_threadsafe(task, loop).result()
-        return asyncio.run(
-            create_responses_api_search_async(
-                user_query,
-                message_history,
-                model,
-                preferred_links,
-                stream=False,
-                user_timezone=user_timezone,
-                user_time=user_time
-            )
-        )
+        asyncio.get_running_loop()
     except RuntimeError:
-        return asyncio.run(
-            create_responses_api_search_async(
-                user_query,
-                message_history,
-                model,
-                preferred_links,
-                stream=False,
-                user_timezone=user_timezone,
-                user_time=user_time
-            )
+        pass
+    else:
+        raise RuntimeError(
+            "create_responses_api_search() cannot be called from a running "
+            "event loop — await create_responses_api_search_async() instead."
         )
+    return asyncio.run(
+        create_responses_api_search_async(
+            user_query,
+            message_history,
+            model,
+            preferred_links,
+            stream=False,
+            user_timezone=user_timezone,
+            user_time=user_time
+        )
+    )
 
 
 def format_sources_for_frontend(

--- a/Main/backend/mcp_client/mcp_manager.py
+++ b/Main/backend/mcp_client/mcp_manager.py
@@ -70,7 +70,10 @@ class MCPClientManager:
 
         self._log("[MCP DEBUG] Starting MCP server connection loop...")
 
-        self._loop = asyncio.get_event_loop()
+        # Captured for run_async_from_sync's cross-thread submissions; must
+        # be the loop this coroutine (and _run_servers) runs on, so borrow
+        # the running loop — never a policy get-or-create.
+        self._loop = asyncio.get_running_loop()
 
         self._stop_event.clear()
         self._servers_ready.clear()

--- a/Main/backend/tests/test_event_loop_hygiene.py
+++ b/Main/backend/tests/test_event_loop_hygiene.py
@@ -28,6 +28,18 @@ def _runtime_python_files():
                 yield Path(dirpath) / name
 
 
+def _binds_get_event_loop(node):
+    # Both spellings: `<anything>.get_event_loop` (module attribute, however
+    # aliased) and `from asyncio[.events] import get_event_loop` (a bare-Name
+    # call site the Attribute match can't see, so flag the import itself).
+    if isinstance(node, ast.Attribute):
+        return node.attr == "get_event_loop"
+    if isinstance(node, ast.ImportFrom):
+        return (node.module or "").split(".")[0] == "asyncio" and any(
+            alias.name == "get_event_loop" for alias in node.names)
+    return False
+
+
 def test_no_get_event_loop_in_runtime_code():
     """Structural sentinel (§PR-A.4): asyncio.get_event_loop() must not
     return to runtime code. Its get-or-create semantics become a hard error
@@ -38,13 +50,25 @@ def test_no_get_event_loop_in_runtime_code():
     for path in _runtime_python_files():
         tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
         for node in ast.walk(tree):
-            if isinstance(node, ast.Attribute) and node.attr == "get_event_loop":
+            if _binds_get_event_loop(node):
                 offenders.append(
                     f"{path.relative_to(BACKEND_DIR)}:{node.lineno}")
     assert offenders == [], (
         "get_event_loop() call sites found (implicit loop creation breaks "
         "on Python 3.14): " + ", ".join(offenders)
     )
+
+
+@pytest.mark.parametrize("snippet", [
+    "import asyncio\nloop = asyncio.get_event_loop()\n",
+    "import asyncio as aio\nloop = aio.get_event_loop()\n",
+    "from asyncio import get_event_loop\nloop = get_event_loop()\n",
+    "from asyncio.events import get_event_loop\n",
+])
+def test_sentinel_catches_every_spelling(snippet):
+    # Guards the guard: each way of reaching get_event_loop must trip the
+    # predicate, or the sentinel silently stops covering that spelling.
+    assert any(_binds_get_event_loop(n) for n in ast.walk(ast.parse(snippet)))
 
 
 async def test_connect_to_servers_captures_running_loop(tmp_path):

--- a/Main/backend/tests/test_event_loop_hygiene.py
+++ b/Main/backend/tests/test_event_loop_hygiene.py
@@ -8,6 +8,7 @@ replacements and structurally guard against the deprecated idiom returning.
 """
 import ast
 import asyncio
+import os
 from pathlib import Path
 
 import pytest
@@ -17,10 +18,14 @@ _EXCLUDED_PARTS = {"tests", ".venv", "__pycache__", "node_modules"}
 
 
 def _runtime_python_files():
-    for path in BACKEND_DIR.rglob("*.py"):
-        if _EXCLUDED_PARTS & set(path.relative_to(BACKEND_DIR).parts):
-            continue
-        yield path
+    # os.walk so excluded trees are pruned before descent: rglob("*.py")
+    # would enumerate all ~10k files under .venv only to discard them,
+    # which costs ~a minute per run on drvfs/9p-mounted checkouts (WSL).
+    for dirpath, dirnames, filenames in os.walk(BACKEND_DIR):
+        dirnames[:] = [d for d in dirnames if d not in _EXCLUDED_PARTS]
+        for name in filenames:
+            if name.endswith(".py"):
+                yield Path(dirpath) / name
 
 
 def test_no_get_event_loop_in_runtime_code():

--- a/Main/backend/tests/test_event_loop_hygiene.py
+++ b/Main/backend/tests/test_event_loop_hygiene.py
@@ -1,0 +1,98 @@
+"""§PR-A.4 — event-loop ownership: the last asyncio.get_event_loop() sites.
+
+Python 3.14 turns get_event_loop()'s implicit get-or-create into an error,
+so runtime code must declare its loop ownership explicitly: borrow the
+current loop with get_running_loop() inside coroutines, or own a private
+loop with asyncio.run() at sync entry points. These tests pin both
+replacements and structurally guard against the deprecated idiom returning.
+"""
+import ast
+import asyncio
+from pathlib import Path
+
+import pytest
+
+BACKEND_DIR = Path(__file__).resolve().parent.parent
+_EXCLUDED_PARTS = {"tests", ".venv", "__pycache__", "node_modules"}
+
+
+def _runtime_python_files():
+    for path in BACKEND_DIR.rglob("*.py"):
+        if _EXCLUDED_PARTS & set(path.relative_to(BACKEND_DIR).parts):
+            continue
+        yield path
+
+
+def test_no_get_event_loop_in_runtime_code():
+    """Structural sentinel (§PR-A.4): asyncio.get_event_loop() must not
+    return to runtime code. Its get-or-create semantics become a hard error
+    on Python 3.14, and every legitimate use here is either
+    get_running_loop() (inside a coroutine) or asyncio.run() (sync entry
+    point). AST-based so comments discussing the old idiom stay legal."""
+    offenders = []
+    for path in _runtime_python_files():
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Attribute) and node.attr == "get_event_loop":
+                offenders.append(
+                    f"{path.relative_to(BACKEND_DIR)}:{node.lineno}")
+    assert offenders == [], (
+        "get_event_loop() call sites found (implicit loop creation breaks "
+        "on Python 3.14): " + ", ".join(offenders)
+    )
+
+
+async def test_connect_to_servers_captures_running_loop(tmp_path):
+    """The manager's cross-thread bridge (run_async_from_sync →
+    run_coroutine_threadsafe) needs the exact loop the manager's tasks run
+    on; connect_to_servers must capture the running loop, never a policy
+    fallback."""
+    from mcp_client.mcp_manager import MCPClientManager
+
+    mgr = MCPClientManager(config_path=str(tmp_path / "absent.json"),
+                           verbose=False)
+    try:
+        await mgr.connect_to_servers()
+        assert mgr._loop is asyncio.get_running_loop()
+    finally:
+        await mgr.cleanup()
+
+
+def test_sync_search_wrapper_runs_coroutine_from_sync_context(
+        monkeypatch, recwarn):
+    """The wrapper's one job: run the async search to completion from a
+    plain sync context (Django WSGI worker thread) and hand back its
+    result — without the 'no current event loop' DeprecationWarning the
+    old get_event_loop() path emitted from the main thread."""
+    from datascraper import openai_search
+
+    async def fake_search(*args, **kwargs):
+        return ("answer", [{"url": "https://example.com"}])
+
+    monkeypatch.setattr(
+        openai_search, "create_responses_api_search_async", fake_search)
+    monkeypatch.setattr(openai_search, "async_client", object())
+    result = openai_search.create_responses_api_search("q", [])
+    assert result == ("answer", [{"url": "https://example.com"}])
+    assert [w for w in recwarn.list
+            if "event loop" in str(w.message)] == []
+
+
+async def test_sync_search_wrapper_refuses_running_loop(monkeypatch):
+    """Called from async context, the sync wrapper must fail fast with a
+    clear contract error pointing at the async API. The old code path
+    raised TypeError from run_coroutine_threadsafe(Task) — and would have
+    deadlocked on .result() had it gotten further. The guard must also
+    fire BEFORE the coroutine is built, so no abandoned-coroutine
+    RuntimeWarning leaks into suite output."""
+    from datascraper import openai_search
+
+    async def fake_search(*args, **kwargs):  # pragma: no cover — never runs
+        return ("unreachable", [])
+
+    monkeypatch.setattr(
+        openai_search, "create_responses_api_search_async", fake_search)
+    monkeypatch.setattr(openai_search, "async_client", object())
+    with pytest.raises(RuntimeError,
+                       match="create_responses_api_search_async"):
+        openai_search.create_responses_api_search("q", [])


### PR DESCRIPTION
## What

The last two runtime `asyncio.get_event_loop()` call sites (§PR-A.4 in the deferred-items log) — Python 3.14 turns its implicit get-or-create into a hard error, so both had to be replaced per their actual intent before any 3.14 upgrade.

## Intent analysis & fixes

**`mcp_client/mcp_manager.py:73`** — `connect_to_servers()` is a coroutine, so the get-or-create semantics never actually engaged; it always got the running loop. The intent is "capture the loop my tasks run on for `run_async_from_sync`'s cross-thread `run_coroutine_threadsafe` bridge" → `asyncio.get_running_loop()`. Zero behavior change, now explicit and 3.14-proof.

**`datascraper/openai_search.py:794`** — the sync wrapper's three-branch loop dance collapsed to guard + `asyncio.run()`:
- Both *reachable* paths already ended in `asyncio.run` (Django WSGI worker threads have no loop → `RuntimeError` → the fallback branch; a fetched non-running loop was simply unused — and on the main thread, leaked).
- The `is_running()` branch was broken-by-construction: `run_coroutine_threadsafe` rejects a `Task` with `TypeError` (verified empirically), and had it accepted one, `.result()` from the loop's own thread would deadlock.
- The new guard raises **before** building the coroutine, so async-context misuse gets a clear `RuntimeError` pointing at `create_responses_api_search_async()` instead of an abandoned-coroutine `RuntimeWarning` (also verified: `asyncio.run` abandons its argument when refused).

## Tests (`tests/test_event_loop_hygiene.py`)

- **AST sentinel**: zero `get_event_loop` call sites across backend runtime code — the 3.14-readiness acceptance criterion; watched fail on main listing exactly the two sites.
- **Behavior pin**: `connect_to_servers` captures exactly the running loop.
- **Behavior pin**: sync wrapper runs the coroutine from a plain sync context, no event-loop DeprecationWarning.
- **Contract**: called from a running loop → clear `RuntimeError` (watched fail on main with the old `TypeError`).

Full backend suite: **682 passed, 1 skipped, 38 subtests — warning-free** (was 678 + 4 new).

Closes §PR-A.4 in `Docs/superpowers/plans/2026-07-10-signals-asof-dow30-deferred.md` (status updated in this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017JHuWqq62JsJtDFa64TT1X