### PR TITLE
fix(build): keep bleach's [css] extra through the uv override (F-1)

### DIFF
--- a/Main/backend/pyproject.toml
+++ b/Main/backend/pyproject.toml
@@ -71,7 +71,10 @@ override-dependencies = [
     "idna>=3.15",              # GHSA: CVE-2024-3651 fix bypass via crafted inputs
     "authlib>=1.6.12",         # GHSA: OIDC open redirect in implicit/hybrid flow
     "cryptography>=48.0.1",    # GHSA: vulnerable OpenSSL bundled in wheels (via authlib)
-    "bleach>=6.4.0",           # GHSA: formaction URI bypass + Unicode scheme sanitization gap
+    # [css] is load-bearing: overrides REPLACE nbconvert's `bleach[css]` requirement,
+    # and dropping the extra loses tinycss2 -> nbconvert crashes at import (NameError:
+    # ALLOWED_STYLES in its no-css-sanitizer fallback path), breaking the docs build.
+    "bleach[css]>=6.4.0",      # GHSA: formaction URI bypass + Unicode scheme sanitization gap
     "starlette>=1.3.1",        # GHSA: form-limit DoS, UNC SSRF, host poisoning, getattr dispatch (via mcp)
 ]
 

--- a/Main/backend/uv.lock
+++ b/Main/backend/uv.lock
@@ -11,7 +11,7 @@ resolution-markers = [
 [manifest]
 overrides = [
     { name = "authlib", specifier = ">=1.6.12" },
-    { name = "bleach", specifier = ">=6.4.0" },
+    { name = "bleach", extras = ["css"], specifier = ">=6.4.0" },
     { name = "cryptography", specifier = ">=48.0.1" },
     { name = "idna", specifier = ">=3.15" },
     { name = "protobuf", specifier = ">=6.33.5" },
@@ -174,6 +174,11 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/48/3c/e12ac860709702bd5ebeb9b56a4fe334f1001246ee1b8f2b7ee28912df7d/bleach-6.4.0.tar.gz", hash = "sha256:4202482733d85cedd04e59fcb2f89f4e4c7c385a78d3c3c23c30446843a37452", size = 204857, upload-time = "2026-06-05T13:01:13.734Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/58/9d/40b6267367182187139a4000b82a3b287d84d745bccd808e75d916920e9d/bleach-6.4.0-py3-none-any.whl", hash = "sha256:4b6b6a54fff2e69a3dde9d21cc6301220bee3c3cb792187d11403fd795031081", size = 165109, upload-time = "2026-06-05T13:01:12.504Z" },
+]
+
+[package.optional-dependencies]
+css = [
+    { name = "tinycss2" },
 ]
 
 [[package]]
@@ -1291,7 +1296,7 @@ version = "7.17.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beautifulsoup4" },
-    { name = "bleach" },
+    { name = "bleach", extra = ["css"] },
     { name = "defusedxml" },
     { name = "jinja2" },
     { name = "jupyter-core" },
@@ -2351,6 +2356,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a3/fe/26df24ce53ffde419a42f5f53d755b995c9318908288c17ec3f3448313a3/tiktoken-0.12.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:35a2f8ddd3824608b3d650a000c1ef71f730d0c56486845705a8248da00f9fe5", size = 1194230, upload-time = "2025-10-06T20:21:57.546Z" },
     { url = "https://files.pythonhosted.org/packages/20/cc/b064cae1a0e9fac84b0d2c46b89f4e57051a5f41324e385d10225a984c24/tiktoken-0.12.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:83d16643edb7fa2c99eff2ab7733508aae1eebb03d5dfc46f5565862810f24e3", size = 1254688, upload-time = "2025-10-06T20:21:58.619Z" },
     { url = "https://files.pythonhosted.org/packages/81/10/b8523105c590c5b8349f2587e2fdfe51a69544bd5a76295fc20f2374f470/tiktoken-0.12.0-cp312-cp312-win_amd64.whl", hash = "sha256:ffc5288f34a8bc02e1ea7047b8d041104791d2ddbf42d1e5fa07822cbffe16bd", size = 878694, upload-time = "2025-10-06T20:21:59.876Z" },
+]
+
+[[package]]
+name = "tinycss2"
+version = "1.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "webencodings" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/ae/2ca4913e5c0f09781d75482874c3a95db9105462a92ddd303c7d285d3df2/tinycss2-1.5.1.tar.gz", hash = "sha256:d339d2b616ba90ccce58da8495a78f46e55d4d25f9fd71dfd526f07e7d53f957", size = 88195, upload-time = "2025-11-23T10:29:10.082Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/45/c7b5c3168458db837e8ceab06dc77824e18202679d0463f0e8f002143a97/tinycss2-1.5.1-py3-none-any.whl", hash = "sha256:3415ba0f5839c062696996998176c4a3751d18b7edaaeeb658c9ce21ec150661", size = 28404, upload-time = "2025-11-23T10:29:08.676Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
The docs dependency group has been unbuildable locally: `uv sync --group docs` + `sphinx-build` crashed at import with `NameError: ALLOWED_STYLES` inside nbconvert (logged as **F-1** in `Docs/superpowers/plans/2026-07-12-hosted-docs-refresh.md`).

**Root cause** (differs from the F-1 log's "old nbconvert" hypothesis — nbconvert is already 7.17.1): `[tool.uv] override-dependencies` REPLACE requirements graph-wide, so the bare `bleach>=6.4.0` security floor erased nbconvert's `bleach[css]` extra, `tinycss2` was never resolved, and nbconvert's no-css-sanitizer fallback path crashes at import time.

**Fix**: re-state the extra in the override — `bleach[css]>=6.4.0`. The security floor is unchanged; the lock diff is `tinycss2` alone. A comment in `pyproject.toml` marks the extra as load-bearing so a future security bump doesn't quietly drop it again.

## Verification
- `uv lock` re-resolve: `Added tinycss2 v1.5.1`, nothing else changed.
- `import nbsphinx` succeeds from the backend venv.
- Full `sphinx-build -b html` of `Docs/source` with nbsphinx **enabled**: build succeeded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MpjVcdhE4vq5CSEY7xmnpf