### PR TITLE
docs: hosted-docs follow-ups from the 2026-07-12 refresh (F-3, F-5..F-8)

### DIFF
--- a/Docs/plans/2026-02-02-deployment-readiness-audit.md
+++ b/Docs/plans/2026-02-02-deployment-readiness-audit.md
@@ -33,6 +33,7 @@ Production system experiencing:
 
 4. **Context Manager State**
    - UnifiedContextManager + Mem0 accumulate session data
+     *(2026-07 note: Mem0 has since been removed entirely — PR #347; only UnifiedContextManager remains.)*
    - No database (signed cookies) = all state in worker memory
    - Metadata persists despite compression
 

--- a/Docs/source/api_reference.rst
+++ b/Docs/source/api_reference.rst
@@ -15,13 +15,15 @@ Connection
 Base URL
 ~~~~~~~~
 
-The API is served by a Django backend on port **8000**.
+The API is served by a Django backend. In production it sits behind a Caddy
+reverse proxy that terminates TLS on the standard HTTPS port (443) — port
+8000 is bound to loopback only and is not reachable from the internet.
 
 **Production** (Fedora droplet at ``134.122.1.153``, IPv4 only):
 
 .. code-block:: text
 
-   https://agenticfinsearch.org:8000
+   https://agenticfinsearch.org
 
 **Local development:**
 
@@ -118,7 +120,7 @@ Check if the backend is running. Does **not** require authentication.
 
 .. code-block:: bash
 
-   curl https://agenticfinsearch.org:8000/health/
+   curl https://agenticfinsearch.org/health/
 
 ---
 
@@ -201,7 +203,7 @@ Returns all available models in OpenAI-compatible format.
 .. code-block:: bash
 
    curl -H "Authorization: Bearer $API_KEY" \
-        https://agenticfinsearch.org:8000/v1/models
+        https://agenticfinsearch.org/v1/models
 
 **Error responses:**
 
@@ -723,7 +725,7 @@ Health Check
 
 .. code-block:: bash
 
-   curl https://agenticfinsearch.org:8000/health/
+   curl https://agenticfinsearch.org/health/
 
 List Models
 ~~~~~~~~~~~
@@ -731,7 +733,7 @@ List Models
 .. code-block:: bash
 
    curl -H "Authorization: Bearer $API_KEY" \
-        https://agenticfinsearch.org:8000/v1/models
+        https://agenticfinsearch.org/v1/models
 
 Thinking Mode (MCP Tools)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -740,7 +742,7 @@ Ask a specific financial question. The agent uses SEC-EDGAR and Yahoo Finance MC
 
 .. code-block:: bash
 
-   curl -X POST https://agenticfinsearch.org:8000/v1/chat/completions \
+   curl -X POST https://agenticfinsearch.org/v1/chat/completions \
      -H "Content-Type: application/json" \
      -H "Authorization: Bearer $API_KEY" \
      -d '{
@@ -758,7 +760,7 @@ Ask a broad research question. The agent searches the web and synthesizes an ans
 
 .. code-block:: bash
 
-   curl -X POST https://agenticfinsearch.org:8000/v1/chat/completions \
+   curl -X POST https://agenticfinsearch.org/v1/chat/completions \
      -H "Content-Type: application/json" \
      -H "Authorization: Bearer $API_KEY" \
      -d '{
@@ -776,7 +778,7 @@ Research Mode with Domain Scoping
 
 .. code-block:: bash
 
-   curl -X POST https://agenticfinsearch.org:8000/v1/chat/completions \
+   curl -X POST https://agenticfinsearch.org/v1/chat/completions \
      -H "Content-Type: application/json" \
      -H "Authorization: Bearer $API_KEY" \
      -d '{
@@ -797,7 +799,7 @@ Inject a page's content before asking a question about it.
 
 .. code-block:: bash
 
-   curl -X POST https://agenticfinsearch.org:8000/v1/chat/completions \
+   curl -X POST https://agenticfinsearch.org/v1/chat/completions \
      -H "Content-Type: application/json" \
      -H "Authorization: Bearer $API_KEY" \
      -d '{
@@ -816,7 +818,7 @@ Pass full conversation history. The API is stateless — include all prior turns
 
 .. code-block:: bash
 
-   curl -X POST https://agenticfinsearch.org:8000/v1/chat/completions \
+   curl -X POST https://agenticfinsearch.org/v1/chat/completions \
      -H "Content-Type: application/json" \
      -H "Authorization: Bearer $API_KEY" \
      -d '{
@@ -834,7 +836,7 @@ Normal Mode (No Tools / No Search)
 
 .. code-block:: bash
 
-   curl -X POST https://agenticfinsearch.org:8000/v1/chat/completions \
+   curl -X POST https://agenticfinsearch.org/v1/chat/completions \
      -H "Content-Type: application/json" \
      -H "Authorization: Bearer $API_KEY" \
      -d '{
@@ -859,7 +861,7 @@ Below is a complete, copy-paste-ready Python script for benchmarking the API. It
    import time
    import json
 
-   BASE_URL = "https://agenticfinsearch.org:8000"
+   BASE_URL = "https://agenticfinsearch.org"
    API_KEY = "<YOUR_API_KEY>"  # omit Authorization header if auth is disabled
 
    HEADERS = {
@@ -1019,6 +1021,8 @@ Below is a complete, copy-paste-ready Python script for benchmarking the API. It
 
 Behavioral Notes
 ----------------
+
+.. _v1-statelessness:
 
 Statelessness
 ~~~~~~~~~~~~~

--- a/Docs/source/mcp_tools.rst
+++ b/Docs/source/mcp_tools.rst
@@ -74,21 +74,23 @@ Ensure your ``.env`` file in ``Main/backend/`` is properly configured:
 Configuration
 -------------
 
-MCP servers are configured in ``Main/backend/mcp_server_config.json``. Each entry specifies:
+MCP servers are configured in ``Main/backend/mcp_server_config.json``. Each
+entry under the top-level ``mcpServers`` key specifies:
 
-- **transport**: ``stdio`` or ``sse``
-- **command** / **args**: The command to launch the server
-- **env**: Environment variables passed to the server process
+- **command** / **args**: The command that launches the server process
+  (all servers communicate over stdio)
+- **env**: Environment variables passed to the server process (optional)
+- **disabled**: Set to ``true`` to skip launching the server
+  (optional, defaults to ``false``)
 
 .. code-block:: json
 
    {
-     "servers": {
+     "mcpServers": {
        "yahoo-finance": {
-         "transport": "stdio",
          "command": "python",
          "args": ["-m", "mcp_server.yahoo_finance_server"],
-         "enabled": true
+         "disabled": false
        }
      }
    }

--- a/Docs/source/project_structure.rst
+++ b/Docs/source/project_structure.rst
@@ -110,7 +110,7 @@ Backend Highlights
 * ``datascraper/research_engine.py`` implements the multi-step research pipeline (query decomposition, parallel execution, gap detection, synthesis).
 * ``datascraper/unified_context_manager.py`` provides session-based context tracking with JSON structure.
 * ``mcp_client/`` handles Model Context Protocol client connections and agent orchestration.
-* ``mcp_server/`` contains standalone MCP server implementations (Yahoo Finance, TradingView).
+* ``mcp_server/`` contains standalone MCP server implementations (Yahoo Finance, TradingView, XBRL Taxonomy).
 * ``prompts/`` contains Markdown prompt templates, including site-specific context prompts.
 * ``axioms/`` + ``truthlayer/`` implement the XBRL validation pipeline documented in :doc:`xbrl_validation`.
 

--- a/Docs/source/usage/basic_usage.rst
+++ b/Docs/source/usage/basic_usage.rst
@@ -31,7 +31,7 @@ The top bar of the pop up contains the following elements:
   shows the currently active mode.
 
 - **Setting Button**: Opens the settings page, and may be closed by clicking anywhere outside the settings page but
-  inside the pop up. It allows users to choose foundation models and set preferred links for Advanced search.
+  inside the pop up. It allows users to choose foundation models and set preferred links for Research mode.
 
 Main Body
 ~~~~~~~~~

--- a/Docs/source/usage/memory_system.rst
+++ b/Docs/source/usage/memory_system.rst
@@ -35,6 +35,8 @@ Session Isolation
   gets its own conversation, and it still cannot cross to another browser.
 - **API Isolation**: OpenAI-compatible API requests with a ``user`` parameter
   get a per-user session; requests without one get a unique ephemeral
-  session.
+  session. Either way the session context is cleared at the start of every
+  request — the /v1 API is fully stateless (see :ref:`v1-statelessness`),
+  so none of the conversation memory described here carries across /v1 calls.
 - **Manual Clearing**: Use the **Clear** button to reset the current session's
   conversation history while optionally preserving scraped web content.

--- a/Docs/superpowers/plans/2026-07-12-hosted-docs-refresh.md
+++ b/Docs/superpowers/plans/2026-07-12-hosted-docs-refresh.md
@@ -1145,17 +1145,17 @@ Per FlyM1ss's decision: the 17 non-`/v1` endpoints (no auth today; rate-limit + 
 
 ## Discovered follow-ups (logged, OUT of scope)
 
-Resolution pass 2026-07-12 (PRs #350 F-1, #351 F-4, #352 F-3/F-5/F-6/F-7/F-8). Only F-2 remains open.
+Resolution pass 2026-07-12 (PRs #350 F-1, #351 F-4+F-9, #352 F-3/F-5/F-6/F-7/F-8). ALL items closed.
 
 - **F-1** ~~backend `[dependency-groups] docs` is broken~~ — **RESOLVED, PR #350.** Root cause differed from the log's "old nbconvert" hypothesis: nbconvert was already 7.17.1, but the `[tool.uv]` override `bleach>=6.4.0` REPLACED nbconvert's `bleach[css]` requirement graph-wide, dropping the extra → no `tinycss2` → nbconvert's no-css-sanitizer fallback crashes at import (`NameError: ALLOWED_STYLES`). Fix: override becomes `bleach[css]>=6.4.0`; lock diff is tinycss2 alone. RTD was never affected (`readthedocs.yml` installs `requirements_sphinx.txt` fresh).
-- **F-2** (STILL OPEN): "does NOT work on **Brave**" notes (`basic_usage.rst:8-9`, `advanced_usage.rst:8-9`) — unverifiable from code; needs a manual retest before removal.
+- **F-2** ~~Brave notes need manual retest~~ — **CLOSED (keep), 2026-07-12.** FlyM1ss retested: the extension still does not work on Brave, so the notes in `basic_usage.rst:8-9` / `advanced_usage.rst:8-9` are accurate and stay.
 - **F-3** ~~`:8000` base URL~~ — **RESOLVED, PR #352.** Verified on the droplet: Caddy terminates TLS on 443, gunicorn's 8000 is loopback-bound and firewalled (`ss -tlnp` + firewalld), so every `https://…:8000` example was unreachable. All production URLs in `api_reference.rst` dropped the port; base-URL section explains the proxy split.
 - **F-4** ~~legacy `gpt-4o-mini` default~~ — **RESOLVED, PR #351.** Fallback centralized as `models_config.DEFAULT_MODEL = "FinGPT"`; all 4 `views.py` call sites use it; `tests/test_models_config.py` drift-guards both the "default is a configured model" invariant and the call-site pattern.
 - **F-5** ~~`mcp_tools.rst` Configuration example~~ — **RESOLVED, PR #352.** `mcpServers`/`disabled` now documented; `transport` bullet removed (loader is stdio-only).
 - **F-6** ~~basic_usage Settings wording + project_structure XBRL~~ — **RESOLVED, PR #352.**
 - **F-7** ~~memory_system /v1 statelessness cross-ref~~ — **RESOLVED, PR #352.** New `v1-statelessness` label on api_reference's Behavioral Notes; API-Isolation bullet links it.
 - **F-8** ~~stale Mem0 line in 2026-02-02 audit~~ — **RESOLVED, PR #352.** Dated-snapshot annotation added (Mem0 removed in #347).
-- **F-9** (NEW, logged 2026-07-12): `datascraper/datascraper_refactored.py` is imported nowhere in the backend (checked all non-venv `*.py`) yet carries ~10 `gpt-4o-mini` signature defaults — dead-code candidate; confirm and delete at leisure.
+- **F-9** ~~`datascraper_refactored.py` dead-code candidate~~ — **RESOLVED, PR #351.** Confirmed zero references repo-wide outside the signed `a2as.yaml` (whose stale-entry prune is already tracked in issue #349) and deleted; full backend suite green (703 passed, 1 skipped).
 
 ### Post-review fix pass (2026-07-12, PR #348 review)
 

--- a/Docs/superpowers/plans/2026-07-12-hosted-docs-refresh.md
+++ b/Docs/superpowers/plans/2026-07-12-hosted-docs-refresh.md
@@ -1145,14 +1145,17 @@ Per FlyM1ss's decision: the 17 non-`/v1` endpoints (no auth today; rate-limit + 
 
 ## Discovered follow-ups (logged, OUT of scope)
 
-- **F-1**: backend `[dependency-groups] docs` is broken — `bleach>=6.4.0` (security override, `pyproject.toml:75`) crashes old `nbconvert` at Sphinx startup (`NameError: ALLOWED_STYLES`). Either bump `nbsphinx`/`nbconvert` in the docs group or delete the group and standardize on `requirements_sphinx.txt`.
-- **F-2**: "does NOT work on **Brave**" notes (`basic_usage.rst:8-9`, `advanced_usage.rst:8-9`) — unverifiable from code; needs a manual retest before removal.
-- **F-3**: `api_reference.rst` "Base URL … port 8000 / `https://agenticfinsearch.org:8000`" — worth confirming against the live Caddy reverse-proxy config next time we're on the droplet (deploy docs suggest Caddy fronts the backend; if it serves on 443, the examples' `:8000` is stale).
-- **F-4**: `api/views.py` has a legacy `params.get('models', 'gpt-4o-mini')` default at 4 call sites (lines 277, 377, 506, 694) — `gpt-4o-mini` is not in `MODELS_CONFIG`, so a client omitting `models` gets an unknown-model path. Harmless today (the extension always sends an explicit model), but the default should become `FinGPT`.
-- **F-5**: `mcp_tools.rst` Configuration example block (~lines 83-94, pre-existing, untouched by this plan) is wrong on three counts: top-level key `"servers"` (real: `"mcpServers"`), a `"transport"` field that doesn't exist in the real config, and `"enabled": true` (real key: `"disabled"`). Needs a FlyM1ss-coordinated docs edit.
-- **F-6**: stale/incoherent phrases outside plan-named regions (final-review Minors): `usage/basic_usage.rst:34` Setting Button "for Advanced search" → Research mode; `project_structure.rst:113` Backend Highlights `mcp_server/` bullet omits XBRL. (The `introduction.rst:10` TradingView/XBRL-taxonomy item originally logged here was fixed in-PR by the post-review pass below.)
-- **F-7**: `usage/memory_system.rst` API-Isolation bullet could cross-ref the /v1 statelessness note (per-request clear at `openai_views.py:273`). (The `api_reference.rst` ETag/Last-Modified nit originally logged here was fixed in-PR by the post-review pass below.)
-- **F-8**: `Docs/plans/2026-02-02-deployment-readiness-audit.md:35` still says "UnifiedContextManager + Mem0 accumulate session data" — dated internal audit snapshot, not user-facing; fix or annotate at leisure.
+Resolution pass 2026-07-12 (PRs #350 F-1, #351 F-4, #352 F-3/F-5/F-6/F-7/F-8). Only F-2 remains open.
+
+- **F-1** ~~backend `[dependency-groups] docs` is broken~~ — **RESOLVED, PR #350.** Root cause differed from the log's "old nbconvert" hypothesis: nbconvert was already 7.17.1, but the `[tool.uv]` override `bleach>=6.4.0` REPLACED nbconvert's `bleach[css]` requirement graph-wide, dropping the extra → no `tinycss2` → nbconvert's no-css-sanitizer fallback crashes at import (`NameError: ALLOWED_STYLES`). Fix: override becomes `bleach[css]>=6.4.0`; lock diff is tinycss2 alone. RTD was never affected (`readthedocs.yml` installs `requirements_sphinx.txt` fresh).
+- **F-2** (STILL OPEN): "does NOT work on **Brave**" notes (`basic_usage.rst:8-9`, `advanced_usage.rst:8-9`) — unverifiable from code; needs a manual retest before removal.
+- **F-3** ~~`:8000` base URL~~ — **RESOLVED, PR #352.** Verified on the droplet: Caddy terminates TLS on 443, gunicorn's 8000 is loopback-bound and firewalled (`ss -tlnp` + firewalld), so every `https://…:8000` example was unreachable. All production URLs in `api_reference.rst` dropped the port; base-URL section explains the proxy split.
+- **F-4** ~~legacy `gpt-4o-mini` default~~ — **RESOLVED, PR #351.** Fallback centralized as `models_config.DEFAULT_MODEL = "FinGPT"`; all 4 `views.py` call sites use it; `tests/test_models_config.py` drift-guards both the "default is a configured model" invariant and the call-site pattern.
+- **F-5** ~~`mcp_tools.rst` Configuration example~~ — **RESOLVED, PR #352.** `mcpServers`/`disabled` now documented; `transport` bullet removed (loader is stdio-only).
+- **F-6** ~~basic_usage Settings wording + project_structure XBRL~~ — **RESOLVED, PR #352.**
+- **F-7** ~~memory_system /v1 statelessness cross-ref~~ — **RESOLVED, PR #352.** New `v1-statelessness` label on api_reference's Behavioral Notes; API-Isolation bullet links it.
+- **F-8** ~~stale Mem0 line in 2026-02-02 audit~~ — **RESOLVED, PR #352.** Dated-snapshot annotation added (Mem0 removed in #347).
+- **F-9** (NEW, logged 2026-07-12): `datascraper/datascraper_refactored.py` is imported nowhere in the backend (checked all non-venv `*.py`) yet carries ~10 `gpt-4o-mini` signature defaults — dead-code candidate; confirm and delete at leisure.
 
 ### Post-review fix pass (2026-07-12, PR #348 review)
 


### PR DESCRIPTION
## Summary
Executes the user-facing-docs follow-ups logged in `Docs/superpowers/plans/2026-07-12-hosted-docs-refresh.md` after #347/#348:

- **F-3** — `api_reference.rst`: dropped `:8000` from every production URL (~12 examples + base-URL block). Verified live on the droplet: Caddy terminates TLS on 443 and reverse-proxies to `127.0.0.1:8000`; port 8000 is loopback-bound and firewalled, so all `https://…:8000` examples were unreachable as written. `http://localhost:8000` kept for local dev; base-URL section now explains the proxy split.
- **F-5** — `mcp_tools.rst` Configuration section now matches `mcp_server_config.json` reality: top-level key `mcpServers` (was `servers`), no `transport` field (loader is stdio-only), flag is `disabled` (was `enabled: true`, a key the loader ignores — every server it "documented" would actually launch).
- **F-6** — `basic_usage.rst`: Settings button sets preferred links for **Research mode** (was "Advanced search"); `project_structure.rst`: `mcp_server/` highlights bullet gains the XBRL Taxonomy server.
- **F-7** — `memory_system.rst` API-Isolation bullet now states that /v1 sessions are cleared per-request, cross-referencing a new `v1-statelessness` label on the existing Behavioral Notes section in `api_reference.rst`.
- **F-8** — `Docs/plans/2026-02-02-deployment-readiness-audit.md`: dated-snapshot annotation on the Mem0 bullet (Mem0 removed in #347).

**F-2** (Brave "does NOT work" notes) is deliberately untouched — it needs a manual browser retest before removal.

## Verification
- Full Sphinx build (nbsphinx enabled, via the #350 venv fix): **build succeeded**, no new warnings.
- `:ref:` cross-ref confirmed in rendered HTML (`memory_system.html` → `api_reference.html#v1-statelessness`).
- Caddyfile + `ss -tlnp` + firewalld inspected on the droplet over SSH for F-3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MpjVcdhE4vq5CSEY7xmnpf