### PR TITLE
fix(build): override mistune >=3.3.0 (DoS fix)

### DIFF
--- a/Main/backend/pyproject.toml
+++ b/Main/backend/pyproject.toml
@@ -76,6 +76,7 @@ override-dependencies = [
     # ALLOWED_STYLES in its no-css-sanitizer fallback path), breaking the docs build.
     "bleach[css]>=6.4.0",      # GHSA: formaction URI bypass + Unicode scheme sanitization gap
     "starlette>=1.3.1",        # GHSA: form-limit DoS, UNC SSRF, host poisoning, getattr dispatch (via mcp)
+    "mistune>=3.3.0",          # GHSA: quadratic-time parse_link_text DoS (Dependabot #183; via nbconvert)
 ]
 
 [tool.pytest.ini_options]

--- a/Main/backend/uv.lock
+++ b/Main/backend/uv.lock
@@ -14,6 +14,7 @@ overrides = [
     { name = "bleach", extras = ["css"], specifier = ">=6.4.0" },
     { name = "cryptography", specifier = ">=48.0.1" },
     { name = "idna", specifier = ">=3.15" },
+    { name = "mistune", specifier = ">=3.3.0" },
     { name = "protobuf", specifier = ">=6.33.5" },
     { name = "pyjwt", specifier = ">=2.13.0" },
     { name = "python-multipart", specifier = ">=0.0.31" },
@@ -1253,11 +1254,11 @@ wheels = [
 
 [[package]]
 name = "mistune"
-version = "3.2.1"
+version = "3.3.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ca/84/620cc3f7e3adf6f5067e10f4dbae71295d8f9e16d5d3f9ef97c40f2f592c/mistune-3.2.1.tar.gz", hash = "sha256:7c8e5501d38bac1582e067e46c8343f17d57ea1aaa735823f3aba1fd59c88a28", size = 98003, upload-time = "2026-05-03T14:33:22.312Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/a5/2dab368d6950e6808904dec98f54c7e726ee7be4a0c6afe00e6e011bd52d/mistune-3.3.3.tar.gz", hash = "sha256:c4c6c0c840b8637a2e9b8b6d607eb7c8f00888bf14c754409bcd339e848c2477", size = 115363, upload-time = "2026-07-09T06:18:05.268Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/7f/a946aa4f8752b37102b41e64dca18a1976ac705c3a0d1dfe74d820a02552/mistune-3.2.1-py3-none-any.whl", hash = "sha256:78cdb0ba5e938053ccf63651b352508d2efa9411dc8810bfb05f2dc5140c0048", size = 53749, upload-time = "2026-05-03T14:33:20.551Z" },
+    { url = "https://files.pythonhosted.org/packages/89/70/b1e4737b84163db5bb1dfde6f216dbfbf32783330a9989c965e121172830/mistune-3.3.3-py3-none-any.whl", hash = "sha256:99de1585e42dcbd826faa9e11a202727a5e202e4e4722a4c69ac1ff615793dd7", size = 63569, upload-time = "2026-07-09T06:18:03.839Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Closes Dependabot alert #183 (high): mistune `<3.3.0` has a quadratic-time DoS in `parse_link_text`.
- mistune is a **transitive, docs-only** dependency (`nbconvert` → `nbsphinx`), not on the app runtime path.
- Forces the patched floor via the established `[tool.uv] override-dependencies` pattern (same mechanism as `bleach[css]`, `starlette`, etc.).

## Change
- `pyproject.toml`: `"mistune>=3.3.0"` added to the uv override list.
- `uv.lock`: mistune `3.2.1` → `3.3.3` (only mistune touched), within nbconvert's `<4` constraint.

## Test plan
- [x] `uv lock` resolves cleanly (192 packages) with no other package disturbed.
- [x] Resolved version 3.3.3 satisfies both the security floor (≥3.3.0) and nbconvert's `<4`.
- [x] Diff reviewed end-to-end: lockfile change is mistune alone.