### PR TITLE
feat(api): bearer-auth on signals/news (P1)

### DIFF
--- a/Main/backend/api/auth.py
+++ b/Main/backend/api/auth.py
@@ -1,0 +1,62 @@
+"""Shared bearer-token auth for FinSearch HTTP endpoints.
+
+Single source of truth extracted from openai_views so /v1 and the non-/v1
+routes cannot drift. See Docs/source/api_reference.rst (Authentication) and
+django_config/settings.py:179-180. The shared FINGPT_API_KEY is a coarse gate;
+per-user attribution is deferred to the identity seam (api/identity.py)."""
+import functools
+import hmac
+import logging
+import os
+from typing import Optional
+
+from django.conf import settings
+from django.http import HttpRequest, JsonResponse
+
+logger = logging.getLogger(__name__)
+
+
+def authenticate_request(request: HttpRequest) -> Optional[JsonResponse]:
+    api_key = os.getenv('FINGPT_API_KEY')
+    if not api_key:
+        if getattr(settings, 'REQUIRE_FINGPT_API_KEY', False):
+            logger.error(
+                "FINGPT_API_KEY is not set but REQUIRE_FINGPT_API_KEY is True; "
+                "refusing request (fail closed)."
+            )
+            return JsonResponse(
+                {'error': {'message': 'Server authentication is misconfigured.', 'type': 'server_error'}},
+                status=503,
+            )
+        return None
+    auth_header = request.META.get('HTTP_AUTHORIZATION', '')
+    if not auth_header:
+        return JsonResponse(
+            {'error': {'message': 'Missing Authorization header. Use: Authorization: Bearer <api_key>', 'type': 'authentication_error'}},
+            status=401,
+        )
+    if not auth_header.startswith('Bearer '):
+        return JsonResponse(
+            {'error': {'message': 'Invalid Authorization format. Use: Authorization: Bearer <api_key>', 'type': 'authentication_error'}},
+            status=401,
+        )
+    if not hmac.compare_digest(auth_header[7:], api_key):
+        return JsonResponse(
+            {'error': {'message': 'Invalid API key', 'type': 'authentication_error'}},
+            status=401,
+        )
+    return None
+
+
+def require_bearer_auth(view_func):
+    """Gate a view with authenticate_request. Placed as the OUTERMOST decorator
+    (just under @csrf_exempt) so an unauthorized request is rejected before any
+    rate-limit token, disk load, or agent work — a deliberate improvement over
+    the /v1 in-body check, same policy."""
+    @functools.wraps(view_func)
+    def _wrapped(request, *args, **kwargs):
+        auth_error = authenticate_request(request)
+        if auth_error is not None:
+            return auth_error
+        return view_func(request, *args, **kwargs)
+    return _wrapped

--- a/Main/backend/api/openai_views.py
+++ b/Main/backend/api/openai_views.py
@@ -22,6 +22,7 @@ from django.conf import settings
 from django_ratelimit import ALL
 from django_ratelimit.decorators import ratelimit
 
+from api.auth import authenticate_request as _authenticate_request
 from api.agent_budget import agent_run_slot, BudgetExceeded, ConcurrencyExceeded
 from api.identity import get_request_identity
 from datascraper import datascraper as ds
@@ -80,51 +81,6 @@ def _get_api_session_id(request: HttpRequest, user_id: Optional[str] = None) -> 
     if user_id:
         return f"api_user_{user_id}"
     return f"api_req_{uuid.uuid4().hex}"
-
-
-def _authenticate_request(request: HttpRequest) -> Optional[JsonResponse]:
-    """
-    Validate Bearer token authentication for API requests.
-    Returns None if authenticated, or a JsonResponse error if not.
-
-    The API key is configured via the FINGPT_API_KEY environment variable.
-    If FINGPT_API_KEY is not set, authentication is disabled (development mode).
-    """
-    api_key = os.getenv('FINGPT_API_KEY')
-    if not api_key:
-        if getattr(settings, 'REQUIRE_FINGPT_API_KEY', False):
-            logger.error(
-                "FINGPT_API_KEY is not set but REQUIRE_FINGPT_API_KEY is True; "
-                "refusing /v1/* requests (fail closed)."
-            )
-            return JsonResponse(
-                {'error': {'message': 'Server authentication is misconfigured.', 'type': 'server_error'}},
-                status=503
-            )
-        # No API key configured — authentication disabled (dev mode)
-        return None
-
-    auth_header = request.META.get('HTTP_AUTHORIZATION', '')
-    if not auth_header:
-        return JsonResponse(
-            {'error': {'message': 'Missing Authorization header. Use: Authorization: Bearer <api_key>', 'type': 'authentication_error'}},
-            status=401
-        )
-
-    if not auth_header.startswith('Bearer '):
-        return JsonResponse(
-            {'error': {'message': 'Invalid Authorization format. Use: Authorization: Bearer <api_key>', 'type': 'authentication_error'}},
-            status=401
-        )
-
-    provided_key = auth_header[7:]  # Strip 'Bearer '
-    if not hmac.compare_digest(provided_key, api_key):
-        return JsonResponse(
-            {'error': {'message': 'Invalid API key', 'type': 'authentication_error'}},
-            status=401
-        )
-
-    return None
 
 
 def _merge_domains_into_preferred_links(

--- a/Main/backend/api/openai_views.py
+++ b/Main/backend/api/openai_views.py
@@ -8,9 +8,7 @@ Provides /v1/models and /v1/chat/completions endpoints with:
 - Thinking mode with MCP tool source tracking
 """
 
-import hmac
 import json
-import os
 import time
 import uuid
 import logging

--- a/Main/backend/api/signals_views.py
+++ b/Main/backend/api/signals_views.py
@@ -26,6 +26,8 @@ from django.views.decorators.http import condition, require_http_methods
 from django_ratelimit import ALL
 from django_ratelimit.decorators import ratelimit
 
+from api.auth import require_bearer_auth
+
 logger = logging.getLogger(__name__)
 
 _PUBLIC_STRIP = ("generator", "model", "prompt_version")
@@ -151,6 +153,7 @@ def _last_modified(request: HttpRequest):
 
 
 @csrf_exempt
+@require_bearer_auth
 @require_http_methods(["GET"])
 @ratelimit(key='api.identity.ratelimit_key', rate=settings.API_RATE_LIMIT,
            method=ALL, block=True)

--- a/Main/backend/tests/test_api_auth.py
+++ b/Main/backend/tests/test_api_auth.py
@@ -3,8 +3,10 @@ import os
 from unittest.mock import patch
 
 from django.test import SimpleTestCase, RequestFactory, override_settings
+from django.http import JsonResponse
 
 from api.openai_views import _authenticate_request
+from api.auth import authenticate_request, require_bearer_auth
 
 
 class AuthFailClosedTests(SimpleTestCase):
@@ -35,3 +37,36 @@ class AuthFailClosedTests(SimpleTestCase):
         with patch.dict(os.environ, {}, clear=False):
             os.environ.pop("FINGPT_API_KEY", None)
             self.assertIsNone(_authenticate_request(self.rf.get("/v1/models")))
+
+
+# Decorator tests (module-level pytest functions)
+@require_bearer_auth
+def _probe(request):
+    return JsonResponse({"ok": True})
+
+
+@override_settings(REQUIRE_FINGPT_API_KEY=False)
+def test_decorator_open_when_no_key(monkeypatch):
+    monkeypatch.delenv("FINGPT_API_KEY", raising=False)
+    resp = _probe(RequestFactory().get("/x/"))
+    assert resp.status_code == 200
+
+
+def test_decorator_401_when_key_set_and_header_missing(monkeypatch):
+    monkeypatch.setenv("FINGPT_API_KEY", "sekret")
+    resp = _probe(RequestFactory().get("/x/"))
+    assert resp.status_code == 401
+
+
+def test_decorator_200_when_bearer_matches(monkeypatch):
+    monkeypatch.setenv("FINGPT_API_KEY", "sekret")
+    resp = _probe(RequestFactory().get("/x/", HTTP_AUTHORIZATION="Bearer sekret"))
+    assert resp.status_code == 200
+
+
+def test_decorator_503_when_required_and_no_key(monkeypatch):
+    # Prod fail-closed (spec req 3): REQUIRE_FINGPT_API_KEY=True + no key -> 503, never silent-open.
+    monkeypatch.delenv("FINGPT_API_KEY", raising=False)
+    with override_settings(REQUIRE_FINGPT_API_KEY=True):
+        resp = _probe(RequestFactory().get("/x/"))
+    assert resp.status_code == 503

--- a/Main/backend/tests/test_api_auth.py
+++ b/Main/backend/tests/test_api_auth.py
@@ -2,11 +2,12 @@
 import os
 from unittest.mock import patch
 
-from django.test import SimpleTestCase, RequestFactory, override_settings
+from django.test import Client, SimpleTestCase, RequestFactory, override_settings
 from django.http import JsonResponse
 
 from api.openai_views import _authenticate_request
 from api.auth import authenticate_request, require_bearer_auth
+from tests.shared_settings import HERMETIC_REQUEST_SETTINGS
 
 
 class AuthFailClosedTests(SimpleTestCase):
@@ -70,3 +71,21 @@ def test_decorator_503_when_required_and_no_key(monkeypatch):
     with override_settings(REQUIRE_FINGPT_API_KEY=True):
         resp = _probe(RequestFactory().get("/x/"))
     assert resp.status_code == 503
+
+
+# Signals endpoint tests via django.test.Client so the gate is proven through
+# real middleware + URL dispatch. HERMETIC_REQUEST_SETTINGS adds "testserver"
+# to ALLOWED_HOSTS (+ disables SSL redirect) so the Client GET is not 400'd —
+# same helper tests/test_signals_endpoint.py uses for this same URL.
+@override_settings(**HERMETIC_REQUEST_SETTINGS)
+def test_signals_401_when_key_set_no_header(monkeypatch):
+    monkeypatch.setenv("FINGPT_API_KEY", "sekret")
+    assert Client().get("/api/signals/news/").status_code == 401
+
+
+@override_settings(REQUIRE_FINGPT_API_KEY=False, SIGNALS_DIR="",
+                   **HERMETIC_REQUEST_SETTINGS)
+def test_signals_open_when_no_key(monkeypatch):
+    monkeypatch.delenv("FINGPT_API_KEY", raising=False)
+    # 404 no_signals (empty SIGNALS_DIR) proves it reached the view, not 401
+    assert Client().get("/api/signals/news/").status_code in (200, 404)

--- a/Main/backend/tests/test_api_auth.py
+++ b/Main/backend/tests/test_api_auth.py
@@ -6,7 +6,7 @@ from django.test import Client, SimpleTestCase, RequestFactory, override_setting
 from django.http import JsonResponse
 
 from api.openai_views import _authenticate_request
-from api.auth import authenticate_request, require_bearer_auth
+from api.auth import require_bearer_auth
 from tests.shared_settings import HERMETIC_REQUEST_SETTINGS
 
 
@@ -89,3 +89,13 @@ def test_signals_open_when_no_key(monkeypatch):
     monkeypatch.delenv("FINGPT_API_KEY", raising=False)
     # 404 no_signals (empty SIGNALS_DIR) proves it reached the view, not 401
     assert Client().get("/api/signals/news/").status_code in (200, 404)
+
+
+@override_settings(SIGNALS_DIR="", **HERMETIC_REQUEST_SETTINGS)
+def test_signals_accepts_valid_bearer(monkeypatch):
+    # Prod path: key set + valid Bearer header -> auth passes, request reaches
+    # the view (404 no_signals with empty SIGNALS_DIR) through real URL dispatch.
+    monkeypatch.setenv("FINGPT_API_KEY", "sekret")
+    resp = Client().get("/api/signals/news/",
+                        HTTP_AUTHORIZATION="Bearer sekret")
+    assert resp.status_code != 401


### PR DESCRIPTION
## What this does (Phase 1 of `finsearch-endpoint-auth-01`)

Require `Authorization: Bearer <FINGPT_API_KEY>` on the **ATL-facing machine endpoint** `api/signals/news/`, and lay the shared-auth foundation for the rest of the rollout — **without breaking any live client**.

Two substantive changes + one cleanup commit:

1. **Extract shared auth** (`8f8b616`) — move `_authenticate_request` out of `api/openai_views.py` into a new `api/auth.py`, exposing:
   - `authenticate_request(request) -> Optional[JsonResponse]` — the callable (behavior identical to before), and
   - `require_bearer_auth` — a view decorator (same policy, applied as the outermost gate).

   `openai_views.py` keeps a module-level alias (`authenticate_request as _authenticate_request`), so the `/v1` in-body call sites and existing tests work unchanged. `/v1` and non-`/v1` auth now physically **cannot drift** — single source of truth.

2. **Gate `api/signals/news/`** (`ae0635f`) — apply `@require_bearer_auth` to `news_signals`, placed directly under `@csrf_exempt` and **above** `@ratelimit`/`@condition`, so an unauthorized request is rejected before it can consume a rate-limit token or trigger the `_load_artifact` disk read.

3. **Final-review cleanup** (`cef2cfe`) — drop imports orphaned by the extract; add the accept-path route test. No behavior change.

## Auth semantics (preserved verbatim)

| Condition | Result |
|---|---|
| no `FINGPT_API_KEY` + `REQUIRE_FINGPT_API_KEY` False | **open** (dev) |
| no key + `REQUIRE_FINGPT_API_KEY` True | **503** fail-closed |
| key set, missing/malformed/mismatched `Bearer` | **401** (`hmac.compare_digest`, timing-safe) |
| key set, valid `Bearer` | passes to view |

## Exemptions (intentional — see `django_config/urls.py` route accounting in the plan)

- **`health/`** — deploy/liveness probe (`entrypoint.sh`); must stay unauthenticated or the health gate breaks.
- **`api/axioms/xbrl/<filename>/`** — fetched by a plain `<a download>` browser click (`Main/frontend/src/modules/helpers.js:321`) that **cannot attach a header**. Stays protected by rate-limiting + the opaque, server-chosen filename.

## Why only `signals/news` here (rollout sequencing)

Prod already sets `FINGPT_API_KEY` + `REQUIRE_FINGPT_API_KEY=True`, so a route enforces auth on the next deploy the moment it gets the decorator. `signals/news` has **no in-repo caller** (ATL's adapter is next-phase and will be built with the header), so gating it is **zero-breakage**.

The **14 extension-facing views are deliberately NOT gated in this PR.** The Chrome extension is publicly distributed and can't be updated atomically across installs — gating its routes before a header-sending build has propagated would 401 every live user. That is a later, client-coordinated rollout:

- **Phase 2** — teach the extension to *send* the header (harmless while its routes stay open).
- **Phase 3** — flip the 14 extension views to enforced (after Phase 2 propagates) + Concierge env + docs.

Phases 2–3 additionally require a human propagation-window cutover sign-off, browser E2E, and user-facing-docs coordination, so they are handled separately.

## Tests

- `tests/test_api_auth.py`: **11 passed** — fail-closed unit tests (4) + decorator tests (4) + signals **route** tests through real `django.test.Client` + URL dispatch: deny (401), dev-open (404 reaches view), and accept (valid `Bearer` → non-401).
- Full backend suite: **710 passed, 1 skipped** (`cd Main/backend && uv run pytest`).

## Notes

- Auth is **additive** — rate-limiting and cookie-rooted session isolation are untouched.
- Honors the identity seam (`api/identity.py`): the shared key is a **coarse gate**; per-user attribution layers on when the login system lands.
- No user-facing/hosted docs are touched by this phase (those are Phase-3 items, coordinated separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
