### PR TITLE
feat(ext): send coarse-gate bearer header to backend calls (endpoint-auth P2)

### DIFF
--- a/Main/frontend/src/modules/api.js
+++ b/Main/frontend/src/modules/api.js
@@ -1,6 +1,6 @@
 // api.js
 
-import { buildBackendUrl, getAuthHeaders } from './backendConfig.js';
+import { buildBackendUrl, authFetch } from './backendConfig.js';
 import { createSSEParser } from './sse.js';
 
 // Session ID management
@@ -16,12 +16,10 @@ function setSessionId(sessionId) {
 
 // Function to POST JSON to the server endpoint
 function postWebTextToServer(textContent, currentUrl) {
-    return fetch(buildBackendUrl('/input_webtext/'), {
+    return authFetch(buildBackendUrl('/input_webtext/'), {
         method: "POST",
-        credentials: "include",
         headers: {
             "Content-Type": "application/json",
-            ...getAuthHeaders(),
         },
         body: JSON.stringify({
             textContent: textContent,
@@ -102,10 +100,9 @@ function getChatResponse(question, selectedModel, promptMode, useRAG, useMCP) {
     // all modes share the two real endpoints now.
     const endpoint = promptMode ? 'get_adv_response' : 'get_chat_response';
 
-    return fetch(buildBackendUrl(`/${endpoint}/`), {
+    return authFetch(buildBackendUrl(`/${endpoint}/`), {
         method: 'POST',
-        credentials: 'include',
-        headers: { 'Content-Type': 'application/json', ...getAuthHeaders() },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(buildChatRequestBody(question, selectedModel, promptMode)),
     })
         .then(response => response.json())
@@ -296,13 +293,11 @@ function getChatResponseStream(question, selectedModel, promptMode, useRAG, useM
         const parser = createSSEParser(handleServerEvent);
         const decoder = new TextDecoder('utf-8');
 
-        fetch(url, {
+        authFetch(url, {
             method: 'POST',
-            credentials: 'include',
             headers: {
                 'Content-Type': 'application/json',
                 'Accept': 'text/event-stream',
-                ...getAuthHeaders(),
             },
             body: requestBody,
             signal: abortController.signal,
@@ -374,7 +369,7 @@ function getChatResponseStream(question, selectedModel, promptMode, useRAG, useM
 
 // Function to clear messages
 function clearMessages() {
-    return fetch(`${buildBackendUrl('/clear_messages/')}?use_memory=true&session_id=${currentSessionId}`, { method: "POST", credentials: "include", headers: { ...getAuthHeaders() } })
+    return authFetch(`${buildBackendUrl('/clear_messages/')}?use_memory=true&session_id=${currentSessionId}`, { method: "POST" })
         .then(response => {
             if (!response.ok) {
                 throw new Error('Network response was not ok');
@@ -404,7 +399,7 @@ function getSourceUrls(searchQuery, currentUrl) {
     const baseEndpoint = buildBackendUrl('/get_source_urls/');
     const requestUrl = queryString ? `${baseEndpoint}?${queryString}` : baseEndpoint;
 
-    return fetch(requestUrl, { method: "GET", credentials: "include", headers: { ...getAuthHeaders() } })
+    return authFetch(requestUrl, { method: "GET" })
         .then(response => response.json())
         .then(data => {
             if (data.session_id) setSessionId(data.session_id);
@@ -421,10 +416,9 @@ function getSourceUrls(searchQuery, currentUrl) {
 function logQuestion(question, button) {
     const currentUrl = window.location.href;
 
-    return fetch(buildBackendUrl('/log_question/'), {
+    return authFetch(buildBackendUrl('/log_question/'), {
         method: 'POST',
-        credentials: 'include',
-        headers: { 'Content-Type': 'application/json', ...getAuthHeaders() },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
             question: String(question),
             button: String(button),
@@ -449,12 +443,10 @@ function syncPreferredLinks() {
     try {
         const preferredLinks = JSON.parse(localStorage.getItem('preferredLinks') || '[]');
         if (preferredLinks.length > 0) {
-            return fetch(buildBackendUrl('/api/sync_preferred_urls/'), {
+            return authFetch(buildBackendUrl('/api/sync_preferred_urls/'), {
                 method: 'POST',
-                credentials: 'include',
                 headers: {
                     'Content-Type': 'application/json',
-                    ...getAuthHeaders(),
                 },
                 body: JSON.stringify({ urls: preferredLinks })
             })
@@ -500,12 +492,10 @@ function triggerAutoScrape(currentUrl) {
         return Promise.resolve({ status: 'skipped', reason: 'no_session_id' });
     }
 
-    return fetch(buildBackendUrl('/api/auto_scrape/'), {
+    return authFetch(buildBackendUrl('/api/auto_scrape/'), {
         method: "POST",
-        credentials: "include",
         headers: {
             "Content-Type": "application/json",
-            ...getAuthHeaders(),
         },
         body: JSON.stringify({
             current_url: currentUrl,
@@ -532,10 +522,9 @@ function triggerAutoScrape(currentUrl) {
 // Layer 1 Validate: POST the current session to /api/axioms/validate/ and
 // return the per-claim verdicts for inline rendering.
 function validateClaims() {
-    return fetch(buildBackendUrl('/api/axioms/validate/'), {
+    return authFetch(buildBackendUrl('/api/axioms/validate/'), {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json', ...getAuthHeaders() },
-        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ session_id: currentSessionId }),
     })
         .then((response) => {
@@ -550,10 +539,8 @@ function validateClaims() {
 // Used to decide whether to show the Validate button on a response bubble.
 function hasAxiomClaims() {
     const params = currentSessionId ? `?session_id=${encodeURIComponent(currentSessionId)}` : '';
-    return fetch(buildBackendUrl(`/api/axioms/has_claims/${params}`), {
+    return authFetch(buildBackendUrl(`/api/axioms/has_claims/${params}`), {
         method: 'GET',
-        credentials: 'include',
-        headers: { ...getAuthHeaders() },
     })
         .then((response) => (response.ok ? response.json() : { has_claims: false }))
         .catch(() => ({ has_claims: false }));

--- a/Main/frontend/src/modules/api.js
+++ b/Main/frontend/src/modules/api.js
@@ -1,6 +1,6 @@
 // api.js
 
-import { buildBackendUrl } from './backendConfig.js';
+import { buildBackendUrl, getAuthHeaders } from './backendConfig.js';
 import { createSSEParser } from './sse.js';
 
 // Session ID management
@@ -21,6 +21,7 @@ function postWebTextToServer(textContent, currentUrl) {
         credentials: "include",
         headers: {
             "Content-Type": "application/json",
+            ...getAuthHeaders(),
         },
         body: JSON.stringify({
             textContent: textContent,
@@ -104,7 +105,7 @@ function getChatResponse(question, selectedModel, promptMode, useRAG, useMCP) {
     return fetch(buildBackendUrl(`/${endpoint}/`), {
         method: 'POST',
         credentials: 'include',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', ...getAuthHeaders() },
         body: JSON.stringify(buildChatRequestBody(question, selectedModel, promptMode)),
     })
         .then(response => response.json())
@@ -301,6 +302,7 @@ function getChatResponseStream(question, selectedModel, promptMode, useRAG, useM
             headers: {
                 'Content-Type': 'application/json',
                 'Accept': 'text/event-stream',
+                ...getAuthHeaders(),
             },
             body: requestBody,
             signal: abortController.signal,
@@ -372,7 +374,7 @@ function getChatResponseStream(question, selectedModel, promptMode, useRAG, useM
 
 // Function to clear messages
 function clearMessages() {
-    return fetch(`${buildBackendUrl('/clear_messages/')}?use_memory=true&session_id=${currentSessionId}`, { method: "POST", credentials: "include" })
+    return fetch(`${buildBackendUrl('/clear_messages/')}?use_memory=true&session_id=${currentSessionId}`, { method: "POST", credentials: "include", headers: { ...getAuthHeaders() } })
         .then(response => {
             if (!response.ok) {
                 throw new Error('Network response was not ok');
@@ -402,7 +404,7 @@ function getSourceUrls(searchQuery, currentUrl) {
     const baseEndpoint = buildBackendUrl('/get_source_urls/');
     const requestUrl = queryString ? `${baseEndpoint}?${queryString}` : baseEndpoint;
 
-    return fetch(requestUrl, { method: "GET", credentials: "include" })
+    return fetch(requestUrl, { method: "GET", credentials: "include", headers: { ...getAuthHeaders() } })
         .then(response => response.json())
         .then(data => {
             if (data.session_id) setSessionId(data.session_id);
@@ -422,7 +424,7 @@ function logQuestion(question, button) {
     return fetch(buildBackendUrl('/log_question/'), {
         method: 'POST',
         credentials: 'include',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', ...getAuthHeaders() },
         body: JSON.stringify({
             question: String(question),
             button: String(button),
@@ -452,6 +454,7 @@ function syncPreferredLinks() {
                 credentials: 'include',
                 headers: {
                     'Content-Type': 'application/json',
+                    ...getAuthHeaders(),
                 },
                 body: JSON.stringify({ urls: preferredLinks })
             })
@@ -502,6 +505,7 @@ function triggerAutoScrape(currentUrl) {
         credentials: "include",
         headers: {
             "Content-Type": "application/json",
+            ...getAuthHeaders(),
         },
         body: JSON.stringify({
             current_url: currentUrl,
@@ -530,7 +534,7 @@ function triggerAutoScrape(currentUrl) {
 function validateClaims() {
     return fetch(buildBackendUrl('/api/axioms/validate/'), {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', ...getAuthHeaders() },
         credentials: 'include',
         body: JSON.stringify({ session_id: currentSessionId }),
     })
@@ -549,6 +553,7 @@ function hasAxiomClaims() {
     return fetch(buildBackendUrl(`/api/axioms/has_claims/${params}`), {
         method: 'GET',
         credentials: 'include',
+        headers: { ...getAuthHeaders() },
     })
         .then((response) => (response.ok ? response.json() : { has_claims: false }))
         .catch(() => ({ has_claims: false }));

--- a/Main/frontend/src/modules/backendConfig.js
+++ b/Main/frontend/src/modules/backendConfig.js
@@ -19,6 +19,19 @@ function getAuthHeaders() {
     return COARSE_GATE_KEY ? { Authorization: `Bearer ${COARSE_GATE_KEY}` } : {};
 }
 
+// Single enforced path for backend calls: every request to our own backend must
+// carry the credentialed session AND the coarse-gate bearer header, so both are
+// attached here rather than hand-spliced at each call site (where a future one
+// could silently drop either). Caller-supplied method/body/signal/headers pass
+// through untouched; the Authorization header is merged in last.
+function authFetch(url, options = {}) {
+    return fetch(url, {
+        ...options,
+        credentials: 'include',
+        headers: { ...options.headers, ...getAuthHeaders() },
+    });
+}
+
 // Hosts the extension is permitted to talk to. Overrides come from
 // window.AGENTIC_BACKEND_URL or localStorage['agenticBackendUrl']; because
 // requests are sent with credentials:'include', an unconstrained override
@@ -111,4 +124,4 @@ function buildBackendUrl(path = '/') {
     return `${baseUrl}${sanitizedPath}`;
 }
 
-export { getBackendBaseUrl, buildBackendUrl, normalizeBaseUrl, getAuthHeaders };
+export { getBackendBaseUrl, buildBackendUrl, normalizeBaseUrl, getAuthHeaders, authFetch };

--- a/Main/frontend/src/modules/backendConfig.js
+++ b/Main/frontend/src/modules/backendConfig.js
@@ -4,6 +4,21 @@
 const DEFAULT_BACKEND_BASE_URL = 'https://agenticfinsearch.org';
 let cachedBaseUrl = null;
 
+// Coarse-gate bearer key, baked at build time by the webpack DefinePlugin from
+// the build environment (process.env.FINGPT_API_KEY). Empty in local/dev builds,
+// so no Authorization header is sent and the extension works against an open dev
+// backend. A public extension bundle is EXTRACTABLE — this is a COARSE gate
+// against drive-by API abuse, NOT per-user auth (deferred to the backend login
+// system, api/identity.py). Tests/dev may override via window.FINGPT_API_KEY.
+const COARSE_GATE_KEY =
+    (typeof window !== 'undefined' && window.FINGPT_API_KEY) ||
+    process.env.FINGPT_API_KEY ||
+    '';
+
+function getAuthHeaders() {
+    return COARSE_GATE_KEY ? { Authorization: `Bearer ${COARSE_GATE_KEY}` } : {};
+}
+
 // Hosts the extension is permitted to talk to. Overrides come from
 // window.AGENTIC_BACKEND_URL or localStorage['agenticBackendUrl']; because
 // requests are sent with credentials:'include', an unconstrained override
@@ -96,4 +111,4 @@ function buildBackendUrl(path = '/') {
     return `${baseUrl}${sanitizedPath}`;
 }
 
-export { getBackendBaseUrl, buildBackendUrl, normalizeBaseUrl };
+export { getBackendBaseUrl, buildBackendUrl, normalizeBaseUrl, getAuthHeaders };

--- a/Main/frontend/src/modules/components/link_manager.js
+++ b/Main/frontend/src/modules/components/link_manager.js
@@ -1,4 +1,4 @@
-import { buildBackendUrl } from '../backendConfig.js';
+import { buildBackendUrl, getAuthHeaders } from '../backendConfig.js';
 
 export function createLinkManager() {
     // Container for the whole link manager
@@ -52,6 +52,7 @@ export function createLinkManager() {
                 credentials: 'include',
                 headers: {
                     'Content-Type': 'application/json',
+                    ...getAuthHeaders(),
                 },
                 body: JSON.stringify({ urls: links })
             })
@@ -178,7 +179,8 @@ export function createLinkManager() {
 
         fetch(buildBackendUrl('/api/get_preferred_urls/'), {
             method: 'GET',
-            credentials: 'include'
+            credentials: 'include',
+            headers: { ...getAuthHeaders() }
         })
         .then(response => {
             if (!response.ok) {

--- a/Main/frontend/src/modules/components/link_manager.js
+++ b/Main/frontend/src/modules/components/link_manager.js
@@ -1,4 +1,4 @@
-import { buildBackendUrl, getAuthHeaders } from '../backendConfig.js';
+import { buildBackendUrl, authFetch } from '../backendConfig.js';
 
 export function createLinkManager() {
     // Container for the whole link manager
@@ -47,12 +47,10 @@ export function createLinkManager() {
     function syncWithBackend(links) {
         // Optional: Sync with backend if available
         if (typeof fetch !== 'undefined') {
-            fetch(buildBackendUrl('/api/sync_preferred_urls/'), {
+            authFetch(buildBackendUrl('/api/sync_preferred_urls/'), {
                 method: 'POST',
-                credentials: 'include',
                 headers: {
                     'Content-Type': 'application/json',
-                    ...getAuthHeaders(),
                 },
                 body: JSON.stringify({ urls: links })
             })
@@ -177,10 +175,8 @@ export function createLinkManager() {
             return;
         }
 
-        fetch(buildBackendUrl('/api/get_preferred_urls/'), {
+        authFetch(buildBackendUrl('/api/get_preferred_urls/'), {
             method: 'GET',
-            credentials: 'include',
-            headers: { ...getAuthHeaders() }
         })
         .then(response => {
             if (!response.ok) {

--- a/Main/frontend/src/modules/config.js
+++ b/Main/frontend/src/modules/config.js
@@ -1,6 +1,6 @@
 // config.js
 
-import { buildBackendUrl, getAuthHeaders } from './backendConfig.js';
+import { buildBackendUrl, authFetch } from './backendConfig.js';
 
 // Available models - will be populated from backend
 let availableModels = [];
@@ -11,7 +11,7 @@ let selectedModel = "FinGPT";
 
 // Fetch available models from backend
 async function fetchAvailableModels() {
-    const response = await fetch(buildBackendUrl('/api/get_available_models/'), { credentials: 'include', headers: { ...getAuthHeaders() } });
+    const response = await authFetch(buildBackendUrl('/api/get_available_models/'), { method: 'GET' });
     if (!response.ok) {
         throw new Error(`Failed to fetch models from backend. HTTP error! status: ${response.status}`);
     }

--- a/Main/frontend/src/modules/config.js
+++ b/Main/frontend/src/modules/config.js
@@ -1,6 +1,6 @@
 // config.js
 
-import { buildBackendUrl } from './backendConfig.js';
+import { buildBackendUrl, getAuthHeaders } from './backendConfig.js';
 
 // Available models - will be populated from backend
 let availableModels = [];
@@ -11,7 +11,7 @@ let selectedModel = "FinGPT";
 
 // Fetch available models from backend
 async function fetchAvailableModels() {
-    const response = await fetch(buildBackendUrl('/api/get_available_models/'), { credentials: 'include' });
+    const response = await fetch(buildBackendUrl('/api/get_available_models/'), { credentials: 'include', headers: { ...getAuthHeaders() } });
     if (!response.ok) {
         throw new Error(`Failed to fetch models from backend. HTTP error! status: ${response.status}`);
     }

--- a/Main/frontend/webpack.config.js
+++ b/Main/frontend/webpack.config.js
@@ -115,6 +115,11 @@ module.exports = {
         hints: "warning"
     },
     plugins: [
+        // Bake the coarse-gate API key from the build env into the bundle. Empty when
+        // FINGPT_API_KEY is unset (local/dev builds) -> getAuthHeaders() returns {}.
+        new webpack.DefinePlugin({
+            'process.env.FINGPT_API_KEY': JSON.stringify(process.env.FINGPT_API_KEY || ''),
+        }),
         new webpack.BannerPlugin({
             banner: '// @charset "UTF-8";',
             raw: true


### PR DESCRIPTION
## Phase 2 of `finsearch-endpoint-auth-01`

Teaches the Chrome extension to **send** `Authorization: Bearer <FINGPT_API_KEY>` on every backend `fetch`. This is the client-safe middle step of the rollout: the header is **inert today** (the extension's routes are still open) but must reach installs **before** Phase 3 flips those routes to enforced. A publicly-distributed extension can't be updated atomically, so shipping enforcement first would 401 every not-yet-updated user.

### What changed
- **`webpack.config.js`** — new `webpack.DefinePlugin` that bakes `process.env.FINGPT_API_KEY` into the bundle at build time. There was no existing build-injection machinery to reuse (`AGENTIC_BACKEND_URL` is a hardcoded source constant, not injected), so this adds the define stage. Empty when the env var is unset → local/dev builds send no header.
- **`backendConfig.js`** — new `getAuthHeaders()` + build-time `COARSE_GATE_KEY`. Returns `{}` when no key is baked.
- **`api.js` (10), `config.js` (1), `components/link_manager.js` (2)** — spread `...getAuthHeaders()` into all **13** backend `fetch` header objects. Every existing `method`/`credentials`/`Content-Type`/body is preserved verbatim.

### Threat model (documented in code + docs)
The public bundle is **extractable**, so any baked key is recoverable. This header is a **coarse gate** against drive-by API abuse, **not** per-user auth. Real per-user attribution is deferred to the backend login/identity system (`api/identity.py`). Baking via `DefinePlugin` (not a source literal) keeps the key out of committed git history / secret-scanning while still shipping it in the (extractable) bundle — same threat model, better hygiene.

### Exemptions unchanged
- `health/` — deploy/liveness probe, stays unauthenticated.
- `api/axioms/xbrl/<filename>/` — fetched by a plain `<a download>` click that can't attach a header; the frontend site (`helpers.js`) is deliberately **not** among the 13 and gets no header.

### Verification
- `FINGPT_API_KEY=devkey bun run build:full` → `grep -c devkey dist/main.js` = **1** (key baked, helper retained).
- keyless `bun run build:full` → `grep -c devkey dist/main.js` = **0** (dev build sends no header); `process.env.FINGPT_API_KEY` fully substituted (0 live lookups).
- ⏳ **Manual E2E handoff** (headless CI can't load an unpacked extension): load `dist/` against a `FINGPT_API_KEY=devkey` backend and confirm gated requests carry `Authorization: Bearer devkey` in DevTools → Network.

### ⚠️ Rollout ordering
**Merge + release this, then let the built extension propagate to installs BEFORE merging Phase 3** (which enforces the 14 extension routes). Phase 3 is prepared as a separate PR held on that propagation window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)