### PR TITLE
feat(api): enforce bearer auth on the 14 extension views (endpoint-auth P3) — HOLD until P2 propagates

### DIFF
--- a/Concierge/.env.concierge.example
+++ b/Concierge/.env.concierge.example
@@ -8,8 +8,12 @@ DISCORD_BOT_TOKEN=
 # Co-located API container; prefer localhost over the public host.
 FINSEARCH_API_BASE=http://localhost:8000
 
-# Optional. Usually unset — the extension endpoints aren't Bearer-gated.
-# FINGPT_API_KEY=
+# REQUIRED against a production backend: get_chat_response_stream/ (the route
+# Concierge streams from) is now Bearer-gated, so every chat turn 401s without
+# this. Set it to the deployment's FINGPT_API_KEY; finsearch_client sends it as
+# `Authorization: Bearer <key>` on the session. Leave empty ONLY against a dev
+# backend that runs with auth open.
+FINGPT_API_KEY=
 
 # Optional. Durable identity store (the ATL anchor). Default: data/identity.sqlite
 # CONCIERGE_IDENTITY_DB=data/identity.sqlite

--- a/Docs/source/api_reference.rst
+++ b/Docs/source/api_reference.rst
@@ -47,10 +47,18 @@ The **OpenAI-compatible endpoints** (``/v1/models``, ``/v1/chat/completions``) u
 - When authentication is enabled, every ``/v1/*`` request must include the ``Authorization`` header.
 
 .. note::
-   The extension and utility endpoints documented below do **not** currently
-   require an API key. They are protected by per-client rate limiting and
-   cookie-rooted session isolation. Extending bearer authentication to these
-   endpoints is tracked on the security roadmap.
+   The extension and utility endpoints documented below now require the same
+   ``Authorization: Bearer <FINGPT_API_KEY>`` header as ``/v1/*`` whenever the
+   server is key-configured (dev-open / prod-fail-closed, exactly as described
+   above). Two endpoints stay exempt: ``/health/`` (the unauthenticated
+   liveness probe) and ``/api/axioms/xbrl/<filename>/`` (fetched by a plain
+   browser download that cannot attach a header — protected instead by rate
+   limiting and an opaque, server-chosen filename). Per-client rate limiting
+   and cookie-rooted session isolation remain in force on top of the bearer
+   gate. Because a publicly distributed extension bundle is extractable, the
+   shared key is a **coarse gate** against drive-by API abuse, not per-user
+   authentication; per-user attribution is deferred to the identity/login
+   system.
 
 **Error responses (401):**
 
@@ -496,11 +504,13 @@ Extension & Utility Endpoints
 -----------------------------
 
 These endpoints back the Chrome extension and other first-party surfaces.
-They are **unauthenticated** (see the note under `Authentication`_): each
-client is rate-limited, and conversations are isolated via the signed
-``fingpt_sessionid`` cookie. Callers may pass an optional ``session_id``
-(query string or JSON body) to select a sub-conversation *under their own*
-cookie root — it can never address another browser's history.
+They require the ``Authorization: Bearer <FINGPT_API_KEY>`` header when the
+server is key-configured (see the note under `Authentication`_) — except
+``/health/`` and ``/api/axioms/xbrl/<filename>/``, which stay unauthenticated.
+Each client is additionally rate-limited, and conversations are isolated via
+the signed ``fingpt_sessionid`` cookie. Callers may pass an optional
+``session_id`` (query string or JSON body) to select a sub-conversation
+*under their own* cookie root — it can never address another browser's history.
 
 .. list-table::
    :widths: 12 34 54
@@ -553,7 +563,7 @@ cookie root — it can never address another browser's history.
      - Does this session have validatable claims?
    * - GET
      - ``/api/axioms/xbrl/<filename>/``
-     - Serve a bundled XBRL filing (Sources popup)
+     - Serve a bundled XBRL filing (Sources popup) — *unauthenticated* browser download (see the note under `Authentication`_)
    * - GET
      - ``/api/signals/news/``
      - Latest news→sentiment signals artifact

--- a/Docs/source/installation/manual_install.rst
+++ b/Docs/source/installation/manual_install.rst
@@ -43,6 +43,22 @@ Only needed when you change the extension source.
    bun install
    bun run build:full
 
+.. note::
+   The commands above produce a **keyless** dev build: it sends no
+   ``Authorization`` header and is meant for a dev backend running with auth
+   open. To build a release bundle that talks to a **key-gated** backend, bake
+   the coarse-gate key in at build time:
+
+   .. code-block:: bash
+
+      cd Main/frontend
+      FINGPT_API_KEY=YOUR_BACKEND_KEY bun run build:full
+
+   A webpack ``DefinePlugin`` bakes this *frontend* build-time key into the
+   (extractable) bundle as a coarse gate against drive-by abuse. It is distinct
+   from — though normally equal to — the backend ``FINGPT_API_KEY`` env var
+   described below.
+
 Environment Variables
 ---------------------
 

--- a/Docs/source/project_structure.rst
+++ b/Docs/source/project_structure.rst
@@ -171,6 +171,13 @@ Frontend Highlights
 
 * ``bun run build:full`` runs ``build-css.js`` then Webpack bundling.
 * ``webpack.config.js`` handles JS bundling with Babel transpilation.
+* ``webpack.config.js`` also bakes the coarse-gate ``FINGPT_API_KEY`` from the
+  build environment into the bundle via a ``DefinePlugin`` stage. A release
+  build run as ``FINGPT_API_KEY=… bun run build:full`` makes the extension send
+  ``Authorization: Bearer`` on backend calls (``getAuthHeaders()`` in
+  ``backendConfig.js``); a keyless dev build sends no header and works against
+  an open dev backend. The bundled key is extractable — a **coarse gate**
+  against drive-by abuse, not per-user auth.
 * ``dist/`` is the final output—load as unpacked extension in Chrome.
 * ``src/modules/`` contains modular JavaScript organized by function.
 * ``src/modules/styles/`` contains component-specific CSS files.

--- a/Main/README.md
+++ b/Main/README.md
@@ -96,8 +96,8 @@ backend/
 
 ### 2.2 Key Components
 
-**`api/views.py`** – Browser extension API endpoints:
-- `/health/` - Service health check (returns version)
+**`api/views.py`** – Browser extension API endpoints (all require `Authorization: Bearer <FINGPT_API_KEY>` when the server is key-configured — dev-open / prod-fail-closed — except `/health/`):
+- `/health/` - Service health check (returns version); **no auth**
 - `/get_chat_response/` - Thinking mode chat
 - `/get_chat_response_stream/` - Thinking mode with SSE streaming
 - `/get_adv_response/` - Research mode with web search
@@ -348,6 +348,8 @@ bun run build:full
 See `InternalDocs/api/API_DOCUMENTATION.md` for the complete API reference with examples.
 
 ### Browser Extension Endpoints (in `api/views.py`)
+
+All endpoints below require `Authorization: Bearer <FINGPT_API_KEY>` when the server has a key configured (dev-open / prod-fail-closed), **except `/health/`**. The extension bakes this coarse-gate key in at build time (webpack `DefinePlugin`); the Concierge Discord bot sends it from its `FINGPT_API_KEY` env var.
 
 | Endpoint | Method | Purpose |
 |----------|--------|---------|

--- a/Main/backend/api/views.py
+++ b/Main/backend/api/views.py
@@ -51,6 +51,7 @@ from datascraper.url_tools import _scrape_url_impl as scrape_url
 from datascraper.session_key import derive_conversation_key
 from datascraper import ssrf_guard
 
+from api.auth import require_bearer_auth
 from api.agent_budget import agent_run_slot, BudgetExceeded, ConcurrencyExceeded
 from api.identity import get_request_identity
 from api.request_params import MalformedJSONBody, merged_params
@@ -174,6 +175,7 @@ def _wrap_for_client(prose: str, session_id: str) -> str:
 
 
 @csrf_exempt
+@require_bearer_auth
 @ratelimit(key='api.identity.ratelimit_key', rate=settings.API_RATE_LIMIT, method=ALL, block=True)
 def has_axiom_claims(request: HttpRequest) -> JsonResponse:
     """Lightweight check: does the current session have any ratio claims
@@ -222,6 +224,7 @@ def xbrl_filing_download(request: HttpRequest, filename: str) -> FileResponse:
 
 
 @csrf_exempt
+@require_bearer_auth
 @require_http_methods(['POST'])
 @ratelimit(key='api.identity.ratelimit_key', rate=settings.API_RATE_LIMIT, method=ALL, block=True)
 def validate_claims(request: HttpRequest) -> JsonResponse:
@@ -260,6 +263,7 @@ def validate_claims(request: HttpRequest) -> JsonResponse:
 # so a wrong-method probe is bounced with 405 without consuming the caller's
 # rate budget.
 @csrf_exempt
+@require_bearer_auth
 @require_http_methods(['GET', 'POST'])
 @ratelimit(key='api.identity.ratelimit_key', rate=settings.API_RATE_LIMIT, method=ALL, block=True)
 def chat_response(request: HttpRequest) -> JsonResponse:
@@ -360,6 +364,7 @@ def chat_response(request: HttpRequest) -> JsonResponse:
 
 
 @csrf_exempt
+@require_bearer_auth
 @require_http_methods(['GET', 'POST'])
 @ratelimit(key='api.identity.ratelimit_key', rate=settings.API_RATE_LIMIT, method=ALL, block=True)
 def adv_response(request: HttpRequest) -> JsonResponse:
@@ -489,6 +494,7 @@ def adv_response(request: HttpRequest) -> JsonResponse:
 
 
 @csrf_exempt
+@require_bearer_auth
 @require_http_methods(['GET', 'POST'])
 @ratelimit(key='api.identity.ratelimit_key', rate=settings.API_RATE_LIMIT, method=ALL, block=True)
 def chat_response_stream(request: HttpRequest) -> StreamingHttpResponse:
@@ -680,6 +686,7 @@ def chat_response_stream(request: HttpRequest) -> StreamingHttpResponse:
 
 
 @csrf_exempt
+@require_bearer_auth
 @require_http_methods(['GET', 'POST'])
 @ratelimit(key='api.identity.ratelimit_key', rate=settings.API_RATE_LIMIT, method=ALL, block=True)
 def adv_response_stream(request: HttpRequest) -> StreamingHttpResponse:
@@ -884,6 +891,7 @@ def adv_response_stream(request: HttpRequest) -> StreamingHttpResponse:
 # None count), which would take the LB probe down together with Redis. Pinned
 # by tests/test_endpoint_protection.py.
 @csrf_exempt
+@require_bearer_auth
 @ratelimit(key='api.identity.ratelimit_key', rate=settings.API_RATE_LIMIT, method=ALL, block=True)
 def auto_scrape(request: HttpRequest) -> JsonResponse:
     """
@@ -948,6 +956,7 @@ def auto_scrape(request: HttpRequest) -> JsonResponse:
 
 
 @csrf_exempt
+@require_bearer_auth
 @ratelimit(key='api.identity.ratelimit_key', rate=settings.API_RATE_LIMIT, method=ALL, block=True)
 def add_webtext(request: HttpRequest) -> JsonResponse:
     """
@@ -1006,6 +1015,7 @@ def add_webtext(request: HttpRequest) -> JsonResponse:
 # already sends POST (dist/main.js fetch {method:"POST"}), so only the
 # accidental-GET surface changes.
 @csrf_exempt
+@require_bearer_auth
 @require_http_methods(['POST'])
 @ratelimit(key='api.identity.ratelimit_key', rate=settings.API_RATE_LIMIT, method=ALL, block=True)
 def clear(request: HttpRequest) -> JsonResponse:
@@ -1057,6 +1067,7 @@ def health(request: HttpRequest) -> JsonResponse:
 
 
 @csrf_exempt
+@require_bearer_auth
 @ratelimit(key='api.identity.ratelimit_key', rate=settings.API_RATE_LIMIT, method=ALL, block=True)
 def get_sources(request: HttpRequest) -> JsonResponse:
     """Get sources for a query"""
@@ -1076,6 +1087,7 @@ def get_sources(request: HttpRequest) -> JsonResponse:
 # the extension has no CSRF token; the endpoint stays side-effect-free
 # (log line only) so the exemption is bounded-damage by construction.
 @csrf_exempt
+@require_bearer_auth
 @require_http_methods(['GET', 'POST'])
 @ratelimit(key='api.identity.ratelimit_key', rate=settings.API_RATE_LIMIT, method=ALL, block=True)
 def log_question(request: HttpRequest) -> JsonResponse:
@@ -1097,6 +1109,7 @@ def log_question(request: HttpRequest) -> JsonResponse:
     return JsonResponse({'status': 'success'})
 
 
+@require_bearer_auth
 @ratelimit(key='api.identity.ratelimit_key', rate=settings.API_RATE_LIMIT, method=ALL, block=True)
 def get_preferred_urls(request: HttpRequest) -> JsonResponse:
     """Retrieve preferred URLs from storage"""
@@ -1106,6 +1119,7 @@ def get_preferred_urls(request: HttpRequest) -> JsonResponse:
 
 
 @csrf_exempt
+@require_bearer_auth
 @ratelimit(key='api.identity.ratelimit_key', rate=settings.API_RATE_LIMIT, method=ALL, block=True)
 def sync_preferred_urls(request: HttpRequest) -> JsonResponse:
     """Sync preferred URLs from frontend to backend storage"""
@@ -1125,6 +1139,7 @@ def sync_preferred_urls(request: HttpRequest) -> JsonResponse:
     return JsonResponse({'status': 'failed'}, status=400)
 
 
+@require_bearer_auth
 @ratelimit(key='api.identity.ratelimit_key', rate=settings.API_RATE_LIMIT, method=ALL, block=True)
 def get_available_models(request: HttpRequest) -> JsonResponse:
     """Get list of available models with their configurations"""

--- a/Main/backend/tests/conftest.py
+++ b/Main/backend/tests/conftest.py
@@ -37,7 +37,7 @@ def core_prompt() -> str:
 
 
 @pytest.fixture(autouse=True)
-def _hermetic_fingpt_api_key():
+def _hermetic_fingpt_api_key(monkeypatch):
     """Keep every test hermetic with respect to FINGPT_API_KEY.
 
     django.setup() above runs settings' load_dotenv(Main/backend/.env), so a key
@@ -45,12 +45,8 @@ def _hermetic_fingpt_api_key():
     now gates the extension/axiom/agent views on that key, so an ambient value
     would 401 the many pre-existing tests that invoke those views without an
     Authorization header. Clear it by default so those tests hit the dev-open
-    path; the bearer-auth tests set it explicitly via monkeypatch (which runs
-    after this fixture and therefore wins).
+    path. The bearer-auth tests set it explicitly via monkeypatch.setenv; because
+    that lands on the same MonkeyPatch instance as this delenv and the two unwind
+    together (LIFO) at teardown, the per-test setenv wins within the test.
     """
-    saved = os.environ.pop("FINGPT_API_KEY", None)
-    try:
-        yield
-    finally:
-        if saved is not None:
-            os.environ["FINGPT_API_KEY"] = saved
+    monkeypatch.delenv("FINGPT_API_KEY", raising=False)

--- a/Main/backend/tests/conftest.py
+++ b/Main/backend/tests/conftest.py
@@ -34,3 +34,23 @@ import mcp_server.xbrl.parser  # noqa: F401,E402 — populate sys.modules
 @pytest.fixture(scope="session")
 def core_prompt() -> str:
     return CORE_PROMPT_PATH.read_text(encoding="utf-8")
+
+
+@pytest.fixture(autouse=True)
+def _hermetic_fingpt_api_key():
+    """Keep every test hermetic with respect to FINGPT_API_KEY.
+
+    django.setup() above runs settings' load_dotenv(Main/backend/.env), so a key
+    set in a developer's .env becomes a process-wide os.environ value. api.auth
+    now gates the extension/axiom/agent views on that key, so an ambient value
+    would 401 the many pre-existing tests that invoke those views without an
+    Authorization header. Clear it by default so those tests hit the dev-open
+    path; the bearer-auth tests set it explicitly via monkeypatch (which runs
+    after this fixture and therefore wins).
+    """
+    saved = os.environ.pop("FINGPT_API_KEY", None)
+    try:
+        yield
+    finally:
+        if saved is not None:
+            os.environ["FINGPT_API_KEY"] = saved

--- a/Main/backend/tests/test_api_auth.py
+++ b/Main/backend/tests/test_api_auth.py
@@ -2,6 +2,7 @@
 import os
 from unittest.mock import patch
 
+import pytest
 from django.test import Client, SimpleTestCase, RequestFactory, override_settings
 from django.http import JsonResponse
 
@@ -99,3 +100,61 @@ def test_signals_accepts_valid_bearer(monkeypatch):
     resp = Client().get("/api/signals/news/",
                         HTTP_AUTHORIZATION="Bearer sekret")
     assert resp.status_code != 401
+
+
+# ---------------------------------------------------------------------------
+# Phase 3: the 14 extension-facing views must enforce bearer auth. health/ and
+# the xbrl download stay exempt. Client-driven so the decorator is proven
+# through real URL dispatch; HERMETIC_REQUEST_SETTINGS avoids the DisallowedHost
+# 400 + SSL-redirect 301 traps (same helper the signals tests above use).
+# ---------------------------------------------------------------------------
+# The 14 extension routes that MUST enforce bearer auth (health + xbrl excluded).
+GATED_EXTENSION_PATHS = [
+    "/input_webtext/", "/api/auto_scrape/", "/get_chat_response/",
+    "/get_chat_response_stream/", "/get_adv_response/", "/get_adv_response_stream/",
+    "/get_source_urls/", "/clear_messages/", "/api/get_preferred_urls/",
+    "/api/sync_preferred_urls/", "/log_question/", "/api/get_available_models/",
+    "/api/axioms/validate/", "/api/axioms/has_claims/",
+]
+
+
+@pytest.mark.parametrize("path", GATED_EXTENSION_PATHS)
+@override_settings(**HERMETIC_REQUEST_SETTINGS)
+def test_extension_route_401_without_header(monkeypatch, path):
+    # Auth is the outermost functional decorator: no header -> 401 before the
+    # method-check / ratelimit / view body. A GET short-circuits at auth, so
+    # this never runs the heavy chat/scrape view bodies.
+    monkeypatch.setenv("FINGPT_API_KEY", "sekret")
+    assert Client().get(path).status_code == 401
+
+
+# Allow-testable at unit level without running a heavy body:
+#   - POST-only routes: GET+header passes auth, then 405 (body never runs) -> spans axioms + context.
+#   - get_available_models: a static read.
+SAFE_ALLOW_PATHS = [
+    "/api/axioms/validate/",       # axioms group  (POST-only -> 405)
+    "/clear_messages/",            # context group (POST-only -> 405)
+    "/api/get_available_models/",  # static read   (-> 200-ish)
+]
+
+
+@pytest.mark.parametrize("path", SAFE_ALLOW_PATHS)
+@override_settings(**HERMETIC_REQUEST_SETTINGS)
+def test_gated_route_accepts_valid_header(monkeypatch, path):
+    # A correct key clears the auth gate: the response is anything BUT 401.
+    monkeypatch.setenv("FINGPT_API_KEY", "sekret")
+    assert Client().get(path, HTTP_AUTHORIZATION="Bearer sekret").status_code != 401
+
+
+@override_settings(REQUIRE_FINGPT_API_KEY=False, **HERMETIC_REQUEST_SETTINGS)
+def test_gated_route_open_in_dev(monkeypatch):
+    monkeypatch.delenv("FINGPT_API_KEY", raising=False)
+    assert Client().get("/api/get_available_models/").status_code != 401
+
+
+@override_settings(**HERMETIC_REQUEST_SETTINGS)
+def test_exempt_routes_never_401(monkeypatch):
+    # health + xbrl download must stay reachable without a header.
+    monkeypatch.setenv("FINGPT_API_KEY", "sekret")
+    assert Client().get("/health/").status_code != 401
+    assert Client().get("/api/axioms/xbrl/nope.json/").status_code != 401  # 400/404 from view, not 401


### PR DESCRIPTION
## ⚠️ DO NOT MERGE until Phase 2 (#355) has propagated to extension installs

This PR flips the 14 extension-facing routes from open to **enforced**. A publicly-distributed extension cannot be updated atomically, so merging this before the Phase 2 header-sending build (#355) has reached installs would **401 every not-yet-updated user**. Merge order: **#355 → release → wait for propagation → this PR**. The propagation-window cutover is @FlyM1ss's scheduling call.

## Phase 3 of `finsearch-endpoint-auth-01`

Applies `@require_bearer_auth` to the 14 extension-facing non-`/v1` views in `api/views.py`:
- **12 views under `@csrf_exempt`** → `@require_bearer_auth` inserted directly under it (so `@csrf_exempt` stays outermost — the CSRF middleware needs the marker on the resolved callable) and above `@ratelimit`/`@require_http_methods` (a 401 returns before a rate-limit token is spent or the body runs).
- **2 GET reads** (`get_preferred_urls`, `get_available_models`, no `@csrf_exempt`) → `@require_bearer_auth` topmost.

Dev-open / prod-fail-closed semantics are unchanged (reuses `api/auth.py` from Phase 1).

### Exempt (unchanged, justified)
- `health/` — deploy/liveness probe, must stay unauthenticated.
- `api/axioms/xbrl/<filename>/` — fetched by a plain `<a download>` click that can't attach a header; protected by rate-limit + opaque server-chosen filename.

### Concierge
`get_chat_response_stream/` has a second client — the Concierge bot. Its `finsearch_client` already attaches `Authorization: Bearer` on the aiohttp session when `FINGPT_API_KEY` is set, so no code change is needed; `.env.concierge.example` is updated to make the key **required** against a prod backend. **The Concierge deploy env must carry `FINGPT_API_KEY` before/with this rollout** or its chat turns 401.

### Tests (TDD)
- `test_extension_route_401_without_header` — parametrized over all 14 paths; each 401s without a header (proven through real URL dispatch + `HERMETIC_REQUEST_SETTINGS`).
- `test_gated_route_accepts_valid_header` — a valid key clears the gate (POST-only routes then 405; the static read passes).
- `test_gated_route_open_in_dev`, `test_exempt_routes_never_401` — dev-open + health/xbrl stay reachable.

### Found + fixed in adversarial review of this diff
`tests/conftest.py` gains an **autouse fixture that clears `FINGPT_API_KEY`** so the whole suite stays hermetic. `settings.py` `load_dotenv()` makes a developer's `.env` key ambient at `django.setup()`; once these views are gated, an ambient key would 401 the many pre-existing tests that call them without a header (reproduced: `FINGPT_API_KEY=x` → 7 failures in `test_axiom_views.py`). The auth tests opt back in via `monkeypatch`. Verified green with and without an ambient key.

**Full backend suite: 729 passed, 1 skipped, 38 subtests.**

### Still open (handoffs, not in this PR)
- **User-facing docs** (`api_reference.rst`, `README.md`, `project_structure.rst`, `manual_install.rst`) — drafts pending @FlyM1ss wording sign-off; will land as a follow-up commit here.
- **Task 8 browser E2E** — load the Phase 2 extension build against a key-enabled backend and confirm chat/scrape/prefs/validate all succeed with the header and 401 without. Headless CI can't load the extension.

🤖 Generated with [Claude Code](https://claude.com/claude-code)