### PR TITLE
build(ext): auto-load coarse-gate FINGPT_API_KEY from .env.local

### DIFF
--- a/Main/frontend/.env.local.example
+++ b/Main/frontend/.env.local.example
@@ -1,0 +1,16 @@
+# Frontend build-time coarse-gate key (endpoint-auth).
+#
+# Copy this file to `.env.local` (gitignored) and set the value to the SAME key
+# the production backend enforces as FINGPT_API_KEY. webpack.config.js reads it
+# automatically at build time, so `bun run build:full` bakes it into the bundle
+# without you pasting the key on the command line every time.
+#
+#   cp .env.local.example .env.local   # then edit the value below
+#
+# Precedence: an inline `FINGPT_API_KEY=… bun run build:full` or a CI secret in
+# process.env still wins over this file. Leave `.env.local` absent (or the value
+# empty) to build a KEYLESS dev bundle for an auth-open local backend.
+#
+# The bundled key is EXTRACTABLE from the shipped extension — it is a COARSE gate
+# against drive-by API abuse, NOT per-user authentication.
+FINGPT_API_KEY=

--- a/Main/frontend/check-dist.js
+++ b/Main/frontend/check-dist.js
@@ -28,6 +28,21 @@ for (const file of requiredFiles) {
   }
 }
 
+// Report whether the built bundle carries the coarse-gate key, so a silent
+// KEYLESS build (which 401s against a key-gated backend) is impossible to miss.
+// Informational only — a keyless dev bundle is a legitimate build, not an error.
+const mainJsPath = path.join(distDir, 'main.js');
+if (fs.existsSync(mainJsPath)) {
+  const bundle = fs.readFileSync(mainJsPath, 'utf8');
+  const baked = bundle.match(/FINGPT_API_KEY\)?\s*\|\|\s*"((?:[^"\\]|\\.)*)"/);
+  const keyed = Boolean(baked && baked[1]);
+  console.log(
+    keyed
+      ? 'Bundle auth: KEYED — sends Authorization: Bearer (ready to publish).'
+      : 'Bundle auth: KEYLESS — no Authorization header (dev build; will 401 against a key-gated backend).'
+  );
+}
+
 if (allGood) {
   console.log(`\nAll required files are present in dist/. Update the plugin in your browser to verify the updates!\n`);
   process.exit(0);

--- a/Main/frontend/webpack.config.js
+++ b/Main/frontend/webpack.config.js
@@ -1,10 +1,48 @@
 const path = require('path');
+const fs = require('fs');
 const CopyPlugin = require('copy-webpack-plugin');
 const webpack = require('webpack');
 const TerserPlugin = require('terser-webpack-plugin');
 
 const { RawSource } = webpack.sources;
 const isBun = Boolean(process.versions && process.versions.bun);
+
+// Resolve the coarse-gate FINGPT_API_KEY that gets baked into the bundle.
+// Precedence, highest first:
+//   1. process.env.FINGPT_API_KEY — an inline `FINGPT_API_KEY=… bun run build:full`,
+//      a CI-injected secret, or a value bun auto-loaded from a .env file.
+//   2. A `FINGPT_API_KEY=…` line in a gitignored `.env.local` (then `.env`) beside
+//      this config — so a release build picks the key up automatically and you never
+//      have to paste it on the command line again.
+// A machine with none of these still builds a valid KEYLESS dev bundle (no
+// Authorization header), which is correct for an auth-open local backend.
+function resolveApiKey() {
+    if (process.env.FINGPT_API_KEY) {
+        return process.env.FINGPT_API_KEY;
+    }
+    for (const name of ['.env.local', '.env']) {
+        let contents;
+        try {
+            contents = fs.readFileSync(path.join(__dirname, name), 'utf8');
+        } catch {
+            continue; // file absent — try the next candidate
+        }
+        const match = contents.match(/^\s*(?:export\s+)?FINGPT_API_KEY\s*=\s*(.*)$/m);
+        if (match) {
+            // strip trailing whitespace/CR and a single pair of surrounding quotes
+            return match[1].trim().replace(/^(['"])(.*)\1$/, '$2');
+        }
+    }
+    return '';
+}
+
+const COARSE_GATE_API_KEY = resolveApiKey();
+console.log(
+    COARSE_GATE_API_KEY
+        ? '[webpack] Baking coarse-gate FINGPT_API_KEY into the bundle (KEYED release build).'
+        : '[webpack] No FINGPT_API_KEY found (env or .env.local) — building a KEYLESS dev '
+          + 'bundle; backend calls will 401 against a key-gated backend.'
+);
 
 const escapeNonAscii = (input) => {
     let modified = false;
@@ -115,10 +153,10 @@ module.exports = {
         hints: "warning"
     },
     plugins: [
-        // Bake the coarse-gate API key from the build env into the bundle. Empty when
-        // FINGPT_API_KEY is unset (local/dev builds) -> getAuthHeaders() returns {}.
+        // Bake the resolved coarse-gate API key (see resolveApiKey above) into the
+        // bundle. Empty for keyless dev builds -> getAuthHeaders() returns {}.
         new webpack.DefinePlugin({
-            'process.env.FINGPT_API_KEY': JSON.stringify(process.env.FINGPT_API_KEY || ''),
+            'process.env.FINGPT_API_KEY': JSON.stringify(COARSE_GATE_API_KEY),
         }),
         new webpack.BannerPlugin({
             banner: '// @charset "UTF-8";',


### PR DESCRIPTION
## What & why

The extension's coarse-gate `FINGPT_API_KEY` is baked into the bundle at build
time (webpack `DefinePlugin`). Until now that only worked if you ran
`FINGPT_API_KEY=… bun run build:full` with the key on the command line — easy to
forget, and a plain `bun run build:full` silently produced a **keyless** bundle
that 401s against the now-enforcing backend (endpoint-auth P3).

This makes the key resolution automatic and adds guardrails so a keyless bundle
can't ship unnoticed. **No change to shipped extension behavior** — the same
coarse-gate key is baked in; only how the build *discovers* it changed.

## Changes

- **`webpack.config.js`** — new `resolveApiKey()` helper. Precedence:
  1. `process.env.FINGPT_API_KEY` (inline / CI secret / bun-auto-loaded `.env`)
  2. a `FINGPT_API_KEY=…` line in a gitignored **`.env.local`** (then `.env`) beside the config
  3. otherwise empty → a valid **keyless dev bundle** (correct for an auth-open local backend)
  Also logs `KEYED` vs `KEYLESS` at build time.
- **`check-dist.js`** — end-of-`build:full` report: inspects `dist/main.js` and prints
  `Bundle auth: KEYED / KEYLESS`. Informational only (keyless dev builds stay valid).
- **`.env.local.example`** — committed template documenting the mechanism.

Contributors just run `cp .env.local.example .env.local`, set the value once, and
every `bun run build:full` is keyed automatically. `.env.local` is covered by the
existing repo-wide `.env.*` gitignore rule, so the secret can't be committed.

## Verification

- Throwaway-key build → webpack logs `KEYED`, `check-dist` reports `KEYED`, baked
  literal length matched the key exactly.
- Keyless build (no file/env) → logs `KEYLESS`, `check-dist` reports `KEYLESS`.
- Real prod key in `.env.local` → bundle's baked key `sha256[:8]` matches the key
  the backend enforces.

## Note for reviewer

CodeQL may re-raise **`js/build-artifact-leak`** on the `DefinePlugin` line — this
is the same **by-design** coarse-gate finding dismissed on #355 (the bundle is
extractable; this is a drive-by-abuse gate, not per-user auth). Dismiss, don't
"fix".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
