### PR TITLE
feat(api): add /api/news/items/ raw news-items endpoint

### DIFF
--- a/.github/workflows/backend-deploy.yml
+++ b/.github/workflows/backend-deploy.yml
@@ -313,7 +313,7 @@ jobs:
             cat > "$OVERRIDE_DIR/override.conf" <<EOF
             [Service]
             ExecStart=
-            ExecStart=/usr/bin/podman run --name ${SYSTEMD_UNIT} --replace --rm --cap-drop=ALL --cap-add=NET_ADMIN --cap-add=CHOWN --cap-add=SETUID --cap-add=SETGID --cap-add=SETPCAP --pids-limit=1024 --read-only --tmpfs=/tmp:rw,size=512m,mode=1777 --tmpfs=/app/staticfiles:rw,mode=0755 --tmpfs=/home/fingpt:rw,mode=0755 --cgroups=split --sdnotify=conmon -d --memory=1.7g --memory-swap=2g --network fingpt-net -v /home/deploy/fingpt/runtime:/app/runtime:U,Z -v /home/deploy/fingpt/heartbeat/signals:/app/signals:ro,Z --env SIGNALS_DIR=/app/signals --publish 127.0.0.1:8000:8000 --env-file /home/deploy/fingpt/envs/.env.production --env REDIS_URL=redis://fingpt-redis:6379/0 ${REMOTE_IMAGE}
+            ExecStart=/usr/bin/podman run --name ${SYSTEMD_UNIT} --replace --rm --cap-drop=ALL --cap-add=NET_ADMIN --cap-add=CHOWN --cap-add=SETUID --cap-add=SETGID --cap-add=SETPCAP --pids-limit=1024 --read-only --tmpfs=/tmp:rw,size=512m,mode=1777 --tmpfs=/app/staticfiles:rw,mode=0755 --tmpfs=/home/fingpt:rw,mode=0755 --cgroups=split --sdnotify=conmon -d --memory=1.7g --memory-swap=2g --network fingpt-net -v /home/deploy/fingpt/runtime:/app/runtime:U,Z -v /home/deploy/fingpt/heartbeat/signals:/app/signals:ro,Z --env SIGNALS_DIR=/app/signals -v /home/deploy/fingpt/heartbeat/digests:/app/digests:ro,Z --env RAW_ITEMS_DIR=/app/digests --publish 127.0.0.1:8000:8000 --env-file /home/deploy/fingpt/envs/.env.production --env REDIS_URL=redis://fingpt-redis:6379/0 ${REMOTE_IMAGE}
             EOF
 
             systemctl --user daemon-reload

--- a/.github/workflows/heartbeat-tests.yml
+++ b/.github/workflows/heartbeat-tests.yml
@@ -7,10 +7,23 @@ on:
     paths:
       - "Heartbeat/**"
       - ".github/workflows/heartbeat-tests.yml"
+      # Main/backend/api/signals_views.py is deliberately NOT listed here,
+      # only on pull_request below: this trigger also gates the deploy job,
+      # whose sole condition is the main-ref check (paths scope the workflow
+      # RUN, not a job), so a Django-only merge would redeploy the droplet's
+      # heartbeat scripts — silently shipping any held-back rollout on a
+      # commit that touched no Heartbeat file.
   pull_request:
     paths:
       - "Heartbeat/**"
       - ".github/workflows/heartbeat-tests.yml"
+      # The backend vendors a port of news_signals.py's validation gate
+      # (clean_text/validation_gate -> _clean_text/_validate_items) and
+      # Heartbeat/tests/test_port_parity.py is what pins the two copies
+      # together, so a port-side edit must run this suite. PR-time is the
+      # right gate: the point is to make drift impossible to MERGE, and
+      # deploy skips on PR refs anyway.
+      - "Main/backend/api/signals_views.py"
   workflow_dispatch:
 
 env:

--- a/Docs/source/api_reference.rst
+++ b/Docs/source/api_reference.rst
@@ -567,6 +567,9 @@ the signed ``fingpt_sessionid`` cookie. Callers may pass an optional
    * - GET
      - ``/api/signals/news/``
      - Latest news→sentiment signals artifact
+   * - GET
+     - ``/api/news/items/``
+     - Raw news stories from the newest Heartbeat batch
 
 All share the ``API_RATE_LIMIT`` budget (``429 {"error": "rate_limited"}``
 when exceeded). The chat endpoints can also return ``503 {"error": "busy"}``
@@ -721,6 +724,44 @@ n_articles}`` with ``score`` in ``[-1, 1]``.
 an ``ETag`` validator and ``Cache-Control: public, max-age=300``.
 ``Last-Modified`` is sent only on unfiltered responses — ``tickers=``-filtered
 variants are ETag-only, so conditional requests for them must use
+``If-None-Match``.
+
+News Items
+~~~~~~~~~~
+
+``GET /api/news/items/`` serves the **raw news stories** of the newest
+Heartbeat batch — the corpus the signals above are derived from, before any
+LLM scoring. Like ``/api/signals/news/`` it is an integration surface for
+external consumers; the browser extension does not call it.
+
+**Query parameters:**
+
+- ``limit=N`` — how many stories to return, newest first. Clamped to
+  ``[1, 200]``; defaults to ``50`` when absent. A non-integer value returns
+  ``400 {"error": "bad_limit"}``.
+
+There is no ``as_of`` here: this endpoint always reads the single newest
+batch.
+
+**Response (200):** ``{schema_version, items, count, batch}``, where ``batch``
+names the source file and each entry of ``items`` is
+``{guid, headline, url, source, published, description, tickers, score}``.
+``published`` is epoch seconds.
+
+.. note::
+
+   ``score`` on this endpoint is the pipeline's **editorial** score — how
+   newsworthy the story is, the gate that decides which stories become
+   sentiment candidates (``SIGNALS_MIN_EDITORIAL_SCORE``). It is *not* the
+   ``[-1, 1]`` sentiment score of the same name under ``/api/signals/news/``.
+   The two fields share a name and nothing else.
+
+``404 {"error": "no_items"}`` when no batch exists, or when the newest one is
+unreadable or validates to zero stories — the endpoint never falls back to an
+older batch, and never returns a ``500``. Responses carry an ``ETag`` and
+``Cache-Control: public, max-age=300``. ``Last-Modified`` is sent only on the
+default-limit variant — an explicit ``?limit`` slices the batch differently,
+so those variants are ETag-only and conditional requests for them must use
 ``If-None-Match``.
 
 ---

--- a/Docs/source/project_structure.rst
+++ b/Docs/source/project_structure.rst
@@ -38,7 +38,7 @@ Backend Structure
    ├── api/                          # REST API layer
    │   ├── views.py                  # Main API endpoints
    │   ├── openai_views.py           # OpenAI-compatible API endpoints
-   │   ├── signals_views.py          # News-signals endpoint (GET /api/signals/news/)
+   │   ├── signals_views.py          # News endpoints (GET /api/signals/news/, GET /api/news/items/)
    │   ├── middleware/               # CORS and custom middleware
    │   ├── utils/                    # API utility functions
    │   ├── apps.py                   # Django app configuration

--- a/Docs/superpowers/specs/2026-07-06-news-to-signals-pipeline-design.md
+++ b/Docs/superpowers/specs/2026-07-06-news-to-signals-pipeline-design.md
@@ -197,7 +197,7 @@ A machine-readable JSON Schema ships at `Heartbeat/schemas/signals-v1.schema.jso
 
 ## 5. Configuration (the v1 tuning surface)
 
-Env vars read by `news_signals.py` (module constants as defaults). This is the surface future user-facing tuning builds on:
+Env vars read by `news_signals.py` (module constants as defaults). This is the surface future user-facing tuning builds on. All are pipeline-only except `SIGNALS_MAX_FILE_MB`, which the Django API reads too (see its row):
 
 | Var | Default | Meaning |
 |-----|---------|---------|
@@ -209,7 +209,7 @@ Env vars read by `news_signals.py` (module constants as defaults). This is the s
 | `SIGNALS_THRESHOLD` | `0.20` | ± threshold for bullish/bearish label (40/60 band, empirically backed; was 0.15) |
 | `SIGNALS_DAMP_CAP` | `0.7` | Max \|score\| when under-corroborated |
 | `SIGNALS_DAMP_MIN_ARTICLES` | `2` | Corroboration needed for \|score\| > damp cap |
-| `SIGNALS_MAX_FILE_MB` | `10` | Reject oversized items files |
+| `SIGNALS_MAX_FILE_MB` | `10` | Reject oversized items files. **Two readers as of 2026-07-14:** `news_signals.py` (via `load_config`) and the Django API (via `settings.RAW_ITEMS_MAX_FILE_MB`, which `GET /api/news/items/` enforces when validating a batch). Deliberately one operator knob — raising it for the pipeline without raising it for the API would 404 a batch the pipeline happily accepted. Set it in `.env.production` alongside the heartbeat's own env file; the two defaults are pinned together by `Heartbeat/tests/test_port_parity.py`. |
 | `SIGNALS_STALENESS_ALERT_H` | `20` | Canary threshold (§6-C). Tuned, not arbitrary: the daily canary check runs 2 h after the daily beat, so a single fully-missed day leaves the newest artifact ~25.5 h old at the *next* day's check — a 30 h threshold would not cross that (it silently absorbs one entire missed day, only firing after a second consecutive miss); 20 h does. |
 
 ## 6. Failure policy (every mode decided)

--- a/Heartbeat/.env.heartbeat.example
+++ b/Heartbeat/.env.heartbeat.example
@@ -36,6 +36,9 @@ DISCORD_CHANNEL_ID=
 # SIGNALS_DAMP_CAP=0.7
 # SIGNALS_DAMP_MIN_ARTICLES=2
 # SIGNALS_MAX_FILE_MB=10
+# NOTE: also read by the Django API (settings.RAW_ITEMS_MAX_FILE_MB) for
+# GET /api/news/items/ — this knob now has two readers. Update both env
+# files together, or the API will 404 a batch the pipeline accepted.
 # Rolling retention cap: keep only the N most recent signals-*.json artifacts;
 # older ones are pruned after each successful sweep. Bounds signals/ growth.
 # SIGNALS_KEEP_N=14

--- a/Heartbeat/README.md
+++ b/Heartbeat/README.md
@@ -14,10 +14,14 @@ fallback), writes a digest log, and posts it to a Discord channel.
 
 The production droplet is 1 vCPU / 2 GB RAM with no pip on the host, so
 `news_heartbeat.py` is a **single stdlib-only Python file** — deploying is
-copying one file; running costs ~30 MB RSS. It is fully decoupled from the
-`fingpt-api` container. Summaries are short, attributed, and always link out to
-the source article (Yahoo ToS posture: orchestration, not raw-data
-redistribution).
+copying one file; running costs ~30 MB RSS. It still runs as an independent
+systemd service and never imports or depends on the Django app — the coupling
+is one-directional: the `fingpt-api` container mounts its `digests/` output
+read-only (as `RAW_ITEMS_DIR`) to serve `GET /api/news/items/`, and
+`Heartbeat/tests/test_port_parity.py` pins the API's vendored copy of the
+validation gate to this script. Summaries are short, attributed, and always
+link out to the source article (Yahoo ToS posture: orchestration, not
+raw-data redistribution).
 
 ## Run
 

--- a/Heartbeat/news_signals.py
+++ b/Heartbeat/news_signals.py
@@ -24,7 +24,7 @@ import urllib.request
 from datetime import date, datetime, timezone
 from pathlib import Path
 
-VERSION = "2026-07-11.2"
+VERSION = "2026-07-14.1"
 SCHEMA_VERSION = 1
 PROMPT_VERSION = 1
 
@@ -45,6 +45,10 @@ DEFAULT_WATCHLIST = " ".join(sorted(set(DOW_30) | set(WATCHLIST_EXTRAS)))
 REQUIRED_FIELDS = ("guid", "title", "link", "source", "published", "score")
 FIELD_CAPS = {"title": 500, "description": 5000, "link": 2000, "source": 200,
               "guid": 200}
+# Required fields that must be strings. A malformed type drops the story — same
+# stance as the numeric parse in validation_gate — so a corrupt field can never
+# reach clean_text as a non-str and can never poison the whole batch.
+TEXT_REQUIRED_FIELDS = ("guid", "title", "link", "source")
 # Caps for the LLM/exception-derived output fields, pinned by the signals-v1
 # schema's maxLength values (headline/source/url are covered by FIELD_CAPS:
 # they pass through from the validated input). Same single-source-of-truth
@@ -109,9 +113,13 @@ def load_env_file(path):
 
 
 def clean_text(s, cap):
+    # non-str (incl. None) collapses to "": the gate must never raise on a
+    # malformed field type. Required-field types are checked in validation_gate;
+    # this keeps optional and LLM-derived callers total on their own.
+    s = s if isinstance(s, str) else ""
     # line boundaries first — CONTROL_RE would strip \v/\f/\x1c-\x1e to
     # nothing and fuse the words they separated
-    s = _LINEBREAK_RE.sub(" ", unicodedata.normalize("NFC", s or ""))
+    s = _LINEBREAK_RE.sub(" ", unicodedata.normalize("NFC", s))
     s = CONTROL_RE.sub("", s)
     s = s.replace("NEWS_DATA", "")  # marker token can never come from the feed
     return s[:cap]
@@ -161,7 +169,8 @@ def load_config():
 
 def validation_gate(path, max_file_mb):
     """Input trust boundary (spec §7.1). Batch-level defects raise ValueError
-    (poison pill, §6.1); a bad `published` drops only that story."""
+    (poison pill, §6.1); a bad `published`, a malformed numeric, or a
+    non-str TEXT_REQUIRED_FIELDS value drops only that story."""
     st = path.stat()
     if st.st_size > max_file_mb * 1024 * 1024:
         raise ValueError(f"file exceeds {max_file_mb}MB")
@@ -181,14 +190,23 @@ def validation_gate(path, max_file_mb):
             continue  # malformed numeric types: drop the story, keep the batch
         if not (lo <= published <= hi):
             continue  # forged/insane epoch: drop the story, keep the batch
+        if not all(isinstance(story[f], str) for f in TEXT_REQUIRED_FIELDS):
+            continue  # malformed text types: drop the story, keep the batch
         story["published"] = published
         story["title"] = clean_text(story["title"], FIELD_CAPS["title"])
         story["description"] = clean_text(story.get("description", ""),
                                           FIELD_CAPS["description"])
         story["source"] = clean_text(story["source"], FIELD_CAPS["source"])
-        story["guid"] = clean_text(str(story["guid"]), FIELD_CAPS["guid"])
-        story["link"] = clean_text(str(story["link"]), FIELD_CAPS["link"])
-        story["tickers"] = [t.upper() for t in story.get("tickers", [])]
+        story["guid"] = clean_text(story["guid"], FIELD_CAPS["guid"])
+        story["link"] = clean_text(story["link"], FIELD_CAPS["link"])
+        # non-list/non-string tickers dropped, never crashed: a corrupt
+        # "tickers":[123] must not .upper() -> AttributeError, which the only
+        # caller (process_batch's ValueError-only except) would not catch and
+        # which would abort the whole sweep; a bare "tickers":"AAPL" must not
+        # char-iterate to ['A','A','P','L'].
+        raw_tickers = story.get("tickers", [])
+        story["tickers"] = ([t.upper() for t in raw_tickers if isinstance(t, str)]
+                            if isinstance(raw_tickers, list) else [])
         stories.append(story)
     return stories
 

--- a/Heartbeat/tests/fixtures/signals-fixture.json
+++ b/Heartbeat/tests/fixtures/signals-fixture.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "profile": "default",
   "generated_at": "2026-07-06T15:00:00+00:00",
-  "generator": "news_signals.py/2026-07-11.2",
+  "generator": "news_signals.py/2026-07-14.1",
   "model": "gpt-4o-mini",
   "prompt_version": 1,
   "source_items": "items-fixture.jsonl",

--- a/Heartbeat/tests/test_news_signals.py
+++ b/Heartbeat/tests/test_news_signals.py
@@ -83,6 +83,27 @@ class TestFoundation(unittest.TestCase):
         self.assertEqual(ns.clean_text(None, 5), "")
         self.assertEqual(ns.clean_text("x" * 10, 5), "xxxxx")
 
+    def test_clean_text_is_total_non_str_types_collapse_to_empty(self):
+        # D1: clean_text's isinstance guard replaces the old "s or ''"
+        # fallback and must never raise on a non-str input.
+        import news_signals as ns
+        for bad in (True, 123, [], {}):
+            with self.subTest(bad=bad):
+                self.assertEqual(ns.clean_text(bad, 100), "")
+
+    def test_clean_text_no_regression_for_every_input_the_old_fallback_handled(self):
+        # D1 strict-superset proof: "s or ''" returned "" for every falsy
+        # input and passed through every truthy str unchanged (modulo the
+        # existing cleanup). Pin the exact old behavior for the falsy/edge
+        # inputs that worked before this change, so a future edit can't
+        # silently regress them.
+        import news_signals as ns
+        self.assertEqual(ns.clean_text("", 100), "")
+        self.assertEqual(ns.clean_text(None, 100), "")
+        self.assertEqual(ns.clean_text(0, 100), "")
+        self.assertEqual(ns.clean_text(False, 100), "")
+        self.assertEqual(ns.clean_text("0", 100), "0")
+
     def test_clean_text_collapses_embedded_newlines_and_tabs(self):
         # A multi-line feed title must not let forged-looking lines reach
         # logs or artifact consumers: headline/rationale/source/guid are
@@ -256,6 +277,58 @@ class TestValidationGate(unittest.TestCase):
         p = write_items(self.td, [s])
         stories = ns.validation_gate(p, 10)
         self.assertNotIn("\u202e", stories[0]["link"])
+
+    def test_non_string_ticker_elements_are_dropped_not_crashed(self):
+        # F2b regression: [t.upper() for t in tickers] would raise
+        # AttributeError on a non-str element ('int' object has no attribute
+        # 'upper'). run_sweep's ONLY except clause around process_batch is
+        # `except ValueError as exc:  # poison pill` (news_signals.py, the
+        # run_sweep loop) \u2014 an AttributeError is NOT a ValueError, so it
+        # would propagate uncaught and abort the whole sweep instead of just
+        # dropping this one story. Must never raise.
+        bad = make_story(guid="bad", tickers=[123, "msft", None, "nvda"])
+        ok = make_story(guid="ok")
+        p = write_items(self.td, [bad, ok])
+        stories = ns.validation_gate(p, 10)
+        self.assertEqual([s["guid"] for s in stories], ["bad", "ok"])
+        self.assertEqual(stories[0]["tickers"], ["MSFT", "NVDA"])
+
+    def test_bare_string_and_non_list_tickers_become_empty_list(self):
+        # A bare "tickers":"AAPL" must not char-iterate to ['A','A','P','L'].
+        cases = [
+            ("str", "AAPL"),
+            ("none", None),
+            ("dict", {"a": 1}),
+        ]
+        for name, val in cases:
+            with self.subTest(tickers=name):
+                p = write_items(self.td, [make_story(guid=name, tickers=val)],
+                                 name=f"items-{name}.jsonl")
+                stories = ns.validation_gate(p, 10)
+                self.assertEqual(stories[0]["tickers"], [])
+
+    def test_non_string_required_text_field_drops_story_not_batch(self):
+        # F2a's Heartbeat twin: title/source/guid/link must be str, else the
+        # story is dropped (D2) rather than reaching clean_text with a type
+        # that would raise inside unicodedata.normalize.
+        bad_title = make_story(guid="bad-title", title=True)      # JSON bool
+        bad_source = make_story(guid="bad-source", source=123)    # JSON number
+        bad_guid = make_story(guid=456, title="fine")
+        bad_link = make_story(guid="bad-link", link=789)
+        ok = make_story(guid="ok")
+        p = write_items(self.td, [bad_title, bad_source, bad_guid, bad_link, ok])
+        stories = ns.validation_gate(p, 10)
+        self.assertEqual([s["guid"] for s in stories], ["ok"])
+
+    def test_non_string_description_blanks_field_but_keeps_story(self):
+        # description is optional and only reaches clean_text's own isinstance
+        # guard (D1) \u2014 it must NOT be dropped like a TEXT_REQUIRED_FIELDS
+        # violation, just blanked.
+        s = make_story(guid="ok", description=True)
+        p = write_items(self.td, [s])
+        stories = ns.validation_gate(p, 10)
+        self.assertEqual([s["guid"] for s in stories], ["ok"])
+        self.assertEqual(stories[0]["description"], "")
 
 
 class TestSubjectGate(unittest.TestCase):

--- a/Heartbeat/tests/test_port_parity.py
+++ b/Heartbeat/tests/test_port_parity.py
@@ -1,0 +1,362 @@
+"""Cross-copy parity between news_signals.py's input trust boundary and its
+port into Main/backend/api/signals_views.py (news-items endpoint, ATL
+integration Phase B).
+
+WHY THE DUPLICATION EXISTS: Heartbeat/news_signals.py is deliberately
+stdlib-only and single-file (same deployability contract as
+news_heartbeat.py — see that file's docstring), so it cannot be imported
+from Django. Main/backend/api/signals_views.py therefore carries a
+byte-faithful PORT of clean_text/validation_gate (as _clean_text/
+_validate_items) rather than an import. That port is a security trust
+boundary (spec §7.1, sanitizes/validates untrusted scraped input) — a
+silent drift between the two copies is exactly the kind of bug that does
+not show up in either file's own test suite, only in the gap between them.
+
+HOW THIS TEST WORKS WITHOUT IMPORTING DJANGO: signals_views.py imports
+django, django_ratelimit and api.auth, none of which are available to this
+stdlib-only CI job (.github/workflows/heartbeat-tests.yml runs the runner's
+system python3 with no deps — see that file's comment on why this suite,
+not backend-deploy.yml, is where a parity test can actually fire before
+merge). So this test never imports signals_views. Instead it ast.parse()s
+the file's SOURCE, pulls out only the nodes that make up the ported region
+(the names in _WANTED_NODE_NAMES below), and compiles+execs just that
+subset into a bare namespace pre-seeded with the stdlib modules those nodes
+need (json, re, unicodedata). The ported region is deliberately Django-free
+except for one guarded reference to `settings` inside _validate_items,
+behind `if max_file_mb is None:` — this test always calls the extracted
+_validate_items with an explicit cap, so that branch, and the name
+`settings`, is never resolved. If a future edit drags a new Django (or any
+other) dependency into the ported region outside that guard, this test
+starts failing with NameError — that is intended: the ported region must
+stay portable.
+
+The rename map between the two copies (the ONLY thing that may differ in
+the ported region):
+    Heartbeat/news_signals.py        ->  Main/backend/api/signals_views.py
+    clean_text                       ->  _clean_text
+    validation_gate                  ->  _validate_items
+    CONTROL_RE                       ->  _CONTROL_RE
+    _LINEBREAK_RE                    ->  _LINEBREAK_RE   (same)
+    REQUIRED_FIELDS                  ->  REQUIRED_FIELDS (same)
+    FIELD_CAPS                       ->  FIELD_CAPS      (same)
+    TEXT_REQUIRED_FIELDS             ->  TEXT_REQUIRED_FIELDS (same)
+
+The ONE sanctioned divergence: cap resolution. Heartbeat reads
+SIGNALS_MAX_FILE_MB via load_config(); the Django copy resolves the same
+env var through settings.RAW_ITEMS_MAX_FILE_MB (one operator knob, two
+readers — see Main/backend/django_config/settings.py). This test pins the
+two DEFAULTS together (test_default_max_file_mb_matches_heartbeat_default)
+rather than the resolution mechanism, since the mechanism is allowed to
+differ.
+
+WHEN THIS TEST GOES RED: mirror the change into the OTHER copy (apply the
+rename map above in reverse as needed) until it goes green again. Do NOT
+delete or weaken this test to make it pass — that defeats its entire
+purpose, which is to make drift between the two copies impossible to merge
+silently.
+"""
+import ast
+import json
+import os
+import re
+import shutil
+import sys
+import tempfile
+import time
+import unicodedata
+import unittest
+import unittest.mock
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import news_signals as ns  # noqa: E402  (sys.path must be set up first)
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SIGNALS_VIEWS_PATH = _REPO_ROOT / "Main" / "backend" / "api" / "signals_views.py"
+
+# The exact node names that make up the ported region. Assign targets and
+# function defs only — see _extract_ported_region.
+_WANTED_NODE_NAMES = (
+    "TEXT_REQUIRED_FIELDS",
+    "REQUIRED_FIELDS",
+    "FIELD_CAPS",
+    "_CONTROL_RE",
+    "_LINEBREAK_RE",
+    "_MAX_ITEMS_FILE_MB",
+    "_clean_text",
+    "_validate_items",
+)
+
+
+def _extract_ported_region(path):
+    """ast.parse() `path`'s source (never import it — it pulls in Django)
+    and select only the top-level Assign/FunctionDef nodes named in
+    _WANTED_NODE_NAMES. Compile that subset alone into a fresh namespace
+    pre-populated with the stdlib names the nodes need, and exec it.
+
+    Returns (namespace, found_names). found_names lets
+    TestPortedNodeSetPresent fail loudly if a rename silently drops a node,
+    instead of this function silently building an incomplete (and
+    therefore vacuously-passing) namespace.
+    """
+    source = path.read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(path))
+    selected = []
+    found = set()
+    for node in tree.body:
+        name = None
+        if (isinstance(node, ast.Assign) and len(node.targets) == 1
+                and isinstance(node.targets[0], ast.Name)):
+            name = node.targets[0].id
+        elif isinstance(node, ast.FunctionDef):
+            name = node.name
+        if name in _WANTED_NODE_NAMES:
+            selected.append(node)
+            found.add(name)
+    module = ast.Module(body=selected, type_ignores=[])
+    ast.fix_missing_locations(module)
+    code = compile(module, filename=str(path), mode="exec")
+    namespace = {"json": json, "re": re, "unicodedata": unicodedata}
+    exec(code, namespace)  # noqa: S102 — deliberate: see module docstring
+    return namespace, found
+
+
+_PORTED_NS, _PORTED_FOUND = _extract_ported_region(_SIGNALS_VIEWS_PATH)
+
+
+def make_story(**over):
+    """Same shape as Heartbeat/tests/test_news_signals.py's make_story —
+    kept local (not imported) so this file stays independently readable,
+    matching Heartbeat/tests/test_watchlist.py's self-contained style."""
+    s = {
+        "guid": "g1", "title": "Microsoft raises Azure guidance",
+        "link": "https://example.com/a", "source": "Reuters",
+        "published": time.time() - 3600, "description": "desc",
+        "tickers": ["MSFT"], "score": 5.0,
+    }
+    s.update(over)
+    return s
+
+
+def _without(story, field):
+    """A story with `field` absent entirely — distinct from the field being
+    present but malformed, and the only way to reach a .get() default arm."""
+    del story[field]
+    return story
+
+
+def write_lines(dirpath, lines, name="items-2026-07-14.jsonl"):
+    """Write raw JSONL lines (already-encoded strings) verbatim — used where
+    a case needs a blank line or deliberately malformed JSON, neither of
+    which make_story()+json.dumps can express."""
+    p = Path(dirpath) / name
+    p.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return p
+
+
+def write_stories(dirpath, stories, name="items-2026-07-14.jsonl"):
+    return write_lines(dirpath, [json.dumps(s) for s in stories], name)
+
+
+class TestPortedNodeSetPresent(unittest.TestCase):
+    """F1 guard, part 0: if a rename in signals_views.py silently drops one
+    of the ported nodes, every other test in this file would just run
+    against a smaller (or missing) namespace and could vacuously pass. This
+    test makes that failure loud instead."""
+
+    def test_all_ported_nodes_present_in_signals_views(self):
+        missing = set(_WANTED_NODE_NAMES) - _PORTED_FOUND
+        self.assertEqual(
+            missing, set(),
+            f"signals_views.py is missing ported node(s) {sorted(missing)} "
+            "— a rename in the ported region must be mirrored from "
+            "news_signals.py, never silently dropped. See this test "
+            "file's module docstring for the rename map.")
+
+
+class TestConstantParity(unittest.TestCase):
+    """F1 guard, part 1: exact equality of every constant in the ported
+    region (modulo the rename map)."""
+
+    def test_required_fields_match(self):
+        self.assertEqual(_PORTED_NS["REQUIRED_FIELDS"], ns.REQUIRED_FIELDS)
+
+    def test_field_caps_match(self):
+        self.assertEqual(_PORTED_NS["FIELD_CAPS"], ns.FIELD_CAPS)
+
+    def test_text_required_fields_match(self):
+        self.assertEqual(_PORTED_NS["TEXT_REQUIRED_FIELDS"],
+                         ns.TEXT_REQUIRED_FIELDS)
+
+    def test_control_re_pattern_matches(self):
+        self.assertEqual(_PORTED_NS["_CONTROL_RE"].pattern,
+                         ns.CONTROL_RE.pattern)
+
+    def test_linebreak_re_pattern_matches(self):
+        self.assertEqual(_PORTED_NS["_LINEBREAK_RE"].pattern,
+                         ns._LINEBREAK_RE.pattern)
+
+    def test_default_max_file_mb_matches_heartbeat_default(self):
+        # F3's guard: the two copies read the SAME env var name
+        # (SIGNALS_MAX_FILE_MB) through two different settings readers
+        # (design decision D3) — that resolution MECHANISM is the one
+        # sanctioned divergence (see module docstring), but the DEFAULT
+        # value both readers fall back to must stay pinned together.
+        with unittest.mock.patch.dict(os.environ, {}, clear=True):
+            heartbeat_default = ns.load_config()["max_file_mb"]
+        self.assertEqual(_PORTED_NS["_MAX_ITEMS_FILE_MB"], heartbeat_default)
+
+
+# Nasty corpus for clean_text/_clean_text behavioral parity. Every entry is
+# (label, value, cap); label is used as the subTest discriminator.
+_CLEAN_TEXT_CORPUS = [
+    ("empty_string", "", 500),
+    ("none", None, 500),
+    ("zero", 0, 500),
+    ("false", False, 500),
+    ("true", True, 500),
+    ("int", 123, 500),
+    ("float", 12.5, 500),
+    ("list", [], 500),
+    ("dict", {}, 500),
+    ("bidi_override", "abc‮def", 500),
+    ("embedded_marker_token", "before NEWS_DATA after", 500),
+    ("tab", "a\tb", 500),
+    ("newline", "a\nb", 500),
+    ("vertical_tab", "a\vb", 500),
+    ("form_feed", "a\fb", 500),
+    ("carriage_return", "a\rb", 500),
+    ("file_separator", "a\x1cb", 500),
+    ("group_separator", "a\x1db", 500),
+    ("record_separator", "a\x1eb", 500),
+    ("nel", "a\x85b", 500),
+    ("line_separator", "a b", 500),
+    ("paragraph_separator", "a b", 500),
+    ("nfc_combining_form", "é", 500),
+    ("nfc_precomposed_form", "é", 500),
+    ("control_char", "a\x01b", 500),
+    ("over_cap_string", "x" * 20, 5),
+]
+
+
+class TestCleanTextParity(unittest.TestCase):
+    """F1 guard, part 2 (also D1's superset proof, behaviorally): the two
+    clean_text/_clean_text copies must return byte-identical output for
+    every input, not just agree on constants."""
+
+    def test_clean_text_matches_across_corpus(self):
+        for label, value, cap in _CLEAN_TEXT_CORPUS:
+            with self.subTest(case=label):
+                ported = _PORTED_NS["_clean_text"](value, cap)
+                heartbeat = ns.clean_text(value, cap)
+                self.assertEqual(ported, heartbeat)
+
+
+class TestValidateItemsParity(unittest.TestCase):
+    """F1 guard, part 3: the two validation_gate/_validate_items copies
+    must agree on every case, including the F2a/F2b malformed-type
+    fail-safes. Both sides mutate their story dicts in place and return a
+    list of dicts, so the returned lists are compared directly."""
+
+    def setUp(self):
+        self._td = tempfile.mkdtemp(prefix="port_parity_")
+        self.addCleanup(shutil.rmtree, self._td, ignore_errors=True)
+
+    def _assert_gate_parity(self, path, max_file_mb=10):
+        ported = _PORTED_NS["_validate_items"](path, max_file_mb)
+        heartbeat = ns.validation_gate(path, max_file_mb)
+        self.assertEqual(ported, heartbeat)
+
+    def test_validate_items_matches_across_corpus(self):
+        now = time.time()
+        cases = {
+            "happy_batch": [
+                make_story(guid="g1", tickers=["msft", "MSFT"]),
+                make_story(guid="g2", title="Other headline", tickers=["nvda"]),
+            ],
+            # F2a: non-str required TEXT field -> drop story, not the batch.
+            "non_string_title": [make_story(title=True)],
+            "non_string_source": [make_story(source=None)],
+            "non_string_guid": [make_story(guid=123)],
+            "non_string_link": [make_story(link=[1, 2])],
+            # D2: optional description is NOT a drop condition -- it just
+            # blanks via _clean_text's own isinstance guard.
+            "non_string_description": [make_story(description=True)],
+            # The numeric parse. These are not optional padding: the guard
+            # shipped without them and went green over a real one-sided edit
+            # that deleted _validate_items' try/except entirely (PR #359
+            # review, P0). No other case reaches float(), because every other
+            # story here carries a well-formed published/score -- the window
+            # cases exercise the `lo <= published <= hi` compare, not the
+            # parse. Each must drop the bad story and keep the good one on
+            # BOTH copies; if either side raises instead, _assert_gate_parity
+            # errors, which is the signal we want.
+            "score_unparseable": [make_story(guid="good"),
+                                  make_story(guid="bad", score="n/a")],
+            "score_none": [make_story(guid="good"),
+                           make_story(guid="bad", score=None)],
+            "score_non_scalar": [make_story(guid="good"),
+                                 make_story(guid="bad", score={})],
+            "published_unparseable": [make_story(guid="good"),
+                                      make_story(guid="bad",
+                                                 published="yesterday")],
+            "published_none": [make_story(guid="good"),
+                               make_story(guid="bad", published=None)],
+            "published_non_scalar": [make_story(guid="good"),
+                                     make_story(guid="bad", published=[1])],
+            # description absent ENTIRELY: the only case that reaches
+            # .get("description", "")'s default arm. Without it, a one-sided
+            # edit to story["description"] passes the guard and only KeyErrors
+            # in production.
+            "description_missing": [_without(make_story(guid="nodesc"),
+                                             "description")],
+            # F2b: malformed tickers must never raise, on either copy.
+            "tickers_mixed_types": [make_story(tickers=[123, "aapl"])],
+            "tickers_bare_string": [make_story(tickers="AAPL")],
+            "tickers_none": [make_story(tickers=None)],
+            "past_out_of_window": [make_story(guid="ancient",
+                                              published=now - 40 * 86400)],
+            "future_beyond_window": [make_story(guid="future",
+                                                published=now + 7200)],
+            "blank_line_middle": None,  # built specially below
+        }
+        for label, stories in cases.items():
+            with self.subTest(case=label):
+                if label == "blank_line_middle":
+                    path = write_lines(self._td, [
+                        json.dumps(make_story(guid="g1")),
+                        "",
+                        json.dumps(make_story(guid="g2")),
+                    ], name=f"items-{label}.jsonl")
+                else:
+                    path = write_stories(self._td, stories,
+                                         name=f"items-{label}.jsonl")
+                self._assert_gate_parity(path)
+
+    def test_missing_required_field_raises_valueerror_on_both(self):
+        story = make_story()
+        del story["score"]
+        path = write_stories(self._td, [story])
+        with self.assertRaises(ValueError):
+            _PORTED_NS["_validate_items"](path, 10)
+        with self.assertRaises(ValueError):
+            ns.validation_gate(path, 10)
+
+    def test_malformed_json_line_raises_valueerror_on_both(self):
+        path = write_lines(self._td, ['{"broken\n'])
+        with self.assertRaises(ValueError):
+            _PORTED_NS["_validate_items"](path, 10)
+        with self.assertRaises(ValueError):
+            ns.validation_gate(path, 10)
+
+    def test_over_cap_file_raises_valueerror_on_both(self):
+        path = write_stories(self._td, [make_story()])
+        with self.assertRaises(ValueError):
+            _PORTED_NS["_validate_items"](path, 0)  # 0 MB cap: any file trips it
+        with self.assertRaises(ValueError):
+            ns.validation_gate(path, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Main/backend/api/signals_views.py
+++ b/Main/backend/api/signals_views.py
@@ -188,9 +188,22 @@ def news_signals(request: HttpRequest) -> JsonResponse:
 # below is PORTED byte-faithfully from Heartbeat/news_signals.py
 # (validation_gate/clean_text) — that script is deliberately isolated and not
 # importable from the Django app — because it is a security trust boundary
-# (spec §7.1): do not paraphrase it.
+# (spec §7.1): do not paraphrase it. Heartbeat/tests/test_port_parity.py is the
+# anti-drift guard: it pins the constants exactly, and compares the two copies'
+# BEHAVIOR over a corpus — so it catches one-sided edits only on inputs the
+# corpus reaches. It shipped missing the malformed-numeric case and went green
+# over exactly that drift once. Widen the corpus when you add a branch here;
+# edit both copies, in the same commit.
+# The ONE deliberate divergence: cap resolution. Heartbeat reads
+# SIGNALS_MAX_FILE_MB in load_config; here the same env var arrives via
+# settings.RAW_ITEMS_MAX_FILE_MB (one operator knob, two readers). The parity
+# test pins the two defaults together.
 REQUIRED_FIELDS = ("guid", "title", "link", "source", "published", "score")
 FIELD_CAPS = {"title": 500, "description": 5000, "link": 2000, "source": 200, "guid": 200}
+# Required fields that must be strings. A malformed type drops the story — same
+# stance as the numeric parse in _validate_items — so a corrupt field can never
+# reach _clean_text as a non-str and can never poison the whole batch.
+TEXT_REQUIRED_FIELDS = ("guid", "title", "link", "source")
 
 # Control chars + bidi/direction overrides (recency/spoofing hygiene, spec 7.1).
 _CONTROL_RE = re.compile(
@@ -201,20 +214,27 @@ _LINEBREAK_RE = re.compile("[\\t\\n\\v\\f\\r\\x1c-\\x1e\\x85\\u2028\\u2029]+")
 
 
 def _clean_text(s, cap):
+    # non-str (incl. None) collapses to "": the gate must never raise on a
+    # malformed field type. Required-field types are checked in _validate_items;
+    # this keeps optional and LLM-derived callers total on their own.
+    s = s if isinstance(s, str) else ""
     # line boundaries first — _CONTROL_RE would strip \v/\f/\x1c-\x1e to nothing and fuse words
-    s = _LINEBREAK_RE.sub(" ", unicodedata.normalize("NFC", s or ""))
+    s = _LINEBREAK_RE.sub(" ", unicodedata.normalize("NFC", s))
     s = _CONTROL_RE.sub("", s)
     s = s.replace("NEWS_DATA", "")   # datamarking token can never come from the feed
     return s[:cap]
 
 
-_MAX_ITEMS_FILE_MB = 10   # matches Heartbeat SIGNALS_MAX_FILE_MB default
+_MAX_ITEMS_FILE_MB = 10   # default only; settings.RAW_ITEMS_MAX_FILE_MB is the live value
 
 
-def _validate_items(path, max_file_mb=_MAX_ITEMS_FILE_MB):
+def _validate_items(path, max_file_mb=None):
     """Input trust boundary (ported from Heartbeat's validation_gate).
-    Batch-level defects raise ValueError (poison pill); a bad `published` or
-    numeric field drops only that story."""
+    Batch-level defects raise ValueError (poison pill); a bad `published`, a
+    malformed numeric, or a non-str TEXT_REQUIRED_FIELDS value drops only that
+    story."""
+    if max_file_mb is None:
+        max_file_mb = getattr(settings, "RAW_ITEMS_MAX_FILE_MB", _MAX_ITEMS_FILE_MB)
     st = path.stat()
     if st.st_size > max_file_mb * 1024 * 1024:
         raise ValueError(f"file exceeds {max_file_mb}MB")
@@ -228,20 +248,25 @@ def _validate_items(path, max_file_mb=_MAX_ITEMS_FILE_MB):
             if field not in story:
                 raise ValueError(f"line {i}: missing required field {field}")
         try:
-            published = float(story["published"]); story["score"] = float(story["score"])
+            published = float(story["published"])
+            story["score"] = float(story["score"])
         except (TypeError, ValueError):
             continue                                   # malformed numerics: drop story, keep batch
         if not (lo <= published <= hi):
             continue                                   # forged/insane epoch: drop story, keep batch
+        if not all(isinstance(story[f], str) for f in TEXT_REQUIRED_FIELDS):
+            continue  # malformed text types: drop the story, keep the batch
         story["published"] = published
         story["title"] = _clean_text(story["title"], FIELD_CAPS["title"])
         story["description"] = _clean_text(story.get("description", ""), FIELD_CAPS["description"])
         story["source"] = _clean_text(story["source"], FIELD_CAPS["source"])
-        story["guid"] = _clean_text(str(story["guid"]), FIELD_CAPS["guid"])
-        story["link"] = _clean_text(str(story["link"]), FIELD_CAPS["link"])
-        # non-list/non-string tickers dropped, not poison-pilled: a corrupt
-        # "tickers":[123] must never .upper() -> AttributeError -> 500, and
-        # a bare "tickers":"AAPL" must never char-iterate to ['A','A','P','L']
+        story["guid"] = _clean_text(story["guid"], FIELD_CAPS["guid"])
+        story["link"] = _clean_text(story["link"], FIELD_CAPS["link"])
+        # non-list/non-string tickers dropped, never crashed: a corrupt
+        # "tickers":[123] must not .upper() -> AttributeError, which the only
+        # caller (process_batch's ValueError-only except) would not catch and
+        # which would abort the whole sweep; a bare "tickers":"AAPL" must not
+        # char-iterate to ['A','A','P','L'].
         raw_tickers = story.get("tickers", [])
         story["tickers"] = ([t.upper() for t in raw_tickers if isinstance(t, str)]
                             if isinstance(raw_tickers, list) else [])

--- a/Main/backend/api/signals_views.py
+++ b/Main/backend/api/signals_views.py
@@ -194,10 +194,10 @@ FIELD_CAPS = {"title": 500, "description": 5000, "link": 2000, "source": 200, "g
 
 # Control chars + bidi/direction overrides (recency/spoofing hygiene, spec 7.1).
 _CONTROL_RE = re.compile(
-    "[\x00-\x08\x0b\x0c\x0e-\x1f\x7f"
-    "\u200e\u200f\u202a-\u202e\u2066-\u2069]"
+    "[\\x00-\\x08\\x0b\\x0c\\x0e-\\x1f\\x7f"
+    "\\u200e\\u200f\\u202a-\\u202e\\u2066-\\u2069]"
 )
-_LINEBREAK_RE = re.compile("[\t\n\v\f\r\x1c-\x1e\x85\u2028\u2029]+")
+_LINEBREAK_RE = re.compile("[\\t\\n\\v\\f\\r\\x1c-\\x1e\\x85\\u2028\\u2029]+")
 
 
 def _clean_text(s, cap):
@@ -239,7 +239,12 @@ def _validate_items(path, max_file_mb=_MAX_ITEMS_FILE_MB):
         story["source"] = _clean_text(story["source"], FIELD_CAPS["source"])
         story["guid"] = _clean_text(str(story["guid"]), FIELD_CAPS["guid"])
         story["link"] = _clean_text(str(story["link"]), FIELD_CAPS["link"])
-        story["tickers"] = [t.upper() for t in story.get("tickers", [])]
+        # non-list/non-string tickers dropped, not poison-pilled: a corrupt
+        # "tickers":[123] must never .upper() -> AttributeError -> 500, and
+        # a bare "tickers":"AAPL" must never char-iterate to ['A','A','P','L']
+        raw_tickers = story.get("tickers", [])
+        story["tickers"] = ([t.upper() for t in raw_tickers if isinstance(t, str)]
+                            if isinstance(raw_tickers, list) else [])
         stories.append(story)
     return stories
 
@@ -251,11 +256,15 @@ _ITEMS_CONTRACT_FIELDS = ("guid", "title", "link", "source", "published",
 
 
 def _load_items():
-    """-> (newest_path, stories_sorted_desc) or None. No ?as_of for items:
-    always the single newest batch. Mirrors _load_artifact's fail-closed
-    contract — any locate/read/validate failure (including a batch that
-    vanishes mid-race, or one that validates to zero stories) returns None,
-    never falling back to an older batch."""
+    """-> (newest_path, newest_mtime, stories_sorted_desc) or None. No ?as_of
+    for items: always the single newest batch. Mirrors _load_artifact's
+    fail-closed contract — any locate/read/validate failure (including a
+    batch that vanishes mid-race, or one that validates to zero stories)
+    returns None, never falling back to an older batch.
+    The mtime is captured here — the only stat() of the winning file — and
+    carried through the memo so @condition's etag/last-modified functions
+    never re-stat: a prune in the window between this load and @condition's
+    call would otherwise turn into a 500 (see _items_etag/_items_last_modified)."""
     configured = getattr(settings, "RAW_ITEMS_DIR", "")
     if not configured:
         return None
@@ -269,12 +278,15 @@ def _load_items():
     try:
         # stat() stays inside the try: a file pruned between glob() and
         # stat() fails closed, never 500s (same race as _load_artifact).
-        newest = max(candidates, key=lambda p: (p.stat().st_mtime, p.name))
+        # Each candidate is stat()'d exactly once here (for the max() key);
+        # the winner's mtime is captured off that same call, not re-stat'd.
+        stats = [(p, p.stat().st_mtime) for p in candidates]
+        newest, mtime = max(stats, key=lambda ps: (ps[1], ps[0].name))
         stories = _validate_items(newest)
         stories.sort(key=lambda s: s["published"], reverse=True)
         if not stories:
             return None
-        return newest, stories
+        return newest, mtime, stories
     except (OSError, ValueError, KeyError, TypeError) as exc:
         logger.error("news_items: unreadable batch %s: %s",
                      newest.name if newest else "<vanished>", exc)
@@ -308,8 +320,12 @@ def _items_etag(request: HttpRequest):
         limit = _parse_limit(request)
     except ValueError:
         return None  # bad limit: skip conditional handling, view re-parses -> 400
-    path, _ = loaded
-    return f'"{path.name}|{path.stat().st_mtime}|{limit or 50}"'
+    path, mtime, _ = loaded
+    # mtime comes from the _load_items memo, not a re-stat: @condition calls
+    # this before the view body runs, and re-statting here would reopen the
+    # TOCTOU window _load_items already closed (a batch pruned in between
+    # would 500 instead of 404).
+    return f'"{path.name}|{mtime}|{limit or 50}"'
 
 
 def _items_last_modified(request: HttpRequest):
@@ -322,8 +338,8 @@ def _items_last_modified(request: HttpRequest):
     loaded = _get_items(request)
     if loaded is None:
         return None
-    path, _ = loaded
-    return datetime.fromtimestamp(path.stat().st_mtime, tz=timezone.utc)
+    _, mtime, _ = loaded
+    return datetime.fromtimestamp(mtime, tz=timezone.utc)  # no stat() — see _items_etag
 
 
 @csrf_exempt
@@ -340,7 +356,7 @@ def news_items(request: HttpRequest) -> JsonResponse:
     loaded = _get_items(request)
     if loaded is None:
         return JsonResponse({'error': 'no_items'}, status=404)
-    path, stories = loaded
+    path, _mtime, stories = loaded
     effective_limit = limit or 50
     sliced = stories[:effective_limit]
     items = [{k: story[k] for k in _ITEMS_CONTRACT_FIELDS} for story in sliced]

--- a/Main/backend/api/signals_views.py
+++ b/Main/backend/api/signals_views.py
@@ -249,10 +249,17 @@ def _validate_items(path, max_file_mb=_MAX_ITEMS_FILE_MB):
     return stories
 
 
-# The response contract's 8 keys, exactly — extra input keys (e.g. "feeds")
-# are dropped at projection time in the view body.
+# The response contract's 8 per-story keys, exactly — extra input keys (e.g.
+# "feeds") are dropped at projection time in the view body.
+# _ITEMS_CONTRACT_FIELDS names the DISK keys (RSS-native title/link — the
+# scraper's format, validated above); _ITEMS_WIRE_RENAMES maps them to the
+# news-story v1 vocabulary the wire speaks (headline/url — the nouns the live
+# signals endpoint already uses). Disk stays scraper-native; the API boundary
+# does the rename. Contract doc: ATL docs/integrations/finsearch-news-items.md.
 _ITEMS_CONTRACT_FIELDS = ("guid", "title", "link", "source", "published",
                           "description", "tickers", "score")
+_ITEMS_WIRE_RENAMES = {"title": "headline", "link": "url"}
+_ITEMS_SCHEMA_VERSION = 1  # news-story v1 — add fields additively; bump on breaking change
 
 
 def _load_items():
@@ -359,8 +366,10 @@ def news_items(request: HttpRequest) -> JsonResponse:
     path, _mtime, stories = loaded
     effective_limit = limit or 50
     sliced = stories[:effective_limit]
-    items = [{k: story[k] for k in _ITEMS_CONTRACT_FIELDS} for story in sliced]
-    body = {"items": items, "count": len(items), "batch": path.name}
+    items = [{_ITEMS_WIRE_RENAMES.get(k, k): story[k] for k in _ITEMS_CONTRACT_FIELDS}
+             for story in sliced]
+    body = {"schema_version": _ITEMS_SCHEMA_VERSION, "items": items,
+            "count": len(items), "batch": path.name}
     response = JsonResponse(body)
     response["Cache-Control"] = "public, max-age=300"
     return response

--- a/Main/backend/api/signals_views.py
+++ b/Main/backend/api/signals_views.py
@@ -15,6 +15,7 @@ pipeline state.
 import json
 import logging
 import re
+import unicodedata
 from datetime import date, datetime, timezone
 from pathlib import Path
 from urllib.parse import quote
@@ -175,6 +176,175 @@ def news_signals(request: HttpRequest) -> JsonResponse:
     if wanted:
         body["signals"] = {k: v for k, v in body["signals"].items()
                            if k in wanted}
+    response = JsonResponse(body)
+    response["Cache-Control"] = "public, max-age=300"
+    return response
+
+
+# --- Raw news-items endpoint (ATL integration Phase B) ---------------------
+# Sibling of news_signals, but reads items-*.jsonl batches directly with no
+# subject/roundup/LLM gating (news_signals' select_candidates etc. is dropped
+# entirely — this serves the raw, ungated feed). The validation/sanitization
+# below is PORTED byte-faithfully from Heartbeat/news_signals.py
+# (validation_gate/clean_text) — that script is deliberately isolated and not
+# importable from the Django app — because it is a security trust boundary
+# (spec §7.1): do not paraphrase it.
+REQUIRED_FIELDS = ("guid", "title", "link", "source", "published", "score")
+FIELD_CAPS = {"title": 500, "description": 5000, "link": 2000, "source": 200, "guid": 200}
+
+# Control chars + bidi/direction overrides (recency/spoofing hygiene, spec 7.1).
+_CONTROL_RE = re.compile(
+    "[\x00-\x08\x0b\x0c\x0e-\x1f\x7f"
+    "\u200e\u200f\u202a-\u202e\u2066-\u2069]"
+)
+_LINEBREAK_RE = re.compile("[\t\n\v\f\r\x1c-\x1e\x85\u2028\u2029]+")
+
+
+def _clean_text(s, cap):
+    # line boundaries first — _CONTROL_RE would strip \v/\f/\x1c-\x1e to nothing and fuse words
+    s = _LINEBREAK_RE.sub(" ", unicodedata.normalize("NFC", s or ""))
+    s = _CONTROL_RE.sub("", s)
+    s = s.replace("NEWS_DATA", "")   # datamarking token can never come from the feed
+    return s[:cap]
+
+
+_MAX_ITEMS_FILE_MB = 10   # matches Heartbeat SIGNALS_MAX_FILE_MB default
+
+
+def _validate_items(path, max_file_mb=_MAX_ITEMS_FILE_MB):
+    """Input trust boundary (ported from Heartbeat's validation_gate).
+    Batch-level defects raise ValueError (poison pill); a bad `published` or
+    numeric field drops only that story."""
+    st = path.stat()
+    if st.st_size > max_file_mb * 1024 * 1024:
+        raise ValueError(f"file exceeds {max_file_mb}MB")
+    lo, hi = st.st_mtime - 30 * 86400, st.st_mtime + 3600
+    stories = []
+    for i, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+        if not line.strip():
+            continue
+        story = json.loads(line)                       # JSONDecodeError -> ValueError -> poison pill
+        for field in REQUIRED_FIELDS:
+            if field not in story:
+                raise ValueError(f"line {i}: missing required field {field}")
+        try:
+            published = float(story["published"]); story["score"] = float(story["score"])
+        except (TypeError, ValueError):
+            continue                                   # malformed numerics: drop story, keep batch
+        if not (lo <= published <= hi):
+            continue                                   # forged/insane epoch: drop story, keep batch
+        story["published"] = published
+        story["title"] = _clean_text(story["title"], FIELD_CAPS["title"])
+        story["description"] = _clean_text(story.get("description", ""), FIELD_CAPS["description"])
+        story["source"] = _clean_text(story["source"], FIELD_CAPS["source"])
+        story["guid"] = _clean_text(str(story["guid"]), FIELD_CAPS["guid"])
+        story["link"] = _clean_text(str(story["link"]), FIELD_CAPS["link"])
+        story["tickers"] = [t.upper() for t in story.get("tickers", [])]
+        stories.append(story)
+    return stories
+
+
+# The response contract's 8 keys, exactly — extra input keys (e.g. "feeds")
+# are dropped at projection time in the view body.
+_ITEMS_CONTRACT_FIELDS = ("guid", "title", "link", "source", "published",
+                          "description", "tickers", "score")
+
+
+def _load_items():
+    """-> (newest_path, stories_sorted_desc) or None. No ?as_of for items:
+    always the single newest batch. Mirrors _load_artifact's fail-closed
+    contract — any locate/read/validate failure (including a batch that
+    vanishes mid-race, or one that validates to zero stories) returns None,
+    never falling back to an older batch."""
+    configured = getattr(settings, "RAW_ITEMS_DIR", "")
+    if not configured:
+        return None
+    directory = Path(configured)
+    if not directory.is_dir():
+        return None
+    candidates = list(directory.glob("items-*.jsonl"))
+    if not candidates:
+        return None
+    newest = None
+    try:
+        # stat() stays inside the try: a file pruned between glob() and
+        # stat() fails closed, never 500s (same race as _load_artifact).
+        newest = max(candidates, key=lambda p: (p.stat().st_mtime, p.name))
+        stories = _validate_items(newest)
+        stories.sort(key=lambda s: s["published"], reverse=True)
+        if not stories:
+            return None
+        return newest, stories
+    except (OSError, ValueError, KeyError, TypeError) as exc:
+        logger.error("news_items: unreadable batch %s: %s",
+                     newest.name if newest else "<vanished>", exc)
+        return None  # fail closed: unreadable/empty == no items
+
+
+def _get_items(request: HttpRequest):
+    """One disk load per request: @condition calls the etag/last-modified
+    functions before the view body runs, and all three need the loaded
+    batch. Mirrors _get_artifact."""
+    if not hasattr(request, "_news_items"):
+        request._news_items = _load_items()
+    return request._news_items
+
+
+def _parse_limit(request: HttpRequest):
+    """Parse ?limit. Absent -> None (caller defaults to 50); present but not
+    a base-10 integer -> raises ValueError (the view maps that to a 400);
+    otherwise clamped to [1, 200]."""
+    raw = request.GET.get("limit")
+    if raw is None:
+        return None
+    return max(1, min(200, int(raw)))
+
+
+def _items_etag(request: HttpRequest):
+    loaded = _get_items(request)
+    if loaded is None:
+        return None
+    try:
+        limit = _parse_limit(request)
+    except ValueError:
+        return None  # bad limit: skip conditional handling, view re-parses -> 400
+    path, _ = loaded
+    return f'"{path.name}|{path.stat().st_mtime}|{limit or 50}"'
+
+
+def _items_last_modified(request: HttpRequest):
+    # Only the default-limit variant carries Last-Modified: an explicit
+    # ?limit slices the batch differently, so only the ETag (which encodes
+    # the limit) can identify that variant — same stance as _last_modified's
+    # tickers-filter handling above.
+    if request.GET.get("limit") is not None:
+        return None
+    loaded = _get_items(request)
+    if loaded is None:
+        return None
+    path, _ = loaded
+    return datetime.fromtimestamp(path.stat().st_mtime, tz=timezone.utc)
+
+
+@csrf_exempt
+@require_bearer_auth
+@require_http_methods(["GET"])
+@ratelimit(key='api.identity.ratelimit_key', rate=settings.API_RATE_LIMIT,
+           method=ALL, block=True)
+@condition(etag_func=_items_etag, last_modified_func=_items_last_modified)
+def news_items(request: HttpRequest) -> JsonResponse:
+    try:
+        limit = _parse_limit(request)
+    except ValueError:
+        return JsonResponse({'error': 'bad_limit'}, status=400)
+    loaded = _get_items(request)
+    if loaded is None:
+        return JsonResponse({'error': 'no_items'}, status=404)
+    path, stories = loaded
+    effective_limit = limit or 50
+    sliced = stories[:effective_limit]
+    items = [{k: story[k] for k in _ITEMS_CONTRACT_FIELDS} for story in sliced]
+    body = {"items": items, "count": len(items), "batch": path.name}
     response = JsonResponse(body)
     response["Cache-Control"] = "public, max-age=300"
     return response

--- a/Main/backend/django_config/settings.py
+++ b/Main/backend/django_config/settings.py
@@ -175,6 +175,14 @@ SIGNALS_DIR = os.getenv('SIGNALS_DIR', '')
 # missing path means the endpoint fail-closes to 404 {"error": "no_items"}.
 RAW_ITEMS_DIR = os.getenv('RAW_ITEMS_DIR', '')
 
+# Cap on a single items-*.jsonl batch. Deliberately the SAME env var the Heartbeat
+# generator reads (news_signals.load_config), so one operator knob moves both
+# readers — raising it for the pipeline without raising it here would 404 a batch
+# the pipeline happily accepted. Set it in .env.production alongside the
+# heartbeat's own env file. The two defaults are pinned together by
+# Heartbeat/tests/test_port_parity.py.
+RAW_ITEMS_MAX_FILE_MB = int(os.getenv('SIGNALS_MAX_FILE_MB', '10'))
+
 # FinGPT API authentication.
 # When FINGPT_API_KEY is set, all /v1/* endpoints require:
 #     Authorization: Bearer <FINGPT_API_KEY>

--- a/Main/backend/django_config/settings.py
+++ b/Main/backend/django_config/settings.py
@@ -170,6 +170,11 @@ API_RATE_LIMIT = os.getenv('API_RATE_LIMIT', '600/h')
 # path means the endpoint fail-closes to 404 {"error": "no_signals"}.
 SIGNALS_DIR = os.getenv('SIGNALS_DIR', '')
 
+# Raw news-items directory (ATL integration Phase B). In prod this is a
+# runtime-enforced :ro mount of the heartbeat's digests/ dir ONLY; unset or
+# missing path means the endpoint fail-closes to 404 {"error": "no_items"}.
+RAW_ITEMS_DIR = os.getenv('RAW_ITEMS_DIR', '')
+
 # FinGPT API authentication.
 # When FINGPT_API_KEY is set, all /v1/* endpoints require:
 #     Authorization: Bearer <FINGPT_API_KEY>

--- a/Main/backend/django_config/urls.py
+++ b/Main/backend/django_config/urls.py
@@ -24,6 +24,7 @@ urlpatterns = [
     path('api/axioms/has_claims/', views.has_axiom_claims, name='axioms_has_claims'),
     path('api/axioms/xbrl/<str:filename>/', views.xbrl_filing_download, name='axioms_xbrl_filing'),
     path('api/signals/news/', signals_views.news_signals, name='news_signals'),
+    path('api/news/items/', signals_views.news_items, name='news_items'),
 
     # Standard OpenAI-compatible API
     path('v1/models', openai_views.models_list, name='openai_models_list'),

--- a/Main/backend/tests/test_api_auth.py
+++ b/Main/backend/tests/test_api_auth.py
@@ -102,6 +102,33 @@ def test_signals_accepts_valid_bearer(monkeypatch):
     assert resp.status_code != 401
 
 
+# news_items (ATL integration Phase B) — same coverage shape as the signals
+# tests directly above (this endpoint isn't in GATED_EXTENSION_PATHS either,
+# it has its own dedicated 401/dev-mode/valid-bearer tests).
+@override_settings(**HERMETIC_REQUEST_SETTINGS)
+def test_items_401_when_key_set_no_header(monkeypatch):
+    monkeypatch.setenv("FINGPT_API_KEY", "sekret")
+    assert Client().get("/api/news/items/").status_code == 401
+
+
+@override_settings(REQUIRE_FINGPT_API_KEY=False, RAW_ITEMS_DIR="",
+                   **HERMETIC_REQUEST_SETTINGS)
+def test_items_open_when_no_key(monkeypatch):
+    monkeypatch.delenv("FINGPT_API_KEY", raising=False)
+    # 404 no_items (empty RAW_ITEMS_DIR) proves it reached the view, not 401
+    assert Client().get("/api/news/items/").status_code in (200, 404)
+
+
+@override_settings(RAW_ITEMS_DIR="", **HERMETIC_REQUEST_SETTINGS)
+def test_items_accepts_valid_bearer(monkeypatch):
+    # Prod path: key set + valid Bearer header -> auth passes, request reaches
+    # the view (404 no_items with empty RAW_ITEMS_DIR) through real URL dispatch.
+    monkeypatch.setenv("FINGPT_API_KEY", "sekret")
+    resp = Client().get("/api/news/items/",
+                        HTTP_AUTHORIZATION="Bearer sekret")
+    assert resp.status_code != 401
+
+
 # ---------------------------------------------------------------------------
 # Phase 3: the 14 extension-facing views must enforce bearer auth. health/ and
 # the xbrl download stay exempt. Client-driven so the decorator is proven

--- a/Main/backend/tests/test_news_items_endpoint.py
+++ b/Main/backend/tests/test_news_items_endpoint.py
@@ -1,0 +1,276 @@
+"""GET /api/news/items/ behavior (Phase B of the ATL news-signals integration
+plan): raw, ungated items-*.jsonl batches served through the PORTED
+Heartbeat/news_signals.py validation gate — newest-by-mtime, limit clamping,
+conditional GET, fail-closed 404s. Mirrors test_signals_endpoint.py."""
+import json
+import os
+import tempfile
+import time
+from pathlib import Path
+from unittest import mock
+
+from django.core.cache import cache
+from django.test import RequestFactory, SimpleTestCase, override_settings
+
+from api import signals_views
+from tests.shared_settings import HERMETIC_REQUEST_SETTINGS as _HERMETIC
+
+URL = "/api/news/items/"
+
+CONTRACT_KEYS = {"guid", "title", "link", "source", "published",
+                 "description", "tickers", "score"}
+
+
+def make_item(guid, title="Example headline", link="https://example.com/a",
+              source="Reuters", published=None, description="A description.",
+              tickers=None, score=0.7, **extra):
+    if published is None:
+        published = time.time() - 3600  # 1h ago by default
+    item = {
+        "guid": guid, "title": title, "link": link, "source": source,
+        "published": published, "description": description,
+        "tickers": tickers if tickers is not None else ["AAPL"],
+        "score": score,
+    }
+    item.update(extra)
+    return item
+
+
+class NewsItemsEndpointTests(SimpleTestCase):
+    def setUp(self):
+        cache.clear()
+        self._td = tempfile.TemporaryDirectory()
+        self.dir = Path(self._td.name)
+        self.addCleanup(self._td.cleanup)
+
+    def _write(self, stem, items):
+        path = self.dir / f"items-{stem}.jsonl"
+        with path.open("w", encoding="utf-8") as f:
+            for item in items:
+                f.write(json.dumps(item) + "\n")
+        return path
+
+    def _recent_epoch(self, hours_ago=1.0):
+        return time.time() - hours_ago * 3600
+
+    # 1. unconfigured dir
+    def test_unconfigured_dir_404s_fail_closed(self):
+        with override_settings(RAW_ITEMS_DIR="", **_HERMETIC):
+            resp = self.client.get(URL)
+        self.assertEqual(resp.status_code, 404)
+        self.assertEqual(resp.json(), {"error": "no_items"})
+
+    # 2. configured empty dir
+    def test_empty_dir_404s(self):
+        with override_settings(RAW_ITEMS_DIR=str(self.dir), **_HERMETIC):
+            resp = self.client.get(URL)
+        self.assertEqual(resp.status_code, 404)
+        self.assertEqual(resp.json(), {"error": "no_items"})
+
+    # 3. serves newest batch, default limit, shape, newest-first, 8 keys, headers
+    def test_serves_newest_batch_default_limit_shape(self):
+        items = [
+            make_item("g0", published=self._recent_epoch(0.0), feeds=["yahoo"]),
+            make_item("g1", published=self._recent_epoch(1.0)),
+            make_item("g2", published=self._recent_epoch(2.0)),
+        ]
+        self._write("2026-07-06", items)
+        with override_settings(RAW_ITEMS_DIR=str(self.dir), **_HERMETIC):
+            resp = self.client.get(URL)
+        self.assertEqual(resp.status_code, 200)
+        body = resp.json()
+        self.assertEqual(set(body), {"items", "count", "batch"})
+        self.assertEqual(body["batch"], "items-2026-07-06.jsonl")
+        self.assertEqual(body["count"], 3)
+        self.assertEqual([it["guid"] for it in body["items"]], ["g0", "g1", "g2"])
+        for it in body["items"]:
+            self.assertEqual(set(it), CONTRACT_KEYS)
+        self.assertIsInstance(body["items"][0]["published"], float)
+        self.assertIsInstance(body["items"][0]["score"], float)
+        self.assertIsInstance(body["items"][0]["tickers"], list)
+        self.assertEqual(resp["Cache-Control"], "public, max-age=300")
+        self.assertTrue(resp.has_header("ETag"))
+        self.assertTrue(resp.has_header("Last-Modified"))
+
+    # 4. newest-by-mtime-not-stem regression guard
+    def test_serves_newest_by_mtime_not_stem_for_same_day_supplemental(self):
+        morning = [make_item("morning", published=self._recent_epoch(8.0))]
+        supplemental = [make_item("supplemental", published=self._recent_epoch(0.1))]
+        self._write("2026-07-06", morning)
+        supp_path = self._write("2026-07-06-153042", supplemental)
+        now = time.time()
+        os.utime(self.dir / "items-2026-07-06.jsonl", (now - 100, now - 100))
+        os.utime(supp_path, (now, now))
+        with override_settings(RAW_ITEMS_DIR=str(self.dir), **_HERMETIC):
+            resp = self.client.get(URL)
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json()["items"][0]["guid"], "supplemental")
+
+    # 5. limit handling
+    def test_limit_slices_item_count(self):
+        items = [make_item(f"g{i}", published=self._recent_epoch(i)) for i in range(5)]
+        self._write("2026-07-06", items)
+        with override_settings(RAW_ITEMS_DIR=str(self.dir), **_HERMETIC):
+            resp = self.client.get(URL, {"limit": "2"})
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(len(resp.json()["items"]), 2)
+        self.assertEqual(resp.json()["count"], 2)
+
+    def test_limit_absent_defaults_to_50(self):
+        items = [make_item(f"g{i}", published=self._recent_epoch(i)) for i in range(5)]
+        self._write("2026-07-06", items)
+        with override_settings(RAW_ITEMS_DIR=str(self.dir), **_HERMETIC):
+            resp = self.client.get(URL)
+        self.assertEqual(len(resp.json()["items"]), 5)  # fewer than 50, all served
+
+    def test_limit_zero_and_negative_clamp_to_one(self):
+        items = [make_item(f"g{i}", published=self._recent_epoch(i)) for i in range(3)]
+        self._write("2026-07-06", items)
+        with override_settings(RAW_ITEMS_DIR=str(self.dir), **_HERMETIC):
+            zero = self.client.get(URL, {"limit": "0"})
+            negative = self.client.get(URL, {"limit": "-5"})
+        self.assertEqual(len(zero.json()["items"]), 1)
+        self.assertEqual(len(negative.json()["items"]), 1)
+
+    def test_limit_above_200_clamps_to_200(self):
+        # Direct unit test of the clamp boundary: fabricating 200+ fixture
+        # items to observe the upper clamp via item count would be wasteful;
+        # the lower bound and slicing are exercised end-to-end above.
+        rf = RequestFactory()
+        self.assertEqual(signals_views._parse_limit(rf.get(URL, {"limit": "9999"})), 200)
+
+    # 6. bad limit
+    def test_bad_limit_400s(self):
+        self._write("2026-07-06", [make_item("g1")])
+        with override_settings(RAW_ITEMS_DIR=str(self.dir), **_HERMETIC):
+            resp = self.client.get(URL, {"limit": "abc"})
+        self.assertEqual(resp.status_code, 400)
+        self.assertEqual(resp.json(), {"error": "bad_limit"})
+
+    # 7. conditional GET replay
+    def test_conditional_get_304(self):
+        self._write("2026-07-06", [make_item("g1")])
+        with override_settings(RAW_ITEMS_DIR=str(self.dir), **_HERMETIC):
+            first = self.client.get(URL)
+            etag = first["ETag"]
+            second = self.client.get(URL, HTTP_IF_NONE_MATCH=etag)
+        self.assertEqual(second.status_code, 304)
+
+    # 8. ETag varies with limit
+    def test_etag_varies_with_limit(self):
+        items = [make_item(f"g{i}", published=self._recent_epoch(i)) for i in range(5)]
+        self._write("2026-07-06", items)
+        with override_settings(RAW_ITEMS_DIR=str(self.dir), **_HERMETIC):
+            unfiltered = self.client.get(URL)
+            limited = self.client.get(URL, {"limit": "2"},
+                                      HTTP_IF_NONE_MATCH=unfiltered["ETag"])
+            self.assertEqual(limited.status_code, 200)
+            limited_etag = limited["ETag"]
+            self.assertNotEqual(limited_etag, unfiltered["ETag"])
+            repeat = self.client.get(URL, {"limit": "2"},
+                                     HTTP_IF_NONE_MATCH=limited_etag)
+        self.assertEqual(repeat.status_code, 304)
+
+    # 9. loader called once per request
+    def test_items_loaded_from_disk_once_per_request(self):
+        self._write("2026-07-06", [make_item("g1")])
+        with override_settings(RAW_ITEMS_DIR=str(self.dir), **_HERMETIC), \
+             mock.patch.object(signals_views, "_load_items",
+                               wraps=signals_views._load_items) as loader:
+            resp = self.client.get(URL)
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(loader.call_count, 1)
+
+    # 10. vanishing batch race
+    def test_batch_vanishing_between_glob_and_stat_404s_fail_closed(self):
+        self._write("2026-07-06", [make_item("g1")])
+        real_stat = Path.stat
+
+        def racing_stat(self, **kwargs):
+            if self.name.endswith(".jsonl"):
+                raise FileNotFoundError(self.name)
+            return real_stat(self, **kwargs)
+
+        with override_settings(RAW_ITEMS_DIR=str(self.dir), **_HERMETIC), \
+             mock.patch.object(Path, "stat", autospec=True, side_effect=racing_stat):
+            resp = self.client.get(URL)
+        self.assertEqual(resp.status_code, 404)
+        self.assertEqual(resp.json(), {"error": "no_items"})
+
+    # 11. method gate
+    def test_post_is_rejected(self):
+        with override_settings(RAW_ITEMS_DIR=str(self.dir), **_HERMETIC):
+            resp = self.client.post(URL)
+        self.assertEqual(resp.status_code, 405)
+
+    # 12. missing required field: poison pill
+    def test_missing_required_field_poisons_batch(self):
+        good = make_item("g1")
+        bad = make_item("g2")
+        del bad["source"]
+        path = self.dir / "items-2026-07-06.jsonl"
+        path.write_text(json.dumps(good) + "\n" + json.dumps(bad) + "\n", encoding="utf-8")
+        with override_settings(RAW_ITEMS_DIR=str(self.dir), **_HERMETIC):
+            resp = self.client.get(URL)
+        self.assertEqual(resp.status_code, 404)
+        self.assertEqual(resp.json(), {"error": "no_items"})
+
+    # 13. malformed JSON line: poison pill
+    def test_malformed_json_line_poisons_batch(self):
+        path = self.dir / "items-2026-07-06.jsonl"
+        path.write_text(json.dumps(make_item("g1")) + "\n{broken\n", encoding="utf-8")
+        with override_settings(RAW_ITEMS_DIR=str(self.dir), **_HERMETIC):
+            resp = self.client.get(URL)
+        self.assertEqual(resp.status_code, 404)
+        self.assertEqual(resp.json(), {"error": "no_items"})
+
+    # 14. bad/out-of-window published: drop story, keep batch
+    def test_out_of_window_published_drops_story_keeps_batch(self):
+        good = make_item("g1", published=self._recent_epoch(1.0))
+        stale = make_item("g2", published=time.time() - 40 * 86400)  # >30d old
+        path = self.dir / "items-2026-07-06.jsonl"
+        path.write_text(json.dumps(good) + "\n" + json.dumps(stale) + "\n", encoding="utf-8")
+        with override_settings(RAW_ITEMS_DIR=str(self.dir), **_HERMETIC):
+            resp = self.client.get(URL)
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual([it["guid"] for it in resp.json()["items"]], ["g1"])
+
+    def test_malformed_numeric_published_drops_story_keeps_batch(self):
+        good = make_item("g1", published=self._recent_epoch(1.0))
+        bad = make_item("g2", published="not-a-number")
+        path = self.dir / "items-2026-07-06.jsonl"
+        path.write_text(json.dumps(good) + "\n" + json.dumps(bad) + "\n", encoding="utf-8")
+        with override_settings(RAW_ITEMS_DIR=str(self.dir), **_HERMETIC):
+            resp = self.client.get(URL)
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual([it["guid"] for it in resp.json()["items"]], ["g1"])
+
+    # 15. oversized file
+    def test_oversized_file_404s(self):
+        huge_description = "x" * (11 * 1024 * 1024)  # > _MAX_ITEMS_FILE_MB
+        self._write("2026-07-06", [make_item("g1", description=huge_description)])
+        with override_settings(RAW_ITEMS_DIR=str(self.dir), **_HERMETIC):
+            resp = self.client.get(URL)
+        self.assertEqual(resp.status_code, 404)
+        self.assertEqual(resp.json(), {"error": "no_items"})
+
+    # 16. control/bidi + marker + over-cap title: security parity
+    def test_control_bidi_and_marker_stripped_title_truncated(self):
+        dirty_title = "Evil\u202eTitle" + "NEWS_DATA" + "A" * 600
+        self._write("2026-07-06", [make_item("g1", title=dirty_title)])
+        with override_settings(RAW_ITEMS_DIR=str(self.dir), **_HERMETIC):
+            resp = self.client.get(URL)
+        self.assertEqual(resp.status_code, 200)
+        served_title = resp.json()["items"][0]["title"]
+        self.assertNotIn("\u202e", served_title)
+        self.assertNotIn("NEWS_DATA", served_title)
+        self.assertLessEqual(len(served_title), 500)
+
+    # 17. zero valid stories after the gate
+    def test_zero_valid_stories_404s(self):
+        stale = make_item("g1", published=time.time() - 40 * 86400)
+        self._write("2026-07-06", [stale])
+        with override_settings(RAW_ITEMS_DIR=str(self.dir), **_HERMETIC):
+            resp = self.client.get(URL)
+        self.assertEqual(resp.status_code, 404)
+        self.assertEqual(resp.json(), {"error": "no_items"})

--- a/Main/backend/tests/test_news_items_endpoint.py
+++ b/Main/backend/tests/test_news_items_endpoint.py
@@ -275,6 +275,13 @@ class NewsItemsEndpointTests(SimpleTestCase):
         self.assertEqual(resp.json()["items"][0]["tickers"], [])
 
     # 15. oversized file
+    # Kept at real 11MB rather than shrunk via override_settings the way
+    # test_max_file_mb_setting_drives_the_accepted_cap (#23) does: that test
+    # only proves the override wiring reacts at call time; this one is the
+    # only test that exercises the actual UNMODIFIED default (settings.py's
+    # RAW_ITEMS_MAX_FILE_MB = int(os.getenv('SIGNALS_MAX_FILE_MB', '10')))
+    # end-to-end against a real oversized payload. Shrinking it would drop
+    # that coverage, not just cost.
     def test_oversized_file_404s(self):
         huge_description = "x" * (11 * 1024 * 1024)  # > _MAX_ITEMS_FILE_MB
         self._write("2026-07-06", [make_item("g1", description=huge_description)])
@@ -326,3 +333,153 @@ class NewsItemsEndpointTests(SimpleTestCase):
         # + _validate_items' size/window check) — none from etag/last-modified
         # or the view body, which all read the memoized (path, mtime, stories).
         self.assertEqual(calls, ["items-2026-07-06.jsonl"] * 2)
+
+    # 19. Last-Modified suppression on ?limit (F4): mirrors
+    # test_last_modified_only_on_unfiltered_variant /
+    # test_if_modified_since_revalidates_unfiltered_but_never_filtered in
+    # test_signals_endpoint.py for the tickers-filter analog. Only the
+    # default-limit variant carries Last-Modified: an explicit ?limit slices
+    # the batch differently, so only the ETag (which encodes the limit) can
+    # identify that variant — a bare If-Modified-Since 304 on a ?limit=
+    # request would tell the client to reuse a differently-sliced body.
+    def test_last_modified_only_on_unlimited_variant(self):
+        self._write("2026-07-06", [make_item("g1")])
+        with override_settings(RAW_ITEMS_DIR=str(self.dir), **_HERMETIC):
+            unlimited = self.client.get(URL)
+            limited = self.client.get(URL, {"limit": "1"})
+        self.assertTrue(unlimited.has_header("Last-Modified"))
+        self.assertFalse(limited.has_header("Last-Modified"))
+
+    def test_if_modified_since_revalidates_unlimited_but_never_limited(self):
+        # RFC 9110: with no If-None-Match, the server answers from
+        # If-Modified-Since alone and never consults the ETag — so a 304
+        # here would tell the client to reuse a differently-limited body.
+        self._write("2026-07-06", [make_item("g1")])
+        with override_settings(RAW_ITEMS_DIR=str(self.dir), **_HERMETIC):
+            first = self.client.get(URL)
+            ims = first["Last-Modified"]
+            unlimited = self.client.get(URL, HTTP_IF_MODIFIED_SINCE=ims)
+            limited = self.client.get(URL, {"limit": "1"},
+                                      HTTP_IF_MODIFIED_SINCE=ims)
+        self.assertEqual(unlimited.status_code, 304)
+        self.assertEqual(limited.status_code, 200)
+
+    # 20. bad/out-of-window published, FUTURE side (F5): twin of
+    # test_out_of_window_published_drops_story_keeps_batch, which only
+    # covers the lo/past side of 'lo, hi = st.st_mtime - 30*86400,
+    # st.st_mtime + 3600'. A story published further in the future than the
+    # hi bound must drop too — the batch sorts published desc, so an
+    # unbounded future timestamp (forged, or clock-skewed) would sort
+    # newest-first FOREVER and permanently shadow real stories. The window
+    # is anchored on the batch file's st_mtime, not wall-clock time; _write
+    # below leaves st_mtime at ~now (the write time), so "now + 2h" is
+    # explicitly past mtime+1h rather than relying on that being true by
+    # luck.
+    def test_future_published_beyond_window_drops_story_keeps_batch(self):
+        good = make_item("g1", published=self._recent_epoch(1.0))
+        future = make_item("g2", published=time.time() + 2 * 3600)  # > mtime + 1h
+        path = self.dir / "items-2026-07-06.jsonl"
+        path.write_text(json.dumps(good) + "\n" + json.dumps(future) + "\n",
+                        encoding="utf-8")
+        with override_settings(RAW_ITEMS_DIR=str(self.dir), **_HERMETIC):
+            resp = self.client.get(URL)
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual([it["guid"] for it in resp.json()["items"]], ["g1"])
+
+    # 21. blank-line skip (F5): 'if not line.strip(): continue' guards
+    # json.loads("") from poison-pilling the batch. Every _write helper here
+    # joins with exactly one trailing newline, so none of the tests above
+    # ever produce a blank line; in the wild the source is a writer that
+    # newline-terminates an already newline-terminated buffer (e.g.
+    # "\n".join(lines) + "\n" where lines already end in "\n", or a
+    # double-flush), landing a blank line mid-file and/or a trailing one.
+    def test_blank_lines_between_and_trailing_are_skipped(self):
+        g1 = make_item("g1", published=self._recent_epoch(1.0))
+        g2 = make_item("g2", published=self._recent_epoch(2.0))
+        path = self.dir / "items-2026-07-06.jsonl"
+        path.write_text(json.dumps(g1) + "\n\n" + json.dumps(g2) + "\n\n",
+                        encoding="utf-8")
+        with override_settings(RAW_ITEMS_DIR=str(self.dir), **_HERMETIC):
+            resp = self.client.get(URL)
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(sorted(it["guid"] for it in resp.json()["items"]),
+                         ["g1", "g2"])
+
+    # 22. text-type rule (F2a): a required TEXT field reaching _clean_text as
+    # a non-str must drop just that story — not raise TypeError out of
+    # unicodedata.normalize() and poison the whole batch into a 404 (the
+    # pre-fix behavior). One boolean and one number are used across the
+    # fields below so both non-str JSON kinds are exercised.
+    def test_non_string_title_drops_story_keeps_batch(self):
+        good = make_item("g1", published=self._recent_epoch(1.0))
+        bad = make_item("g2", published=self._recent_epoch(1.0), title=True)
+        path = self.dir / "items-2026-07-06.jsonl"
+        path.write_text(json.dumps(good) + "\n" + json.dumps(bad) + "\n",
+                        encoding="utf-8")
+        with override_settings(RAW_ITEMS_DIR=str(self.dir), **_HERMETIC):
+            resp = self.client.get(URL)
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual([it["guid"] for it in resp.json()["items"]], ["g1"])
+
+    def test_non_string_source_drops_story_keeps_batch(self):
+        good = make_item("g1", published=self._recent_epoch(1.0))
+        bad = make_item("g2", published=self._recent_epoch(1.0), source=123)
+        path = self.dir / "items-2026-07-06.jsonl"
+        path.write_text(json.dumps(good) + "\n" + json.dumps(bad) + "\n",
+                        encoding="utf-8")
+        with override_settings(RAW_ITEMS_DIR=str(self.dir), **_HERMETIC):
+            resp = self.client.get(URL)
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual([it["guid"] for it in resp.json()["items"]], ["g1"])
+
+    def test_non_string_guid_drops_story_keeps_batch(self):
+        good = make_item("g1", published=self._recent_epoch(1.0))
+        bad = make_item("g2", published=self._recent_epoch(1.0))
+        bad["guid"] = 123  # guid is make_item's positional id param — set after construction
+        path = self.dir / "items-2026-07-06.jsonl"
+        path.write_text(json.dumps(good) + "\n" + json.dumps(bad) + "\n",
+                        encoding="utf-8")
+        with override_settings(RAW_ITEMS_DIR=str(self.dir), **_HERMETIC):
+            resp = self.client.get(URL)
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual([it["guid"] for it in resp.json()["items"]], ["g1"])
+
+    def test_non_string_link_drops_story_keeps_batch(self):
+        good = make_item("g1", published=self._recent_epoch(1.0))
+        bad = make_item("g2", published=self._recent_epoch(1.0), link=True)
+        path = self.dir / "items-2026-07-06.jsonl"
+        path.write_text(json.dumps(good) + "\n" + json.dumps(bad) + "\n",
+                        encoding="utf-8")
+        with override_settings(RAW_ITEMS_DIR=str(self.dir), **_HERMETIC):
+            resp = self.client.get(URL)
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual([it["guid"] for it in resp.json()["items"]], ["g1"])
+
+    def test_non_string_description_blanks_not_drops(self):
+        # description is optional (not in TEXT_REQUIRED_FIELDS): its own
+        # isinstance guard inside _clean_text blanks it rather than the
+        # story being dropped.
+        item = make_item("g1", published=self._recent_epoch(1.0), description=123)
+        path = self.dir / "items-2026-07-06.jsonl"
+        path.write_text(json.dumps(item) + "\n", encoding="utf-8")
+        with override_settings(RAW_ITEMS_DIR=str(self.dir), **_HERMETIC):
+            resp = self.client.get(URL)
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual([it["guid"] for it in resp.json()["items"]], ["g1"])
+        self.assertEqual(resp.json()["items"][0]["description"], "")
+
+    # 23. _MAX_ITEMS_FILE_MB is settings-driven (F3): prove
+    # RAW_ITEMS_MAX_FILE_MB is read at call time (not frozen at import) by
+    # driving the wiring off a deliberately small cap against a small file,
+    # rather than writing another 11MB fixture.
+    def test_max_file_mb_setting_drives_the_accepted_cap(self):
+        path = self._write("2026-07-06", [make_item("g1", published=self._recent_epoch(1.0))])
+        size_mb = path.stat().st_size / (1024 * 1024)
+        with override_settings(RAW_ITEMS_DIR=str(self.dir),
+                               RAW_ITEMS_MAX_FILE_MB=size_mb / 2, **_HERMETIC):
+            too_small_cap = self.client.get(URL)
+        with override_settings(RAW_ITEMS_DIR=str(self.dir),
+                               RAW_ITEMS_MAX_FILE_MB=size_mb * 2, **_HERMETIC):
+            big_enough_cap = self.client.get(URL)
+        self.assertEqual(too_small_cap.status_code, 404)
+        self.assertEqual(big_enough_cap.status_code, 200)

--- a/Main/backend/tests/test_news_items_endpoint.py
+++ b/Main/backend/tests/test_news_items_endpoint.py
@@ -245,6 +245,28 @@ class NewsItemsEndpointTests(SimpleTestCase):
         self.assertEqual(resp.status_code, 200)
         self.assertEqual([it["guid"] for it in resp.json()["items"]], ["g1"])
 
+    # 14b. corrupt tickers: fail-closed guard, never poisons the story/batch
+    def test_corrupt_ticker_elements_dropped_not_poisoned(self):
+        # a non-string element (e.g. 123) must never reach .upper() -> 500;
+        # non-string elements are dropped, valid ones still served uppercased
+        good = make_item("g1", published=self._recent_epoch(1.0), tickers=[123, "aapl"])
+        path = self.dir / "items-2026-07-06.jsonl"
+        path.write_text(json.dumps(good) + "\n", encoding="utf-8")
+        with override_settings(RAW_ITEMS_DIR=str(self.dir), **_HERMETIC):
+            resp = self.client.get(URL)
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json()["items"][0]["tickers"], ["AAPL"])
+
+    def test_bare_string_tickers_becomes_empty_list(self):
+        # a bare string must never char-iterate into ['A','A','P','L']
+        good = make_item("g1", published=self._recent_epoch(1.0), tickers="AAPL")
+        path = self.dir / "items-2026-07-06.jsonl"
+        path.write_text(json.dumps(good) + "\n", encoding="utf-8")
+        with override_settings(RAW_ITEMS_DIR=str(self.dir), **_HERMETIC):
+            resp = self.client.get(URL)
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json()["items"][0]["tickers"], [])
+
     # 15. oversized file
     def test_oversized_file_404s(self):
         huge_description = "x" * (11 * 1024 * 1024)  # > _MAX_ITEMS_FILE_MB
@@ -274,3 +296,26 @@ class NewsItemsEndpointTests(SimpleTestCase):
             resp = self.client.get(URL)
         self.assertEqual(resp.status_code, 404)
         self.assertEqual(resp.json(), {"error": "no_items"})
+
+    # 18. no re-stat after the load memoizes: @condition's etag/last-modified
+    # functions must read the mtime carried in the memo, not call path.stat()
+    # again — a re-stat there would reopen the TOCTOU window _load_items's
+    # own stat() already closed (a prune in that window would 500, not 404).
+    def test_condition_functions_never_restat_after_load(self):
+        self._write("2026-07-06", [make_item("g1")])
+        real_stat = Path.stat
+        calls = []
+
+        def counting_stat(self, **kwargs):
+            if self.name.endswith(".jsonl"):
+                calls.append(self.name)
+            return real_stat(self, **kwargs)
+
+        with override_settings(RAW_ITEMS_DIR=str(self.dir), **_HERMETIC), \
+             mock.patch.object(Path, "stat", autospec=True, side_effect=counting_stat):
+            resp = self.client.get(URL)
+        self.assertEqual(resp.status_code, 200)
+        # exactly the two stat()s inside _load_items (the max() selection key
+        # + _validate_items' size/window check) — none from etag/last-modified
+        # or the view body, which all read the memoized (path, mtime, stories).
+        self.assertEqual(calls, ["items-2026-07-06.jsonl"] * 2)

--- a/Main/backend/tests/test_news_items_endpoint.py
+++ b/Main/backend/tests/test_news_items_endpoint.py
@@ -17,7 +17,10 @@ from tests.shared_settings import HERMETIC_REQUEST_SETTINGS as _HERMETIC
 
 URL = "/api/news/items/"
 
-CONTRACT_KEYS = {"guid", "title", "link", "source", "published",
+# Wire keys (news-story v1): disk batches stay RSS-native (title/link); the
+# view projection renames to the shared vocabulary the live signals endpoint
+# already speaks (headline/url). make_item below builds DISK-shape items.
+CONTRACT_KEYS = {"guid", "headline", "url", "source", "published",
                  "description", "tickers", "score"}
 
 
@@ -79,12 +82,16 @@ class NewsItemsEndpointTests(SimpleTestCase):
             resp = self.client.get(URL)
         self.assertEqual(resp.status_code, 200)
         body = resp.json()
-        self.assertEqual(set(body), {"items", "count", "batch"})
+        self.assertEqual(set(body), {"schema_version", "items", "count", "batch"})
+        self.assertEqual(body["schema_version"], 1)
         self.assertEqual(body["batch"], "items-2026-07-06.jsonl")
         self.assertEqual(body["count"], 3)
         self.assertEqual([it["guid"] for it in body["items"]], ["g0", "g1", "g2"])
         for it in body["items"]:
             self.assertEqual(set(it), CONTRACT_KEYS)
+        # rename fidelity: wire headline/url carry the disk title/link values
+        self.assertEqual(body["items"][0]["headline"], "Example headline")
+        self.assertEqual(body["items"][0]["url"], "https://example.com/a")
         self.assertIsInstance(body["items"][0]["published"], float)
         self.assertIsInstance(body["items"][0]["score"], float)
         self.assertIsInstance(body["items"][0]["tickers"], list)
@@ -283,10 +290,10 @@ class NewsItemsEndpointTests(SimpleTestCase):
         with override_settings(RAW_ITEMS_DIR=str(self.dir), **_HERMETIC):
             resp = self.client.get(URL)
         self.assertEqual(resp.status_code, 200)
-        served_title = resp.json()["items"][0]["title"]
-        self.assertNotIn("\u202e", served_title)
-        self.assertNotIn("NEWS_DATA", served_title)
-        self.assertLessEqual(len(served_title), 500)
+        served_headline = resp.json()["items"][0]["headline"]
+        self.assertNotIn("\u202e", served_headline)
+        self.assertNotIn("NEWS_DATA", served_headline)
+        self.assertLessEqual(len(served_headline), 500)
 
     # 17. zero valid stories after the gate
     def test_zero_valid_stories_404s(self):


### PR DESCRIPTION
Adds `GET /api/news/items/` — the newest raw news-items batch (`items-*.jsonl`), a sibling of `/api/signals/news/`. Phase B of the ATL news-signals integration; ATL's Home panel consumes it for a richer "Latest news" feed and falls back to the existing signals-derived feed if it's unavailable.

**What it does**
- Serves the newest `items-*.jsonl` from a new `RAW_ITEMS_DIR` (Heartbeat `digests/`), newest-first by `published`, `?limit=` (default 50, max 200), empty/unreadable → `404 {"error":"no_items"}`, `?limit=abc` → `400`.
- Ports the generic `validation_gate` + `clean_text` (control/bidi stripping, field caps) from `Heartbeat/news_signals.py` — it's a security trust boundary, so copied verbatim, not paraphrased. Subject/roundup/LLM gating is intentionally dropped (this is the raw feed).
- Same decorator stack as `news_signals` (bearer auth → ratelimit → conditional-GET); fail-closed to 404 on any load error, never 500.
- Deploy-ready: adds the `digests/` bind-mount + `RAW_ITEMS_DIR` env to `backend-deploy.yml` (mirrors the existing signals mount).

**Review fixes (2026-07-14)**
- The gate now drops a story on a non-str required field instead of raising, and `clean_text` is total. This fixed a **live crash in `news_signals.py`**: a corrupt `"tickers":[123]` raised `AttributeError` past `process_batch`'s ValueError-only `except`, aborting the whole sweep.
- Both copies fixed together and pinned by `Heartbeat/tests/test_port_parity.py`, which AST-extracts the ported region and compares behaviour without importing Django. Its corpus is mutation-proven against the drift it claims to catch. Lives in the Heartbeat suite because that one runs on PRs.
- `settings.RAW_ITEMS_MAX_FILE_MB` reads `SIGNALS_MAX_FILE_MB` — one operator knob, two readers, defaults pinned by the parity test.
- `signals_views.py` is on `heartbeat-tests.yml`'s `pull_request` paths **only**: the `push` trigger also gates the deploy job, so listing it there would redeploy the droplet on a Django-only merge.
- `news_signals.py` `VERSION` → `2026-07-14.1` (deployed behaviour changed).

**Tests**: `test_news_items_endpoint.py` (34 cases incl. poison-pill vs drop-story, limit clamping, conditional-GET, control-char stripping) + auth 401s + `test_port_parity.py` (12). Backend 751 passed, Heartbeat 170 OK, `manage.py check` clean.

**Docs**: hosted API reference now carries a News Items section + table row; `project_structure.rst` and the pipeline design spec updated. Sphinx build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018rCr1NSRDG8kpsYtHPndmM
