### PR TITLE
fix(models): fail-safe validate_model_support on ambiguous model_name

### DIFF
--- a/Main/backend/datascraper/models_config.py
+++ b/Main/backend/datascraper/models_config.py
@@ -108,15 +108,22 @@ def validate_model_support(model_id: str, feature: str) -> bool:
     """Check if a model supports a specific feature (e.g., mcp, advanced).
 
     Accepts either a display name ('FinGPT') or a resolved model name
-    ('gpt-5.2-chat-latest', 'gemini-3-flash-preview').
+    ('gpt-5.2-chat-latest', 'gemini-3-flash-preview'). When a model_name is
+    shared by several entries, resolution fails SAFE onto a `direct` (no-tools)
+    entry — see the reverse-lookup note below.
     """
     config = get_model_config(model_id)
     if not config:
-        # Reverse lookup: model_id might be a resolved model_name
-        for _id, cfg in MODELS_CONFIG.items():
-            if cfg.get("model_name") == model_id:
-                config = cfg
-                break
+        # Reverse lookup: model_id may be a resolved model_name. When a name is
+        # shared by more than one entry (e.g. 'gemini-3-flash-preview', used by
+        # both FinGPT and the direct/no-tools FinSearch-Trader), prefer a
+        # `direct` entry so an ambiguous identifier reports the restrictive
+        # capability set instead of the first (possibly tool-enabled) match —
+        # the same fail-safe policy _direct_dispatch_target applies at routing.
+        matches = [cfg for cfg in MODELS_CONFIG.values()
+                   if cfg.get("model_name") == model_id]
+        config = next((cfg for cfg in matches if cfg.get("direct")),
+                      matches[0] if matches else None)
     if not config:
         return False
     return config.get(f"supports_{feature}", False)

--- a/Main/backend/tests/test_models_config.py
+++ b/Main/backend/tests/test_models_config.py
@@ -15,3 +15,23 @@ def test_views_model_fallbacks_use_default_model():
     fallbacks = re.findall(r"params\.get\(\s*['\"]models['\"]\s*,\s*([^)]+)\)", src)
     assert fallbacks, "expected at least one models fallback in api/views.py"
     assert all(f.strip() == "DEFAULT_MODEL" for f in fallbacks), fallbacks
+
+
+def test_validate_model_support_fails_safe_on_ambiguous_model_name():
+    """A raw model_name shared by a tool-enabled entry (FinGPT, supports_mcp=True)
+    and a direct no-tools entry (FinSearch-Trader, supports_mcp=False) must resolve
+    to the DIRECT entry, so an ambiguous identifier reports the restrictive
+    capability set (fail safe) — the same policy _direct_dispatch_target applies at
+    the routing seam (see test_trader_persona). Exact display-name keys and unique
+    model_names are unaffected."""
+    from datascraper.models_config import validate_model_support
+    # Shared 'gemini-3-flash-preview' must fail safe onto the direct entry.
+    assert validate_model_support("gemini-3-flash-preview", "mcp") is False
+    assert validate_model_support("gemini-3-flash-preview", "advanced") is False
+    # Exact keys resolve exactly — FinGPT keeps its capabilities, trader stays off.
+    assert validate_model_support("FinGPT", "mcp") is True
+    assert validate_model_support("FinSearch-Trader", "mcp") is False
+    # A unique model_name (no direct sibling) still resolves via reverse lookup.
+    assert validate_model_support("gpt-5.1-chat-latest", "mcp") is True
+    # Unknown identifiers stay unsupported.
+    assert validate_model_support("no-such-model", "mcp") is False


### PR DESCRIPTION
Deferred defense-in-depth follow-up from PR #358's review.

`validate_model_support` reverse-looked-up a raw `model_name` by first match, so the ambiguous `gemini-3-flash-preview` (shared by `FinGPT` tools-on and `FinSearch-Trader` direct/tools-off) resolved to `FinGPT` (`supports_mcp=True`) — a fail-open. Now prefers a `direct` entry, matching `_direct_dispatch_target`'s already-merged routing policy (#358).

Not a currently-reachable path: both live `mcp`-gate callers sit behind #358's direct short-circuit. This closes the last naive resolution surface for any future direct caller. Regression test added; full suite green (751 passed).