### PR TITLE
ci: validate backend PRs pre-merge

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,124 @@
+# Scheduled dependency updates.
+#
+# Why this file exists: until it landed, the repo had NO dependabot config at all, so
+# Dependabot only ever opened *security* PRs -- the alert-driven kind. The practical
+# effect is that dependencies sat still until one became vulnerable and then jumped
+# (six such PRs between 2026-06 and 2026-07, e.g. #265 requests, #303 tornado, #363
+# dompurify). That is the worst of both worlds: no routine drift control, and every
+# actual bump arrives as an urgent one on a version gap nobody has been watching.
+# Scheduled version-updates keep each step small and individually reviewable, so the
+# security PRs that still fire land on top of a current tree instead of a stale one.
+#
+# All of these are now gated pre-merge: backend-deploy.yml gained a pull_request
+# trigger and runs `uv sync --locked` + Django checks + verify_deployment.py + the
+# image build + pytest, so a bump that breaks resolution or the image fails the PR
+# rather than the production deploy.
+#
+# Grouping policy: minor+patch collapse into one PR per ecosystem per run (that is the
+# bulk of the volume and it is rarely worth reviewing separately); majors stay
+# ungrouped so each lands on its own reviewable diff. Security updates ignore grouping
+# config and keep arriving individually, which is what we want.
+version: 2
+updates:
+  # ---- Python: backend (uv) --------------------------------------------------------
+  # The lockfile is authoritative: Main/backend/Dockerfile installs with `uv sync
+  # --frozen` and CI now asserts freshness with `uv sync --locked`, so Dependabot
+  # regenerating uv.lock here is exactly the input the image is built from.
+  - package-ecosystem: "uv"
+    directory: "/Main/backend"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "build(deps)"
+    groups:
+      backend-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # ---- JavaScript: frontend (npm) --------------------------------------------------
+  # NOTE: Main/frontend has package.json but NO committed lockfile, so Dependabot edits
+  # the manifest ranges only and installs stay non-reproducible. Committing a lockfile
+  # is a separate change (see the PR body's follow-ups) -- not folded in here, because
+  # generating one is a large diff that deserves its own review.
+  - package-ecosystem: "npm"
+    directory: "/Main/frontend"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "build(deps)"
+    groups:
+      frontend-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # ---- Python: concierge (pip / requirements.txt) ----------------------------------
+  - package-ecosystem: "pip"
+    directory: "/Concierge"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: "build(deps)"
+    groups:
+      concierge-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # ---- Python: docs toolchain (requirements_sphinx.txt at repo root) ---------------
+  # Docs-only deps, but they are fully pinned (==) and pull in jinja2//urllib3-class
+  # transitives that do get advisories, so they should not be left to rot.
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: "build(deps)"
+    groups:
+      docs-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # ---- Container base images -------------------------------------------------------
+  # ⚠ COUPLING, read before merging any bump here: Main/backend/Dockerfile is
+  # `FROM mcr.microsoft.com/playwright/python:v1.58.0-jammy` and sets
+  # PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1, so the browsers baked into the BASE IMAGE are
+  # the only ones present -- their version must track the `playwright>=1.58.0,<2` pin
+  # in Main/backend/pyproject.toml. A base-image bump merged ALONE desyncs the two and
+  # breaks browser launch at runtime. Pair it with the pyproject/uv.lock bump in the
+  # same PR. The pre-cutover BOOT_CHECK_ONLY gate in backend-deploy.yml exercises a real
+  # browser launch and aborts before cutover if they disagree, so the failure mode is a
+  # blocked deploy rather than a broken prod -- but the fix is still to pair them.
+  - package-ecosystem: "docker"
+    directories:
+      - "/Main/backend"
+      - "/Main/frontend"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: "build(deps)"
+
+  # ---- GitHub Actions --------------------------------------------------------------
+  # Every `uses:` in this repo is SHA-pinned with a trailing `# vX.Y.Z` comment
+  # (supply-chain hardening -- a tag can be re-pointed, a SHA cannot). Dependabot
+  # understands that convention: it bumps the SHA and rewrites the version comment,
+  # so the pinning survives its PRs.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: "build(deps)"
+    groups:
+      actions-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/backend-deploy.yml
+++ b/.github/workflows/backend-deploy.yml
@@ -12,6 +12,18 @@ on:
     paths:
       - "Main/backend/**"
       - ".github/workflows/backend-deploy.yml"
+  # Same allowlist on PRs, so backend changes are validated BEFORE merge instead of
+  # by the deploy pipeline after it. Without this the build/test jobs ran only on
+  # push-to-main: a bad lockfile or Dockerfile surfaced as a FAILED PRODUCTION
+  # DEPLOY, not a red PR (dependabot bumps merged on a lone neutral CodeQL check --
+  # #265 is the worked example). The deploy job is ref-gated to main and the
+  # GHCR-writing steps are event-gated below, so a PR run validates and pushes
+  # nothing. Matches the pull_request triggers the sibling heartbeat/concierge
+  # suites already carry.
+  pull_request:
+    paths:
+      - "Main/backend/**"
+      - ".github/workflows/backend-deploy.yml"
   workflow_dispatch:
 
 env:
@@ -47,9 +59,18 @@ jobs:
       - name: Install Python ${{ env.PYTHON_VERSION }}
         run: uv python install ${{ env.PYTHON_VERSION }}
 
+      # --locked, NOT --frozen. The two are not synonyms and the difference is a real
+      # gap that already bit this repo: --frozen installs from uv.lock without checking
+      # it still matches pyproject.toml, so a dependency edit committed without a relock
+      # builds an image from STALE resolutions and CI stays green. --locked asserts the
+      # lock is up to date and fails loudly if not. Evidence it was silent: uv.lock
+      # carried fingpt-backend 0.13.3 while pyproject.toml said 0.15.0 (two version
+      # bumps landed unrelocked) until a dependabot regeneration incidentally corrected
+      # it in #265. The Dockerfile deliberately keeps --frozen: by the time it runs, this
+      # step has already validated the very lock it copies in.
       - name: Sync backend dependencies
         working-directory: ${{ env.BACKEND_DIR }}
-        run: uv sync --frozen --python ${{ env.PYTHON_VERSION }}
+        run: uv sync --locked --python ${{ env.PYTHON_VERSION }}
 
       - name: Run Django system checks
         working-directory: ${{ env.BACKEND_DIR }}
@@ -69,7 +90,13 @@ jobs:
           echo "main_tag=${IMAGE_ID}:main" >> "$GITHUB_OUTPUT"
           echo "latest_tag=${IMAGE_ID}:latest" >> "$GITHUB_OUTPUT"
 
+      # Registry writes are push/dispatch-only. A PR run stops at "does it build?" --
+      # it must never publish a :main or :latest tag that the droplet could pull, and a
+      # fork PR's GITHUB_TOKEN is read-only anyway, so an unconditional login would just
+      # fail the job. The image build itself DOES run on PRs: catching a broken
+      # Dockerfile or an uninstallable lock is most of the value of gating pre-merge.
       - name: Log in to GHCR
+        if: ${{ github.event_name != 'pull_request' }}
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772  # v3.4.0
         with:
           registry: ${{ env.REGISTRY }}
@@ -87,13 +114,19 @@ jobs:
             ${{ env.BACKEND_DIR }}
 
       - name: Push backend image
+        if: ${{ github.event_name != 'pull_request' }}
         run: |
           docker push ${{ steps.meta.outputs.sha_tag }}
           docker push ${{ steps.meta.outputs.main_tag }}
           docker push ${{ steps.meta.outputs.latest_tag }}
 
+      # Skipped on PRs for a hard reason, not just symmetry: RepoDigests is populated by
+      # the PUSH, so this inspect returns an empty list and the index errors out when
+      # nothing was pushed. The empty `digest` output that results is harmless -- its
+      # only consumer is the deploy job, which is ref-gated to main.
       - name: Capture pushed image digest
         id: digest
+        if: ${{ github.event_name != 'pull_request' }}
         run: |
           DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' ${{ steps.meta.outputs.sha_tag }})
           echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
@@ -114,9 +147,11 @@ jobs:
       - name: Install Python ${{ env.PYTHON_VERSION }}
         run: uv python install ${{ env.PYTHON_VERSION }}
 
+      # --locked for the same reason as the build job: this suite must run against the
+      # dependency set pyproject.toml actually asks for, not a stale pin.
       - name: Sync backend dependencies
         working-directory: ${{ env.BACKEND_DIR }}
-        run: uv sync --frozen --python ${{ env.PYTHON_VERSION }}
+        run: uv sync --locked --python ${{ env.PYTHON_VERSION }}
 
       - name: Run backend tests
         working-directory: ${{ env.BACKEND_DIR }}


### PR DESCRIPTION
Backend changes were validated only *after* merge: `backend-deploy.yml` had no `pull_request` trigger, so a broken lockfile or Dockerfile surfaced as a failed production deploy, not a red PR. #265 is the worked example — a dep bump merged on a lone neutral CodeQL check.

- **`pull_request` trigger** reusing the existing paths allowlist. GHCR login/push/digest are gated to non-PR events, so a PR validates and builds but publishes nothing; `deploy` stays ref-gated to `main`.
- **`uv sync --frozen` → `--locked`** (both jobs). `--frozen` skips the freshness check — which is why `uv.lock` sat at `fingpt-backend` 0.13.3 while `pyproject.toml` said 0.15.0 until a dependabot regeneration incidentally fixed it in #265.
- **`.github/dependabot.yml`** (new). With no config, only *security* PRs ever fired, so deps sat still until one became vulnerable, then jumped.

⚠ Read the coupling note in `dependabot.yml` before merging any `docker` bump: the Playwright base image must move together with the `playwright` pin in `pyproject.toml`.

**Verified on this PR's own run** (it exercises the trigger it adds): `uv sync --locked` ran and resolved 192 packages; image **built**; `Log in to GHCR`, `Push backend image`, `Capture pushed image digest` all **skipped**; `deploy` **skipped**. Publishes nothing, deploys nothing.

Follow-ups, not in scope: `Main/frontend` has no committed npm lockfile (installs aren't reproducible); `test` still `needs: build`, so pytest waits on the image build; `manage.py check` spawns MCP stdio children that dump a `BrokenPipeError` traceback on teardown (step still exits 0 — pre-existing, unrelated to this diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
